### PR TITLE
genai: switch to v1beta

### DIFF
--- a/genai/client.go
+++ b/genai/client.go
@@ -15,7 +15,7 @@
 // To get the protoveneer tool:
 //    go install cloud.google.com/go/internal/protoveneer/cmd/protoveneer@latest
 
-//go:generate protoveneer -license license.txt config.yaml ../../../googleapis/google-cloud-go/ai/generativelanguage/apiv1/generativelanguagepb
+//go:generate protoveneer -license license.txt config.yaml ../../../googleapis/google-cloud-go/ai/generativelanguage/apiv1beta/generativelanguagepb
 
 package genai
 
@@ -27,8 +27,8 @@ import (
 	"reflect"
 	"strings"
 
-	gl "cloud.google.com/go/ai/generativelanguage/apiv1"
-	pb "cloud.google.com/go/ai/generativelanguage/apiv1/generativelanguagepb"
+	gl "cloud.google.com/go/ai/generativelanguage/apiv1beta"
+	pb "cloud.google.com/go/ai/generativelanguage/apiv1beta/generativelanguagepb"
 
 	"github.com/google/generative-ai-go/internal"
 	"github.com/google/generative-ai-go/internal/support"

--- a/genai/client_test.go
+++ b/genai/client_test.go
@@ -121,12 +121,12 @@ func TestLive(t *testing.T) {
 		}
 
 		checkMatch(t,
-			send("Name puppy breeds.", false),
-			"Beagle", "Boxer")
+			send("Name the 5 most popular puppy breeds.", false),
+			"Retriever", "Poodle")
 
 		checkMatch(t,
 			send("Which is best?", true),
-			"best", "depends", "([Cc]onsider|research|compare)")
+			"best", "depends", "([Cc]onsider|research|compare|preferences)")
 	})
 
 	t.Run("image", func(t *testing.T) {

--- a/genai/client_test.go
+++ b/genai/client_test.go
@@ -122,7 +122,7 @@ func TestLive(t *testing.T) {
 
 		checkMatch(t,
 			send("Name puppy breeds.", false),
-			"Beagle", "Poodle")
+			"Beagle", "Boxer")
 
 		checkMatch(t,
 			send("Which is best?", true),

--- a/genai/config.yaml
+++ b/genai/config.yaml
@@ -16,7 +16,7 @@
 
 package: genai
 
-protoImportPath: cloud.google.com/go/ai/generativelanguage/apiv1/generativelanguagepb
+protoImportPath: cloud.google.com/go/ai/generativelanguage/apiv1beta/generativelanguagepb
 supportImportPath: github.com/google/generative-ai-go/internal/support
 
 types:
@@ -83,6 +83,8 @@ types:
       fields:
         Index:
           type: int32
+        GroundingAttributions:
+          omit: true
 
     GenerateContentResponse_PromptFeedback:
       name: PromptFeedback
@@ -112,7 +114,6 @@ types:
           type: float32
         TopK:
           type: int32
-
 
 
 # Omit everything not explicitly configured.

--- a/genai/content.go
+++ b/genai/content.go
@@ -17,7 +17,7 @@ package genai
 import (
 	"fmt"
 
-	pb "cloud.google.com/go/ai/generativelanguage/apiv1/generativelanguagepb"
+	pb "cloud.google.com/go/ai/generativelanguage/apiv1beta/generativelanguagepb"
 )
 
 const (

--- a/genai/embed.go
+++ b/genai/embed.go
@@ -17,7 +17,7 @@ package genai
 import (
 	"context"
 
-	pb "cloud.google.com/go/ai/generativelanguage/apiv1/generativelanguagepb"
+	pb "cloud.google.com/go/ai/generativelanguage/apiv1beta/generativelanguagepb"
 )
 
 // EmbeddingModel creates a new instance of the named embedding model.

--- a/genai/generativelanguagepb_veneer.gen.go
+++ b/genai/generativelanguagepb_veneer.gen.go
@@ -19,7 +19,7 @@ package genai
 import (
 	"fmt"
 
-	pb "cloud.google.com/go/ai/generativelanguage/apiv1/generativelanguagepb"
+	pb "cloud.google.com/go/ai/generativelanguage/apiv1beta/generativelanguagepb"
 	"github.com/google/generative-ai-go/internal/support"
 )
 

--- a/genai/list_models.go
+++ b/genai/list_models.go
@@ -17,8 +17,8 @@ package genai
 import (
 	"context"
 
-	gl "cloud.google.com/go/ai/generativelanguage/apiv1"
-	pb "cloud.google.com/go/ai/generativelanguage/apiv1/generativelanguagepb"
+	gl "cloud.google.com/go/ai/generativelanguage/apiv1beta"
+	pb "cloud.google.com/go/ai/generativelanguage/apiv1beta/generativelanguagepb"
 
 	"google.golang.org/api/iterator"
 )


### PR DESCRIPTION
Use the v1beta version of the API.
This will provide access to function calling.
