### PR TITLE
genai: check for nil value from service

### DIFF
--- a/genai/chat.go
+++ b/genai/chat.go
@@ -60,6 +60,9 @@ func (cs *ChatSession) SendMessageStream(ctx context.Context, parts ...Part) *Ge
 func (cs *ChatSession) addToHistory(cands []*Candidate) bool {
 	if len(cands) > 0 {
 		c := cands[0].Content
+		if c == nil {
+			return false
+		}
 		c.Role = roleModel
 		cs.History = append(cs.History, c)
 		return true


### PR DESCRIPTION
Avoid dereferencing a nil.
This may fix an actual bug, but even if it doesn't, it's a good idea to assume as little as possible about values returned from the service.

For #55.