### PR TITLE
Update the internal version.

### DIFF
--- a/genai/internal/version.go
+++ b/genai/internal/version.go
@@ -5,4 +5,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.11.0"
+const Version = "0.11.2"


### PR DESCRIPTION
This CL should be followed by tagging the repo v0.11.2.
