### PR TITLE
bugfix: use a pointer for GenerationConfig.Temperature

### DIFF
--- a/genai/client.go
+++ b/genai/client.go
@@ -84,8 +84,8 @@ const defaultMaxOutputTokens = 2048
 func (c *Client) GenerativeModel(name string) *GenerativeModel {
 	return &GenerativeModel{
 		GenerationConfig: GenerationConfig{
-			MaxOutputTokens: defaultMaxOutputTokens,
-			TopK:            3,
+			MaxOutputTokens: Ptr(int32(defaultMaxOutputTokens)),
+			TopK:            Ptr(int32(3)),
 		},
 		c:        c,
 		fullName: fullModelName(name),

--- a/genai/client.go
+++ b/genai/client.go
@@ -77,16 +77,10 @@ type GenerativeModel struct {
 	SafetySettings []*SafetySetting
 }
 
-const defaultMaxOutputTokens = 2048
-
 // GenerativeModel creates a new instance of the named generative model.
 // For instance, "gemini-pro" or "models/gemini-pro".
 func (c *Client) GenerativeModel(name string) *GenerativeModel {
 	return &GenerativeModel{
-		GenerationConfig: GenerationConfig{
-			MaxOutputTokens: Ptr(int32(defaultMaxOutputTokens)),
-			TopK:            Ptr(int32(3)),
-		},
 		c:        c,
 		fullName: fullModelName(name),
 	}

--- a/genai/client_test.go
+++ b/genai/client_test.go
@@ -50,7 +50,7 @@ func TestLive(t *testing.T) {
 	}
 	defer client.Close()
 	model := client.GenerativeModel(*modelName)
-	model.Temperature = 0
+	model.SetTemperature(0)
 
 	t.Run("GenerateContent", func(t *testing.T) {
 		resp, err := model.GenerateContent(ctx, Text("What is the average size of a swallow?"))
@@ -114,7 +114,7 @@ func TestLive(t *testing.T) {
 
 	t.Run("image", func(t *testing.T) {
 		vmodel := client.GenerativeModel(*modelName + "-vision")
-		vmodel.Temperature = 0
+		vmodel.SetTemperature(0)
 
 		data, err := os.ReadFile(filepath.Join("testdata", imageFile))
 		if err != nil {
@@ -156,7 +156,7 @@ func TestLive(t *testing.T) {
 	})
 	t.Run("max-tokens", func(t *testing.T) {
 		maxModel := client.GenerativeModel(*modelName)
-		maxModel.Temperature = 0
+		maxModel.SetTemperature(0)
 		maxModel.MaxOutputTokens = 10
 		res, err := maxModel.GenerateContent(ctx, Text("What is a dog?"))
 		if err != nil {
@@ -170,7 +170,7 @@ func TestLive(t *testing.T) {
 	})
 	t.Run("max-tokens-streaming", func(t *testing.T) {
 		maxModel := client.GenerativeModel(*modelName)
-		maxModel.Temperature = 0
+		maxModel.SetTemperature(0)
 		maxModel.MaxOutputTokens = 10
 		iter := maxModel.GenerateContentStream(ctx, Text("What is a dog?"))
 		var merged *GenerateContentResponse
@@ -455,5 +455,21 @@ func TestMatchString(t *testing.T) {
 		if !re.MatchString(test.in) {
 			t.Errorf("%q doesn't match %q", test.re, test.in)
 		}
+	}
+}
+
+func TestTemperature(t *testing.T) {
+	m := &GenerativeModel{}
+	got := m.GenerationConfig.toProto().Temperature
+	if got != nil {
+		t.Errorf("got %v, want nil", got)
+	}
+	m.SetTemperature(0)
+	got = m.GenerationConfig.toProto().Temperature
+	if got == nil {
+		t.Fatal("got nil")
+	}
+	if g := *got; g != 0 {
+		t.Errorf("got %v, want 0", g)
 	}
 }

--- a/genai/client_test.go
+++ b/genai/client_test.go
@@ -50,7 +50,7 @@ func TestLive(t *testing.T) {
 	}
 	defer client.Close()
 	model := client.GenerativeModel(*modelName)
-	model.SetTemperature(0)
+	model.Temperature = Ptr[float32](0)
 
 	t.Run("GenerateContent", func(t *testing.T) {
 		resp, err := model.GenerateContent(ctx, Text("What is the average size of a swallow?"))
@@ -114,7 +114,7 @@ func TestLive(t *testing.T) {
 
 	t.Run("image", func(t *testing.T) {
 		vmodel := client.GenerativeModel(*modelName + "-vision")
-		vmodel.SetTemperature(0)
+		vmodel.Temperature = Ptr[float32](0)
 
 		data, err := os.ReadFile(filepath.Join("testdata", imageFile))
 		if err != nil {
@@ -156,8 +156,8 @@ func TestLive(t *testing.T) {
 	})
 	t.Run("max-tokens", func(t *testing.T) {
 		maxModel := client.GenerativeModel(*modelName)
-		maxModel.SetTemperature(0)
-		maxModel.MaxOutputTokens = 10
+		maxModel.Temperature = Ptr(float32(0))
+		maxModel.MaxOutputTokens = Ptr[int32](10)
 		res, err := maxModel.GenerateContent(ctx, Text("What is a dog?"))
 		if err != nil {
 			t.Fatal(err)
@@ -170,8 +170,8 @@ func TestLive(t *testing.T) {
 	})
 	t.Run("max-tokens-streaming", func(t *testing.T) {
 		maxModel := client.GenerativeModel(*modelName)
-		maxModel.SetTemperature(0)
-		maxModel.MaxOutputTokens = 10
+		maxModel.Temperature = Ptr[float32](0)
+		maxModel.MaxOutputTokens = Ptr[int32](10)
 		iter := maxModel.GenerateContentStream(ctx, Text("What is a dog?"))
 		var merged *GenerateContentResponse
 		for {
@@ -455,21 +455,5 @@ func TestMatchString(t *testing.T) {
 		if !re.MatchString(test.in) {
 			t.Errorf("%q doesn't match %q", test.re, test.in)
 		}
-	}
-}
-
-func TestTemperature(t *testing.T) {
-	m := &GenerativeModel{}
-	got := m.GenerationConfig.toProto().Temperature
-	if got != nil {
-		t.Errorf("got %v, want nil", got)
-	}
-	m.SetTemperature(0)
-	got = m.GenerationConfig.toProto().Temperature
-	if got == nil {
-		t.Fatal("got nil")
-	}
-	if g := *got; g != 0 {
-		t.Errorf("got %v, want 0", g)
 	}
 }

--- a/genai/client_test.go
+++ b/genai/client_test.go
@@ -157,7 +157,7 @@ func TestLive(t *testing.T) {
 	t.Run("max-tokens", func(t *testing.T) {
 		maxModel := client.GenerativeModel(*modelName)
 		maxModel.Temperature = Ptr(float32(0))
-		maxModel.MaxOutputTokens = Ptr[int32](10)
+		maxModel.SetMaxOutputTokens(10)
 		res, err := maxModel.GenerateContent(ctx, Text("What is a dog?"))
 		if err != nil {
 			t.Fatal(err)

--- a/genai/config.yaml
+++ b/genai/config.yaml
@@ -63,8 +63,6 @@ types:
 
     GenerationConfig:
       fields:
-        Temperature:
-          type: float32
         TopP:
           type: float32
         TopK:

--- a/genai/config.yaml
+++ b/genai/config.yaml
@@ -62,15 +62,6 @@ types:
       docVerb: contains
 
     GenerationConfig:
-      fields:
-        TopP:
-          type: float32
-        TopK:
-          type: int32
-        CandidateCount:
-          type: int32
-        MaxOutputTokens:
-          type: int32
 
     SafetySetting:
 

--- a/genai/content.go
+++ b/genai/content.go
@@ -78,3 +78,8 @@ func ImageData(format string, data []byte) Blob {
 		Data:     data,
 	}
 }
+
+// SetTemperature sets the temperature on the config.
+func (gc *GenerationConfig) SetTemperature(t float32) {
+	gc.Temperature = &t
+}

--- a/genai/content.go
+++ b/genai/content.go
@@ -81,3 +81,18 @@ func ImageData(format string, data []byte) Blob {
 
 // Ptr returns a pointer to its argument.
 func Ptr[T any](t T) *T { return &t }
+
+// SetCandidateCount sets the CandidateCount field.
+func (c *GenerationConfig) SetCandidateCount(x int32) { c.CandidateCount = &x }
+
+// SetMaxOutputTokens sets the MaxOutputTokens field.
+func (c *GenerationConfig) SetMaxOutputTokens(x int32) { c.MaxOutputTokens = &x }
+
+// SetTemperature sets the Temperature field.
+func (c *GenerationConfig) SetTemperature(x float32) { c.Temperature = &x }
+
+// SetTopP sets the TopP field.
+func (c *GenerationConfig) SetTopP(x float32) { c.TopP = &x }
+
+// SetTopK sets the TopK field.
+func (c *GenerationConfig) SetTopK(x int32) { c.TopK = &x }

--- a/genai/content.go
+++ b/genai/content.go
@@ -80,6 +80,9 @@ func ImageData(format string, data []byte) Blob {
 }
 
 // Ptr returns a pointer to its argument.
+// It can be used to initialize pointer fields:
+//
+//	model.Temperature = genai.Ptr[float32](0.1)
 func Ptr[T any](t T) *T { return &t }
 
 // SetCandidateCount sets the CandidateCount field.

--- a/genai/content.go
+++ b/genai/content.go
@@ -79,7 +79,5 @@ func ImageData(format string, data []byte) Blob {
 	}
 }
 
-// SetTemperature sets the temperature on the config.
-func (gc *GenerationConfig) SetTemperature(t float32) {
-	gc.Temperature = &t
-}
+// Ptr returns a pointer to its argument.
+func Ptr[T any](t T) *T { return &t }

--- a/genai/example_test.go
+++ b/genai/example_test.go
@@ -53,10 +53,10 @@ func ExampleGenerativeModel_GenerateContent_config() {
 	defer client.Close()
 
 	model := client.GenerativeModel("gemini-pro")
-	model.SetTemperature(0.9)
-	model.TopP = 0.5
-	model.TopK = 20
-	model.MaxOutputTokens = 100
+	model.Temperature = genai.Ptr[float32](0.9)
+	model.TopP = genai.Ptr[float32](0.5)
+	model.TopK = genai.Ptr[int32](20)
+	model.MaxOutputTokens = genai.Ptr[int32](100)
 	resp, err := model.GenerateContent(ctx, genai.Text("What is the average size of a swallow?"))
 	if err != nil {
 		log.Fatal(err)

--- a/genai/example_test.go
+++ b/genai/example_test.go
@@ -53,7 +53,7 @@ func ExampleGenerativeModel_GenerateContent_config() {
 	defer client.Close()
 
 	model := client.GenerativeModel("gemini-pro")
-	model.Temperature = 0.9
+	model.SetTemperature(0.9)
 	model.TopP = 0.5
 	model.TopK = 20
 	model.MaxOutputTokens = 100

--- a/genai/example_test.go
+++ b/genai/example_test.go
@@ -53,10 +53,10 @@ func ExampleGenerativeModel_GenerateContent_config() {
 	defer client.Close()
 
 	model := client.GenerativeModel("gemini-pro")
-	model.Temperature = genai.Ptr[float32](0.9)
-	model.TopP = genai.Ptr[float32](0.5)
-	model.TopK = genai.Ptr[int32](20)
-	model.MaxOutputTokens = genai.Ptr[int32](100)
+	model.SetTemperature(0.9)
+	model.SetTopP(0.5)
+	model.SetTopK(20)
+	model.SetMaxOutputTokens(100)
 	resp, err := model.GenerateContent(ctx, genai.Text("What is the average size of a swallow?"))
 	if err != nil {
 		log.Fatal(err)

--- a/genai/generativelanguagepb_veneer.gen.go
+++ b/genai/generativelanguagepb_veneer.gen.go
@@ -408,7 +408,7 @@ type GenerationConfig struct {
 	// inclusive. A value closer to 1.0 will produce responses that are more
 	// varied and creative, while a value closer to 0.0 will typically result in
 	// more straightforward responses from the model.
-	Temperature float32
+	Temperature *float32
 	// Optional. The maximum cumulative probability of tokens to consider when
 	// sampling.
 	//
@@ -442,7 +442,7 @@ func (v *GenerationConfig) toProto() *pb.GenerationConfig {
 		CandidateCount:  support.AddrOrNil(v.CandidateCount),
 		StopSequences:   v.StopSequences,
 		MaxOutputTokens: support.AddrOrNil(v.MaxOutputTokens),
-		Temperature:     support.AddrOrNil(v.Temperature),
+		Temperature:     v.Temperature,
 		TopP:            support.AddrOrNil(v.TopP),
 		TopK:            support.AddrOrNil(v.TopK),
 	}
@@ -456,7 +456,7 @@ func (GenerationConfig) fromProto(p *pb.GenerationConfig) *GenerationConfig {
 		CandidateCount:  support.DerefOrZero(p.CandidateCount),
 		StopSequences:   p.StopSequences,
 		MaxOutputTokens: support.DerefOrZero(p.MaxOutputTokens),
-		Temperature:     support.DerefOrZero(p.Temperature),
+		Temperature:     p.Temperature,
 		TopP:            support.DerefOrZero(p.TopP),
 		TopK:            support.DerefOrZero(p.TopK),
 	}

--- a/genai/generativelanguagepb_veneer.gen.go
+++ b/genai/generativelanguagepb_veneer.gen.go
@@ -389,7 +389,7 @@ type GenerationConfig struct {
 	//
 	// This value must be between [1, 8], inclusive. If unset, this will default
 	// to 1.
-	CandidateCount int32
+	CandidateCount *int32
 	// Optional. The set of character sequences (up to 5) that will stop output
 	// generation. If specified, the API will stop at the first appearance of a
 	// stop sequence. The stop sequence will not be included as part of the
@@ -399,7 +399,7 @@ type GenerationConfig struct {
 	//
 	// If unset, this will default to output_token_limit specified in the `Model`
 	// specification.
-	MaxOutputTokens int32
+	MaxOutputTokens *int32
 	// Optional. Controls the randomness of the output.
 	// Note: The default value varies by model, see the `Model.temperature`
 	// attribute of the `Model` returned the `getModel` function.
@@ -421,7 +421,7 @@ type GenerationConfig struct {
 	//
 	// Note: The default value varies by model, see the `Model.top_p`
 	// attribute of the `Model` returned the `getModel` function.
-	TopP float32
+	TopP *float32
 	// Optional. The maximum number of tokens to consider when sampling.
 	//
 	// The model uses combined Top-k and nucleus sampling.
@@ -431,7 +431,7 @@ type GenerationConfig struct {
 	//
 	// Note: The default value varies by model, see the `Model.top_k`
 	// attribute of the `Model` returned the `getModel` function.
-	TopK int32
+	TopK *int32
 }
 
 func (v *GenerationConfig) toProto() *pb.GenerationConfig {
@@ -439,12 +439,12 @@ func (v *GenerationConfig) toProto() *pb.GenerationConfig {
 		return nil
 	}
 	return &pb.GenerationConfig{
-		CandidateCount:  support.AddrOrNil(v.CandidateCount),
+		CandidateCount:  v.CandidateCount,
 		StopSequences:   v.StopSequences,
-		MaxOutputTokens: support.AddrOrNil(v.MaxOutputTokens),
+		MaxOutputTokens: v.MaxOutputTokens,
 		Temperature:     v.Temperature,
-		TopP:            support.AddrOrNil(v.TopP),
-		TopK:            support.AddrOrNil(v.TopK),
+		TopP:            v.TopP,
+		TopK:            v.TopK,
 	}
 }
 
@@ -453,12 +453,12 @@ func (GenerationConfig) fromProto(p *pb.GenerationConfig) *GenerationConfig {
 		return nil
 	}
 	return &GenerationConfig{
-		CandidateCount:  support.DerefOrZero(p.CandidateCount),
+		CandidateCount:  p.CandidateCount,
 		StopSequences:   p.StopSequences,
-		MaxOutputTokens: support.DerefOrZero(p.MaxOutputTokens),
+		MaxOutputTokens: p.MaxOutputTokens,
 		Temperature:     p.Temperature,
-		TopP:            support.DerefOrZero(p.TopP),
-		TopK:            support.DerefOrZero(p.TopK),
+		TopP:            p.TopP,
+		TopK:            p.TopK,
 	}
 }
 


### PR DESCRIPTION
Use *float32 for the Temperature field of GenerationConfig.
Provide a SetTemperature method for the user's convenience.

Previously, GenerationConfig.Temperature was a float32 even though
the proto had a *float32, and we intpreted zero as nil. This meant
it was impossible to set a zero temperature: attempting to do
so would transmit a nil Temperature to the server, which the server
would interpret as the default.

No other fields in GenerationConfig have this problem because none
of the others have a valid zero value.
