### PR TITLE
Remove stale reference in doc

### DIFF
--- a/genai/content.go
+++ b/genai/content.go
@@ -25,7 +25,7 @@ const (
 	roleModel = "model"
 )
 
-// A Part is either a Text, a Blob, or a FileData.
+// A Part is either a Text or a Blob.
 type Part interface {
 	toPart() *pb.Part
 }


### PR DESCRIPTION
There's another odd reference in the doc of `Blob`:

```
// Blob contains raw media bytes.
//
// Text should not be sent as raw bytes, use the 'text' field.
```

It's not clear what "the 'text' field" is? 

But this is coming from generated code with protoveneer, so harder to change.