### PR TITLE
genai: fix panic on nil response

### DIFF
--- a/genai/client.go
+++ b/genai/client.go
@@ -207,6 +207,9 @@ func (iter *GenerateContentResponseIterator) Next() (*GenerateContentResponse, e
 
 func protoToResponse(resp *pb.GenerateContentResponse) (*GenerateContentResponse, error) {
 	gcp := (GenerateContentResponse{}).fromProto(resp)
+	if gcp == nil {
+		return nil, errors.New("empty response from model")
+	}
 	// Assume a non-nil PromptFeedback is an error.
 	// TODO: confirm.
 	if gcp.PromptFeedback != nil && gcp.PromptFeedback.BlockReason != BlockReasonUnspecified {


### PR DESCRIPTION
If the model returns no response, treat that as an error.

Fixes #54.
