### PR TITLE
genai: set genai-go in header

### DIFF
--- a/genai/client.go
+++ b/genai/client.go
@@ -77,7 +77,7 @@ Import the option package as "google.golang.org/api/option".`)
 	if err != nil {
 		return nil, err
 	}
-	c.SetGoogleClientInfo("gccl", "v"+internal.Version)
+	c.SetGoogleClientInfo("gccl", "v"+internal.Version, "genai-go", internal.Version)
 	return &Client{c, mc, fc, ds}, nil
 }
 


### PR DESCRIPTION
Add genai-go/VERSION to the x-goog-api-client header.
Following the Python client, the version is not prefixed with a 'v'.
