### PR TITLE
genai: support the GetModel RPC

### DIFF
--- a/genai/client.go
+++ b/genai/client.go
@@ -213,6 +213,19 @@ func (m *GenerativeModel) newCountTokensRequest(contents ...*Content) *pb.CountT
 	}
 }
 
+func (m *GenerativeModel) Info(ctx context.Context) (*ModelInfo, error) {
+	return m.c.modelInfo(ctx, m.fullName)
+}
+
+func (c *Client) modelInfo(ctx context.Context, fullName string) (*ModelInfo, error) {
+	req := &pb.GetModelRequest{Name: fullName}
+	res, err := c.mc.GetModel(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return (ModelInfo{}).fromProto(res), nil
+}
+
 // A BlockedError indicates that the model's response was blocked.
 // There can be two underlying causes: the prompt or a candidate response.
 type BlockedError struct {

--- a/genai/client.go
+++ b/genai/client.go
@@ -213,6 +213,7 @@ func (m *GenerativeModel) newCountTokensRequest(contents ...*Content) *pb.CountT
 	}
 }
 
+// Info returns information about the model.
 func (m *GenerativeModel) Info(ctx context.Context) (*ModelInfo, error) {
 	return m.c.modelInfo(ctx, m.fullName)
 }

--- a/genai/client_test.go
+++ b/genai/client_test.go
@@ -276,6 +276,25 @@ func TestLive(t *testing.T) {
 			}
 		}
 	})
+	t.Run("get-model", func(t *testing.T) {
+		modelName := "gemini-pro"
+		got, err := client.GenerativeModel(modelName).Info(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if w := "models/" + modelName; got.Name != w {
+			t.Errorf("got name %q, want %q", got.Name, w)
+		}
+
+		modelName = "embedding-001"
+		got, err = client.EmbeddingModel(modelName).Info(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if w := "models/" + modelName; got.Name != w {
+			t.Errorf("got name %q, want %q", got.Name, w)
+		}
+	})
 }
 
 func TestJoinResponses(t *testing.T) {

--- a/genai/embed.go
+++ b/genai/embed.go
@@ -118,6 +118,8 @@ func (m *EmbeddingModel) BatchEmbedContents(ctx context.Context, b *EmbeddingBat
 	}
 	return (BatchEmbedContentsResponse{}).fromProto(res), nil
 }
+
+// Info returns information about the model.
 func (m *EmbeddingModel) Info(ctx context.Context) (*ModelInfo, error) {
 	return m.c.modelInfo(ctx, m.fullName)
 }

--- a/genai/embed.go
+++ b/genai/embed.go
@@ -118,3 +118,6 @@ func (m *EmbeddingModel) BatchEmbedContents(ctx context.Context, b *EmbeddingBat
 	}
 	return (BatchEmbedContentsResponse{}).fromProto(res), nil
 }
+func (m *EmbeddingModel) Info(ctx context.Context) (*ModelInfo, error) {
+	return m.c.modelInfo(ctx, m.fullName)
+}


### PR DESCRIPTION
Add GenerativeModel.Info and EmbeddedModel.Info, which both call the GetModel RPC.