### PR TITLE
genai: check for API key

### DIFF
--- a/genai/client_test.go
+++ b/genai/client_test.go
@@ -507,3 +507,10 @@ func TestMatchString(t *testing.T) {
 		}
 	}
 }
+
+func TestNoAPIKey(t *testing.T) {
+	_, err := NewClient(context.Background())
+	if err == nil {
+		t.Fatal("got nil, want error")
+	}
+}


### PR DESCRIPTION
NewClient will return an error if not passed the WithAPIKey option.