### PR TITLE
implement batch embedding

### DIFF
--- a/genai/client_test.go
+++ b/genai/client_test.go
@@ -222,7 +222,7 @@ func TestLive(t *testing.T) {
 		b := em.NewBatch().
 			AddContent(Text("cheddar cheese")).
 			AddContentWithTitle("My Cheese Report", Text("I love cheddar cheese."))
-		res, err := b.EmbedContents(ctx)
+		res, err := em.BatchEmbedContents(ctx, b)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/genai/client_test.go
+++ b/genai/client_test.go
@@ -219,9 +219,9 @@ func TestLive(t *testing.T) {
 	})
 	t.Run("batch-embed", func(t *testing.T) {
 		em := client.EmbeddingModel("embedding-001")
-		b := em.NewBatch()
-		b.AddContent(Text("cheddar cheese"))
-		b.AddContentWithTitle("My Cheese Report", Text("I love cheddar cheese."))
+		b := em.NewBatch().
+			AddContent(Text("cheddar cheese")).
+			AddContentWithTitle("My Cheese Report", Text("I love cheddar cheese."))
 		res, err := b.EmbedContents(ctx)
 		if err != nil {
 			t.Fatal(err)

--- a/genai/client_test.go
+++ b/genai/client_test.go
@@ -214,9 +214,23 @@ func TestLive(t *testing.T) {
 			t.Fatal(err)
 		}
 		if res == nil || res.Embedding == nil || len(res.Embedding.Values) < 10 {
-			t.Errorf("bad result: %v\n", res)
+			t.Errorf("bad result: %v", res)
 		}
 	})
+	t.Run("batch-embed", func(t *testing.T) {
+		em := client.EmbeddingModel("embedding-001")
+		b := em.NewBatch()
+		b.AddContent(Text("cheddar cheese"))
+		b.AddContentWithTitle("My Cheese Report", Text("I love cheddar cheese."))
+		res, err := b.EmbedContents(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res == nil || len(res.Embeddings) != 2 {
+			t.Errorf("bad result: %v", res)
+		}
+	})
+
 	t.Run("list-models", func(t *testing.T) {
 		iter := client.ListModels(ctx)
 		var got []*Model

--- a/genai/config.yaml
+++ b/genai/config.yaml
@@ -95,6 +95,7 @@ types:
         TaskType_TASK_TYPE_UNSPECIFIED: TaskTypeUnspecified
 
     EmbedContentResponse:
+    BatchEmbedContentsResponse:
 
     ContentEmbedding:
 

--- a/genai/embed.go
+++ b/genai/embed.go
@@ -85,11 +85,10 @@ type EmbeddingBatch struct {
 	req *pb.BatchEmbedContentsRequest
 }
 
-// NewBatch returns a new, empty EmbeddingBatch.
-// Make multiple calls to [EmbeddingBatch.AddContent] or
-// [EmbeddingBatch.AddContentWithTitle].
-// [EmbeddingBatch.EmbedContents] will then get all the embeddings
-// in a single call to the model.
+// NewBatch returns a new, empty EmbeddingBatch with the same TaskType as the model.
+// Make multiple calls to [EmbeddingBatch.AddContent] or EmbeddingBatch.AddContentWithTitle].
+// Then pass the EmbeddingBatch to [EmbeddingModel.BatchEmbedContents] to get
+// all the embeddings in a single call to the model.
 func (m *EmbeddingModel) NewBatch() *EmbeddingBatch {
 	return &EmbeddingBatch{
 		tt: m.TaskType,

--- a/genai/embed.go
+++ b/genai/embed.go
@@ -40,6 +40,11 @@ type EmbeddingModel struct {
 	TaskType TaskType
 }
 
+// Name returns the name of the EmbeddingModel.
+func (m *EmbeddingModel) Name() string {
+	return m.name
+}
+
 // EmbedContent returns an embedding for the list of parts.
 func (m *EmbeddingModel) EmbedContent(ctx context.Context, parts ...Part) (*EmbedContentResponse, error) {
 	return m.EmbedContentWithTitle(ctx, "", parts...)
@@ -49,12 +54,20 @@ func (m *EmbeddingModel) EmbedContent(ctx context.Context, parts ...Part) (*Embe
 // If the given title is non-empty, it is passed to the model and
 // the task type is set to TaskTypeRetrievalDocument.
 func (m *EmbeddingModel) EmbedContentWithTitle(ctx context.Context, title string, parts ...Part) (*EmbedContentResponse, error) {
+	req := newEmbedContentRequest(m.fullName, m.TaskType, title, parts)
+	res, err := m.c.c.EmbedContent(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return (EmbedContentResponse{}).fromProto(res), nil
+}
+
+func newEmbedContentRequest(model string, tt TaskType, title string, parts []Part) *pb.EmbedContentRequest {
 	req := &pb.EmbedContentRequest{
-		Model:   m.fullName,
+		Model:   model,
 		Content: newUserContent(parts).toProto(),
 	}
 	// A non-empty title overrides the task type.
-	tt := m.TaskType
 	if title != "" {
 		req.Title = &title
 		tt = TaskTypeRetrievalDocument
@@ -63,9 +76,46 @@ func (m *EmbeddingModel) EmbedContentWithTitle(ctx context.Context, title string
 		taskType := pb.TaskType(tt)
 		req.TaskType = &taskType
 	}
-	res, err := m.c.c.EmbedContent(ctx, req)
+	return req
+}
+
+// An EmbeddingBatch holds a collection of embedding requests.
+type EmbeddingBatch struct {
+	c   *Client
+	tt  TaskType
+	req *pb.BatchEmbedContentsRequest
+}
+
+// NewBatch returns a new, empty EmbeddingBatch.
+// Make multiple calls to [EmbeddingBatch.AddContent] or
+// [EmbeddingBatch.AddContentWithTitle].
+// [EmbeddingBatch.EmbedContents] will then get all the embeddings
+// in a single call to the model.
+func (m *EmbeddingModel) NewBatch() *EmbeddingBatch {
+	return &EmbeddingBatch{
+		c:  m.c,
+		tt: m.TaskType,
+		req: &pb.BatchEmbedContentsRequest{
+			Model: m.fullName,
+		},
+	}
+}
+
+// AddContent adds a content to the batch.
+func (b *EmbeddingBatch) AddContent(parts ...Part) {
+	b.AddContentWithTitle("", parts...)
+}
+
+// AddContent adds a content to the batch with a title.
+func (b *EmbeddingBatch) AddContentWithTitle(title string, parts ...Part) {
+	b.req.Requests = append(b.req.Requests, newEmbedContentRequest(b.req.Model, b.tt, title, parts))
+}
+
+// EmbedContents returns the embeddings for all the contents in the batch.
+func (b *EmbeddingBatch) EmbedContents(ctx context.Context) (*BatchEmbedContentsResponse, error) {
+	res, err := b.c.c.BatchEmbedContents(ctx, b.req)
 	if err != nil {
 		return nil, err
 	}
-	return (EmbedContentResponse{}).fromProto(res), nil
+	return (BatchEmbedContentsResponse{}).fromProto(res), nil
 }

--- a/genai/embed.go
+++ b/genai/embed.go
@@ -81,7 +81,6 @@ func newEmbedContentRequest(model string, tt TaskType, title string, parts []Par
 
 // An EmbeddingBatch holds a collection of embedding requests.
 type EmbeddingBatch struct {
-	c   *Client
 	tt  TaskType
 	req *pb.BatchEmbedContentsRequest
 }
@@ -93,7 +92,6 @@ type EmbeddingBatch struct {
 // in a single call to the model.
 func (m *EmbeddingModel) NewBatch() *EmbeddingBatch {
 	return &EmbeddingBatch{
-		c:  m.c,
 		tt: m.TaskType,
 		req: &pb.BatchEmbedContentsRequest{
 			Model: m.fullName,
@@ -113,9 +111,9 @@ func (b *EmbeddingBatch) AddContentWithTitle(title string, parts ...Part) *Embed
 	return b
 }
 
-// EmbedContents returns the embeddings for all the contents in the batch.
-func (b *EmbeddingBatch) EmbedContents(ctx context.Context) (*BatchEmbedContentsResponse, error) {
-	res, err := b.c.c.BatchEmbedContents(ctx, b.req)
+// BatchEmbedContents returns the embeddings for all the contents in the batch.
+func (m *EmbeddingModel) BatchEmbedContents(ctx context.Context, b *EmbeddingBatch) (*BatchEmbedContentsResponse, error) {
+	res, err := m.c.c.BatchEmbedContents(ctx, b.req)
 	if err != nil {
 		return nil, err
 	}

--- a/genai/embed.go
+++ b/genai/embed.go
@@ -102,13 +102,15 @@ func (m *EmbeddingModel) NewBatch() *EmbeddingBatch {
 }
 
 // AddContent adds a content to the batch.
-func (b *EmbeddingBatch) AddContent(parts ...Part) {
+func (b *EmbeddingBatch) AddContent(parts ...Part) *EmbeddingBatch {
 	b.AddContentWithTitle("", parts...)
+	return b
 }
 
 // AddContent adds a content to the batch with a title.
-func (b *EmbeddingBatch) AddContentWithTitle(title string, parts ...Part) {
+func (b *EmbeddingBatch) AddContentWithTitle(title string, parts ...Part) *EmbeddingBatch {
 	b.req.Requests = append(b.req.Requests, newEmbedContentRequest(b.req.Model, b.tt, title, parts))
+	return b
 }
 
 // EmbedContents returns the embeddings for all the contents in the batch.

--- a/genai/example_test.go
+++ b/genai/example_test.go
@@ -203,7 +203,7 @@ func ExampleEmbeddingBatch() {
 	b := em.NewBatch().
 		AddContent(genai.Text("cheddar cheese")).
 		AddContentWithTitle("My Cheese Report", genai.Text("I love cheddar cheese."))
-	res, err := b.EmbedContents(ctx)
+	res, err := em.BatchEmbedContents(ctx, b)
 	if err != nil {
 		panic(err)
 	}

--- a/genai/example_test.go
+++ b/genai/example_test.go
@@ -192,6 +192,26 @@ func ExampleEmbeddingModel_EmbedContent() {
 	fmt.Println(res.Embedding.Values)
 }
 
+func ExampleEmbeddingBatch() {
+	ctx := context.Background()
+	client, err := genai.NewClient(ctx, option.WithAPIKey(os.Getenv("API_KEY")))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Close()
+	em := client.EmbeddingModel("embedding-001")
+	b := em.NewBatch().
+		AddContent(genai.Text("cheddar cheese")).
+		AddContentWithTitle("My Cheese Report", genai.Text("I love cheddar cheese."))
+	res, err := b.EmbedContents(ctx)
+	if err != nil {
+		panic(err)
+	}
+	for _, e := range res.Embeddings {
+		fmt.Println(e.Values)
+	}
+}
+
 func ExampleClient_ListModels() {
 	ctx := context.Background()
 	client, err := genai.NewClient(ctx, option.WithAPIKey(os.Getenv("API_KEY")))

--- a/genai/generativelanguagepb_veneer.gen.go
+++ b/genai/generativelanguagepb_veneer.gen.go
@@ -23,6 +23,31 @@ import (
 	"github.com/google/generative-ai-go/internal/support"
 )
 
+// BatchEmbedContentsResponse is the response to a `BatchEmbedContentsRequest`.
+type BatchEmbedContentsResponse struct {
+	// Output only. The embeddings for each request, in the same order as provided
+	// in the batch request.
+	Embeddings []*ContentEmbedding
+}
+
+func (v *BatchEmbedContentsResponse) toProto() *pb.BatchEmbedContentsResponse {
+	if v == nil {
+		return nil
+	}
+	return &pb.BatchEmbedContentsResponse{
+		Embeddings: support.TransformSlice(v.Embeddings, (*ContentEmbedding).toProto),
+	}
+}
+
+func (BatchEmbedContentsResponse) fromProto(p *pb.BatchEmbedContentsResponse) *BatchEmbedContentsResponse {
+	if p == nil {
+		return nil
+	}
+	return &BatchEmbedContentsResponse{
+		Embeddings: support.TransformSlice(p.Embeddings, (ContentEmbedding{}).fromProto),
+	}
+}
+
 // Blob contains raw media bytes.
 //
 // Text should not be sent as raw bytes, use the 'text' field.


### PR DESCRIPTION
The API consists of an EmbeddingBatch type to which contents can be added, and then used for the RPC. This is simpler than the alternative API, which would require the user to create a slice of individual requests.