### PR TITLE
genai: change construction of full model name

### DIFF
--- a/genai/client.go
+++ b/genai/client.go
@@ -88,7 +88,7 @@ func (c *Client) GenerativeModel(name string) *GenerativeModel {
 }
 
 func fullModelName(name string) string {
-	if strings.HasPrefix(name, "models/") || strings.HasPrefix(name, "tunedModels/") {
+	if strings.ContainsRune(name, '/') {
 		return name
 	}
 	return "models/" + name

--- a/genai/client_test.go
+++ b/genai/client_test.go
@@ -83,7 +83,7 @@ func TestLive(t *testing.T) {
 			t.Fatalf("does not wrap a googleapi.Error")
 		}
 		got := gerr.Error()
-		want := "invalid argument"
+		want := "INVALID_ARGUMENT"
 		if !strings.Contains(got, want) {
 			t.Errorf("got %q\n\ndoes not contain %q", got, want)
 		}


### PR DESCRIPTION
Previously, the name passed to Client.GenerativeModel was converted to a full model name for the service by prepending "models/" unless that prefix was already present, in which case the name was used unmodified.

For a more general approach, we now treat any name with a slash verbatim, and only prepend "models/" if there is no slash.