### PR TITLE
init empty citationsources to handle nil from proto

### DIFF
--- a/genai/generativelanguagepb_veneer.gen.go
+++ b/genai/generativelanguagepb_veneer.gen.go
@@ -173,7 +173,10 @@ func (v *CitationMetadata) toProto() *pb.CitationMetadata {
 
 func (CitationMetadata) fromProto(p *pb.CitationMetadata) *CitationMetadata {
 	if p == nil {
-		return nil
+		ls := make([]*CitationSource, 0)
+		return &CitationMetadata{
+			CitationSources: ls,
+		}
 	}
 	return &CitationMetadata{
 		CitationSources: support.TransformSlice(p.CitationSources, (CitationSource{}).fromProto),


### PR DESCRIPTION
When CitationMetadata is returned from protobuf, sometimes CitationSources is empty. Hence, defining nil for the CitationMetadata would result in nil for CitationSources. The proposed pull request was to handling returned nil value from protoBuf.