### PR TITLE
accept full name for models

### DIFF
--- a/genai/client.go
+++ b/genai/client.go
@@ -81,7 +81,7 @@ type GenerativeModel struct {
 const defaultMaxOutputTokens = 2048
 
 // GenerativeModel creates a new instance of the named generative model.
-// For instance, "gemini-pro".
+// For instance, "gemini-pro" or "models/gemini-pro".
 func (c *Client) GenerativeModel(name string) *GenerativeModel {
 	return &GenerativeModel{
 		GenerationConfig: GenerationConfig{
@@ -90,13 +90,15 @@ func (c *Client) GenerativeModel(name string) *GenerativeModel {
 		},
 		c:        c,
 		name:     name,
-		fullName: fmt.Sprintf("models/%s", name),
+		fullName: fullModelName(name),
 	}
 }
 
-// Name returns the name of the model.
-func (m *GenerativeModel) Name() string {
-	return m.name
+func fullModelName(name string) string {
+	if strings.HasPrefix(name, "models/") {
+		return name
+	}
+	return "models/" + name
 }
 
 // GenerateContent produces a single request and response.

--- a/genai/embed.go
+++ b/genai/embed.go
@@ -16,18 +16,17 @@ package genai
 
 import (
 	"context"
-	"fmt"
 
 	pb "cloud.google.com/go/ai/generativelanguage/apiv1/generativelanguagepb"
 )
 
 // EmbeddingModel creates a new instance of the named embedding model.
-// Example name: "embedding-001".
+// Example name: "embedding-001" or "models/embedding-001".
 func (c *Client) EmbeddingModel(name string) *EmbeddingModel {
 	return &EmbeddingModel{
 		c:        c,
 		name:     name,
-		fullName: fmt.Sprintf("models/%s", name),
+		fullName: fullModelName(name),
 	}
 }
 


### PR DESCRIPTION
Client.GenerativeModel and Client.EmbeddingModel now accept
both "models/name" and "name".

Remove the GenerativeModel.Name method because it isn't clear
what it should do.
