### PR TITLE
genai: add example of setting proxy

### DIFF
--- a/genai/example_test.go
+++ b/genai/example_test.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/google/generative-ai-go/genai"
@@ -459,6 +461,63 @@ func ExampleClient_UploadFile() {
 		log.Fatal(err)
 	}
 	_ = resp // Use resp as usual.
+}
+
+type ProxyRT struct {
+	// APIKey is the API Key to set on requests.
+	APIKey string
+
+	// ProxyURL is the URL of the proxy server. If empty, no proxy is used.
+	ProxyURL string
+}
+
+func (t *ProxyRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Set Proxy on the transport, if t.ProxyURL was provided
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+
+	if t.ProxyURL != "" {
+		proxyURL, err := url.Parse(t.ProxyURL)
+		if err != nil {
+			return nil, err
+		}
+		transport.Proxy = http.ProxyURL(proxyURL)
+	}
+
+	// Set API key on the request we're sending
+	newReq := req.Clone(req.Context())
+	vals := newReq.URL.Query()
+	vals.Set("key", t.APIKey)
+	newReq.URL.RawQuery = vals.Encode()
+
+	resp, err := transport.RoundTrip(newReq)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func ExampleClient_setProxy() {
+	c := &http.Client{Transport: &ProxyRT{
+		APIKey:   os.Getenv("GEMINI_API_KEY"),
+		ProxyURL: "http://<proxy-url>",
+	}}
+
+	ctx := context.Background()
+	client, err := genai.NewClient(ctx, option.WithHTTPClient(c))
+
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Close()
+
+	model := client.GenerativeModel("gemini-1.0-pro")
+	resp, err := model.GenerateContent(ctx, genai.Text("What is the average size of a swallow?"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	printResponse(resp)
 }
 
 func printResponse(resp *genai.GenerateContentResponse) {


### PR DESCRIPTION
Inspired by #17 

We keep seeing people wanting to be able to use proxies (latest example: https://github.com/eliben/gemini-cli/issues/2), and it's good to have a canonical resource.

It's useful to have an example for this because the interaction of `option.WithHTTPClient` with API keys is tricky (custom HTTP clients don't set the key properly).
