### PR TITLE
genai: add File time fields

### DIFF
--- a/genai/client_test.go
+++ b/genai/client_test.go
@@ -27,6 +27,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
@@ -407,6 +408,11 @@ func TestLive(t *testing.T) {
 		}
 		if got, want := file.SizeBytes, int64(9218); got != want {
 			t.Errorf("got file size %d, want %d", got, want)
+		}
+		// The file should have just been created. Be generous, though.
+		now := time.Now()
+		if file.CreateTime.Before(now.Add(-time.Hour)) || file.CreateTime.After(now.Add(time.Hour)) {
+			t.Errorf("got file time %s, wanted around now (%s)", file.CreateTime, now)
 		}
 		// Don't test GetFile, because UploadFile already calls GetFile.
 		// ListFiles should return the file we just uploaded, and maybe other files too.

--- a/genai/config.yaml
+++ b/genai/config.yaml
@@ -150,20 +150,16 @@ types:
 
     File:
       fields:
-        CreateTime:
-          # TODO(jba): support time in protoveneer
-          omit: true
-          # type: time.Time
-        UpdateTime:
-          omit: true
-          # type: time.Time
-        ExpirationTime:
-          omit: true
-          # type: time.Time
         Uri:
           name: URI
         MimeType:
           name: MIMEType
+        Error:
+          # TODO(jba): support or convert status.Status
+          omit: true
+        Metadata:
+          # TODO(jba): support
+          omit: true
     File_State:
       name: FileState
       docVerb: represents

--- a/genai/generativelanguagepb_veneer.gen.go
+++ b/genai/generativelanguagepb_veneer.gen.go
@@ -21,6 +21,8 @@ import (
 
 	pb "cloud.google.com/go/ai/generativelanguage/apiv1beta/generativelanguagepb"
 	"github.com/google/generative-ai-go/internal/support"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"time"
 )
 
 // BatchEmbedContentsResponse is the response to a `BatchEmbedContentsRequest`.
@@ -357,6 +359,13 @@ type File struct {
 	MIMEType string
 	// Output only. Size of the file in bytes.
 	SizeBytes int64
+	// Output only. The timestamp of when the `File` was created.
+	CreateTime time.Time
+	// Output only. The timestamp of when the `File` was last updated.
+	UpdateTime time.Time
+	// Output only. The timestamp of when the `File` will be deleted. Only set if
+	// the `File` is scheduled to expire.
+	ExpirationTime time.Time
 	// Output only. SHA-256 hash of the uploaded bytes.
 	Sha256Hash []byte
 	// Output only. The uri of the `File`.
@@ -370,13 +379,16 @@ func (v *File) toProto() *pb.File {
 		return nil
 	}
 	return &pb.File{
-		Name:        v.Name,
-		DisplayName: v.DisplayName,
-		MimeType:    v.MIMEType,
-		SizeBytes:   v.SizeBytes,
-		Sha256Hash:  v.Sha256Hash,
-		Uri:         v.URI,
-		State:       pb.File_State(v.State),
+		Name:           v.Name,
+		DisplayName:    v.DisplayName,
+		MimeType:       v.MIMEType,
+		SizeBytes:      v.SizeBytes,
+		CreateTime:     timestamppb.New(v.CreateTime),
+		UpdateTime:     timestamppb.New(v.UpdateTime),
+		ExpirationTime: timestamppb.New(v.ExpirationTime),
+		Sha256Hash:     v.Sha256Hash,
+		Uri:            v.URI,
+		State:          pb.File_State(v.State),
 	}
 }
 
@@ -385,13 +397,16 @@ func (File) fromProto(p *pb.File) *File {
 		return nil
 	}
 	return &File{
-		Name:        p.Name,
-		DisplayName: p.DisplayName,
-		MIMEType:    p.MimeType,
-		SizeBytes:   p.SizeBytes,
-		Sha256Hash:  p.Sha256Hash,
-		URI:         p.Uri,
-		State:       FileState(p.State),
+		Name:           p.Name,
+		DisplayName:    p.DisplayName,
+		MIMEType:       p.MimeType,
+		SizeBytes:      p.SizeBytes,
+		CreateTime:     support.TimeFromProto(p.CreateTime),
+		UpdateTime:     support.TimeFromProto(p.UpdateTime),
+		ExpirationTime: support.TimeFromProto(p.ExpirationTime),
+		Sha256Hash:     p.Sha256Hash,
+		URI:            p.Uri,
+		State:          FileState(p.State),
 	}
 }
 
@@ -1088,7 +1103,7 @@ func (SafetyRating) fromProto(p *pb.SafetyRating) *SafetyRating {
 
 // SafetySetting is safety setting, affecting the safety-blocking behavior.
 //
-// Passing a safety setting for a category changes the allowed proability that
+// Passing a safety setting for a category changes the allowed probability that
 // content is blocked.
 type SafetySetting struct {
 	// Required. The category for this setting.

--- a/genai/internal/generativelanguage/v1beta/generativelanguage-api.json
+++ b/genai/internal/generativelanguage/v1beta/generativelanguage-api.json
@@ -1,1796 +1,46 @@
 {
   "description": "The Gemini API allows developers to build generative AI applications using Gemini models. Gemini is our most capable model, built from the ground up to be multimodal. It can generalize and seamlessly understand, operate across, and combine different types of information including language, images, audio, video, and code. You can use the Gemini API for use cases like reasoning across text and images, content generation, dialogue agents, summarization and classification systems, and more.",
-  "resources": {
-    "files": {
-      "methods": {
-        "delete": {
-          "id": "generativelanguage.files.delete",
-          "parameters": {
-            "name": {
-              "location": "path",
-              "description": "Required. The name of the `File` to delete. Example: `files/abc-123`",
-              "type": "string",
-              "required": true,
-              "pattern": "^files/[^/]+$"
-            }
-          },
-          "description": "Deletes the `File`.",
-          "response": {
-            "$ref": "Empty"
-          },
-          "httpMethod": "DELETE",
-          "parameterOrder": [
-            "name"
-          ],
-          "path": "v1beta/{+name}",
-          "flatPath": "v1beta/files/{filesId}"
-        },
-        "get": {
-          "parameters": {
-            "name": {
-              "required": true,
-              "type": "string",
-              "description": "Required. The name of the `File` to get. Example: `files/abc-123`",
-              "location": "path",
-              "pattern": "^files/[^/]+$"
-            }
-          },
-          "flatPath": "v1beta/files/{filesId}",
-          "path": "v1beta/{+name}",
-          "response": {
-            "$ref": "File"
-          },
-          "httpMethod": "GET",
-          "id": "generativelanguage.files.get",
-          "parameterOrder": [
-            "name"
-          ],
-          "description": "Gets the metadata for the given `File`."
-        },
-        "list": {
-          "id": "generativelanguage.files.list",
-          "parameters": {
-            "pageSize": {
-              "type": "integer",
-              "location": "query",
-              "description": "Optional. Maximum number of `File`s to return per page. If unspecified, defaults to 10. Maximum `page_size` is 100.",
-              "format": "int32"
-            },
-            "pageToken": {
-              "location": "query",
-              "description": "Optional. A page token from a previous `ListFiles` call.",
-              "type": "string"
-            }
-          },
-          "flatPath": "v1beta/files",
-          "description": "Lists the metadata for `File`s owned by the requesting project.",
-          "path": "v1beta/files",
-          "httpMethod": "GET",
-          "response": {
-            "$ref": "ListFilesResponse"
-          },
-          "parameterOrder": []
-        }
-      }
-    },
-    "media": {
-      "methods": {
-        "upload": {
-          "id": "generativelanguage.media.upload",
-          "parameters": {},
-          "description": "Creates a `File`.",
-          "path": "v1beta/files",
-          "request": {
-            "$ref": "CreateFileRequest"
-          },
-          "mediaUpload": {
-            "accept": [
-              "*/*"
-            ],
-            "protocols": {
-              "resumable": {
-                "path": "/resumable/upload/v1beta/files",
-                "multipart": true
-              },
-              "simple": {
-                "multipart": true,
-                "path": "/upload/v1beta/files"
-              }
-            },
-            "maxSize": "2147483648"
-          },
-          "flatPath": "v1beta/files",
-          "parameterOrder": [],
-          "response": {
-            "$ref": "CreateFileResponse"
-          },
-          "httpMethod": "POST",
-          "supportsMediaUpload": true
-        }
-      }
-    },
-    "tunedModels": {
-      "resources": {
-        "permissions": {
-          "methods": {
-            "patch": {
-              "response": {
-                "$ref": "Permission"
-              },
-              "request": {
-                "$ref": "Permission"
-              },
-              "parameterOrder": [
-                "name"
-              ],
-              "path": "v1beta/{+name}",
-              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions/{permissionsId}",
-              "description": "Updates the permission.",
-              "id": "generativelanguage.tunedModels.permissions.patch",
-              "httpMethod": "PATCH",
-              "parameters": {
-                "name": {
-                  "required": true,
-                  "description": "Output only. Identifier. The permission name. A unique name will be generated on create. Examples: tunedModels/{tuned_model}/permissions/{permission} corpora/{corpus}/permissions/{permission} Output only.",
-                  "pattern": "^tunedModels/[^/]+/permissions/[^/]+$",
-                  "type": "string",
-                  "location": "path"
-                },
-                "updateMask": {
-                  "location": "query",
-                  "type": "string",
-                  "format": "google-fieldmask",
-                  "description": "Required. The list of fields to update. Accepted ones: - role (`Permission.role` field)"
-                }
-              }
-            },
-            "delete": {
-              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions/{permissionsId}",
-              "id": "generativelanguage.tunedModels.permissions.delete",
-              "description": "Deletes the permission.",
-              "httpMethod": "DELETE",
-              "parameterOrder": [
-                "name"
-              ],
-              "response": {
-                "$ref": "Empty"
-              },
-              "parameters": {
-                "name": {
-                  "location": "path",
-                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
-                  "required": true,
-                  "pattern": "^tunedModels/[^/]+/permissions/[^/]+$",
-                  "type": "string"
-                }
-              },
-              "path": "v1beta/{+name}"
-            },
-            "create": {
-              "description": "Create a permission to a specific resource.",
-              "response": {
-                "$ref": "Permission"
-              },
-              "parameterOrder": [
-                "parent"
-              ],
-              "path": "v1beta/{+parent}/permissions",
-              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions",
-              "request": {
-                "$ref": "Permission"
-              },
-              "httpMethod": "POST",
-              "parameters": {
-                "parent": {
-                  "required": true,
-                  "type": "string",
-                  "location": "path",
-                  "description": "Required. The parent resource of the `Permission`. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`",
-                  "pattern": "^tunedModels/[^/]+$"
-                }
-              },
-              "id": "generativelanguage.tunedModels.permissions.create"
-            },
-            "get": {
-              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions/{permissionsId}",
-              "parameters": {
-                "name": {
-                  "type": "string",
-                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
-                  "location": "path",
-                  "required": true,
-                  "pattern": "^tunedModels/[^/]+/permissions/[^/]+$"
-                }
-              },
-              "path": "v1beta/{+name}",
-              "response": {
-                "$ref": "Permission"
-              },
-              "id": "generativelanguage.tunedModels.permissions.get",
-              "httpMethod": "GET",
-              "description": "Gets information about a specific Permission.",
-              "parameterOrder": [
-                "name"
-              ]
-            },
-            "list": {
-              "description": "Lists permissions for the specific resource.",
-              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions",
-              "id": "generativelanguage.tunedModels.permissions.list",
-              "parameters": {
-                "parent": {
-                  "pattern": "^tunedModels/[^/]+$",
-                  "location": "path",
-                  "type": "string",
-                  "description": "Required. The parent resource of the permissions. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`",
-                  "required": true
-                },
-                "pageSize": {
-                  "type": "integer",
-                  "location": "query",
-                  "description": "Optional. The maximum number of `Permission`s to return (per page). The service may return fewer permissions. If unspecified, at most 10 permissions will be returned. This method returns at most 1000 permissions per page, even if you pass larger page_size.",
-                  "format": "int32"
-                },
-                "pageToken": {
-                  "type": "string",
-                  "location": "query",
-                  "description": "Optional. A page token, received from a previous `ListPermissions` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListPermissions` must match the call that provided the page token."
-                }
-              },
-              "path": "v1beta/{+parent}/permissions",
-              "httpMethod": "GET",
-              "parameterOrder": [
-                "parent"
-              ],
-              "response": {
-                "$ref": "ListPermissionsResponse"
-              }
-            }
-          }
-        }
-      },
-      "methods": {
-        "generateText": {
-          "parameters": {
-            "model": {
-              "pattern": "^tunedModels/[^/]+$",
-              "description": "Required. The name of the `Model` or `TunedModel` to use for generating the completion. Examples: models/text-bison-001 tunedModels/sentence-translator-u3b7m",
-              "required": true,
-              "type": "string",
-              "location": "path"
-            }
-          },
-          "httpMethod": "POST",
-          "flatPath": "v1beta/tunedModels/{tunedModelsId}:generateText",
-          "id": "generativelanguage.tunedModels.generateText",
-          "request": {
-            "$ref": "GenerateTextRequest"
-          },
-          "parameterOrder": [
-            "model"
-          ],
-          "response": {
-            "$ref": "GenerateTextResponse"
-          },
-          "path": "v1beta/{+model}:generateText",
-          "description": "Generates a response from the model given an input message."
-        },
-        "transferOwnership": {
-          "description": "Transfers ownership of the tuned model. This is the only way to change ownership of the tuned model. The current owner will be downgraded to writer role.",
-          "path": "v1beta/{+name}:transferOwnership",
-          "response": {
-            "$ref": "TransferOwnershipResponse"
-          },
-          "id": "generativelanguage.tunedModels.transferOwnership",
-          "parameters": {
-            "name": {
-              "required": true,
-              "location": "path",
-              "pattern": "^tunedModels/[^/]+$",
-              "description": "Required. The resource name of the tuned model to transfer ownership. Format: `tunedModels/my-model-id`",
-              "type": "string"
-            }
-          },
-          "flatPath": "v1beta/tunedModels/{tunedModelsId}:transferOwnership",
-          "parameterOrder": [
-            "name"
-          ],
-          "httpMethod": "POST",
-          "request": {
-            "$ref": "TransferOwnershipRequest"
-          }
-        },
-        "list": {
-          "path": "v1beta/tunedModels",
-          "description": "Lists tuned models owned by the user.",
-          "response": {
-            "$ref": "ListTunedModelsResponse"
-          },
-          "parameters": {
-            "pageSize": {
-              "location": "query",
-              "format": "int32",
-              "type": "integer",
-              "description": "Optional. The maximum number of `TunedModels` to return (per page). The service may return fewer tuned models. If unspecified, at most 10 tuned models will be returned. This method returns at most 1000 models per page, even if you pass a larger page_size."
-            },
-            "pageToken": {
-              "location": "query",
-              "description": "Optional. A page token, received from a previous `ListTunedModels` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListTunedModels` must match the call that provided the page token.",
-              "type": "string"
-            },
-            "filter": {
-              "type": "string",
-              "description": "Optional. A filter is a full text search over the tuned model's description and display name. By default, results will not include tuned models shared with everyone. Additional operators: - owner:me - writers:me - readers:me - readers:everyone Examples: \"owner:me\" returns all tuned models to which caller has owner role \"readers:me\" returns all tuned models to which caller has reader role \"readers:everyone\" returns all tuned models that are shared with everyone",
-              "location": "query"
-            }
-          },
-          "flatPath": "v1beta/tunedModels",
-          "httpMethod": "GET",
-          "parameterOrder": [],
-          "id": "generativelanguage.tunedModels.list"
-        },
-        "create": {
-          "request": {
-            "$ref": "TunedModel"
-          },
-          "httpMethod": "POST",
-          "parameterOrder": [],
-          "response": {
-            "$ref": "Operation"
-          },
-          "parameters": {
-            "tunedModelId": {
-              "location": "query",
-              "description": "Optional. The unique id for the tuned model if specified. This value should be up to 40 characters, the first character must be a letter, the last could be a letter or a number. The id must match the regular expression: [a-z]([a-z0-9-]{0,38}[a-z0-9])?.",
-              "type": "string"
-            }
-          },
-          "description": "Creates a tuned model. Intermediate tuning progress (if any) is accessed through the [google.longrunning.Operations] service. Status and results can be accessed through the Operations service. Example: GET /v1/tunedModels/az2mb0bpw6i/operations/000-111-222",
-          "id": "generativelanguage.tunedModels.create",
-          "flatPath": "v1beta/tunedModels",
-          "path": "v1beta/tunedModels"
-        },
-        "generateContent": {
-          "parameterOrder": [
-            "model"
-          ],
-          "httpMethod": "POST",
-          "request": {
-            "$ref": "GenerateContentRequest"
-          },
-          "path": "v1beta/{+model}:generateContent",
-          "response": {
-            "$ref": "GenerateContentResponse"
-          },
-          "description": "Generates a response from the model given an input `GenerateContentRequest`. Input capabilities differ between models, including tuned models. See the [model guide](https://ai.google.dev/models/gemini) and [tuning guide](https://ai.google.dev/docs/model_tuning_guidance) for details.",
-          "id": "generativelanguage.tunedModels.generateContent",
-          "flatPath": "v1beta/tunedModels/{tunedModelsId}:generateContent",
-          "parameters": {
-            "model": {
-              "location": "path",
-              "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`.",
-              "required": true,
-              "pattern": "^tunedModels/[^/]+$",
-              "type": "string"
-            }
-          }
-        },
-        "delete": {
-          "flatPath": "v1beta/tunedModels/{tunedModelsId}",
-          "description": "Deletes a tuned model.",
-          "parameterOrder": [
-            "name"
-          ],
-          "path": "v1beta/{+name}",
-          "response": {
-            "$ref": "Empty"
-          },
-          "parameters": {
-            "name": {
-              "description": "Required. The resource name of the model. Format: `tunedModels/my-model-id`",
-              "required": true,
-              "type": "string",
-              "pattern": "^tunedModels/[^/]+$",
-              "location": "path"
-            }
-          },
-          "id": "generativelanguage.tunedModels.delete",
-          "httpMethod": "DELETE"
-        },
-        "get": {
-          "parameterOrder": [
-            "name"
-          ],
-          "flatPath": "v1beta/tunedModels/{tunedModelsId}",
-          "description": "Gets information about a specific TunedModel.",
-          "id": "generativelanguage.tunedModels.get",
-          "path": "v1beta/{+name}",
-          "httpMethod": "GET",
-          "parameters": {
-            "name": {
-              "description": "Required. The resource name of the model. Format: `tunedModels/my-model-id`",
-              "required": true,
-              "pattern": "^tunedModels/[^/]+$",
-              "type": "string",
-              "location": "path"
-            }
-          },
-          "response": {
-            "$ref": "TunedModel"
-          }
-        },
-        "patch": {
-          "response": {
-            "$ref": "TunedModel"
-          },
-          "description": "Updates a tuned model.",
-          "httpMethod": "PATCH",
-          "parameters": {
-            "updateMask": {
-              "format": "google-fieldmask",
-              "description": "Required. The list of fields to update.",
-              "type": "string",
-              "location": "query"
-            },
-            "name": {
-              "required": true,
-              "pattern": "^tunedModels/[^/]+$",
-              "location": "path",
-              "description": "Output only. The tuned model name. A unique name will be generated on create. Example: `tunedModels/az2mb0bpw6i` If display_name is set on create, the id portion of the name will be set by concatenating the words of the display_name with hyphens and adding a random portion for uniqueness. Example: display_name = \"Sentence Translator\" name = \"tunedModels/sentence-translator-u3b7m\"",
-              "type": "string"
-            }
-          },
-          "parameterOrder": [
-            "name"
-          ],
-          "flatPath": "v1beta/tunedModels/{tunedModelsId}",
-          "path": "v1beta/{+name}",
-          "request": {
-            "$ref": "TunedModel"
-          },
-          "id": "generativelanguage.tunedModels.patch"
-        }
-      }
-    },
-    "corpora": {
-      "resources": {
-        "permissions": {
-          "methods": {
-            "delete": {
-              "path": "v1beta/{+name}",
-              "response": {
-                "$ref": "Empty"
-              },
-              "id": "generativelanguage.corpora.permissions.delete",
-              "parameters": {
-                "name": {
-                  "pattern": "^corpora/[^/]+/permissions/[^/]+$",
-                  "required": true,
-                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
-                  "type": "string",
-                  "location": "path"
-                }
-              },
-              "httpMethod": "DELETE",
-              "flatPath": "v1beta/corpora/{corporaId}/permissions/{permissionsId}",
-              "parameterOrder": [
-                "name"
-              ],
-              "description": "Deletes the permission."
-            },
-            "get": {
-              "parameters": {
-                "name": {
-                  "location": "path",
-                  "pattern": "^corpora/[^/]+/permissions/[^/]+$",
-                  "required": true,
-                  "type": "string",
-                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`"
-                }
-              },
-              "response": {
-                "$ref": "Permission"
-              },
-              "path": "v1beta/{+name}",
-              "id": "generativelanguage.corpora.permissions.get",
-              "httpMethod": "GET",
-              "parameterOrder": [
-                "name"
-              ],
-              "description": "Gets information about a specific Permission.",
-              "flatPath": "v1beta/corpora/{corporaId}/permissions/{permissionsId}"
-            },
-            "list": {
-              "response": {
-                "$ref": "ListPermissionsResponse"
-              },
-              "parameters": {
-                "parent": {
-                  "description": "Required. The parent resource of the permissions. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`",
-                  "required": true,
-                  "type": "string",
-                  "pattern": "^corpora/[^/]+$",
-                  "location": "path"
-                },
-                "pageToken": {
-                  "description": "Optional. A page token, received from a previous `ListPermissions` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListPermissions` must match the call that provided the page token.",
-                  "location": "query",
-                  "type": "string"
-                },
-                "pageSize": {
-                  "format": "int32",
-                  "type": "integer",
-                  "description": "Optional. The maximum number of `Permission`s to return (per page). The service may return fewer permissions. If unspecified, at most 10 permissions will be returned. This method returns at most 1000 permissions per page, even if you pass larger page_size.",
-                  "location": "query"
-                }
-              },
-              "httpMethod": "GET",
-              "flatPath": "v1beta/corpora/{corporaId}/permissions",
-              "path": "v1beta/{+parent}/permissions",
-              "parameterOrder": [
-                "parent"
-              ],
-              "description": "Lists permissions for the specific resource.",
-              "id": "generativelanguage.corpora.permissions.list"
-            },
-            "create": {
-              "path": "v1beta/{+parent}/permissions",
-              "parameters": {
-                "parent": {
-                  "type": "string",
-                  "required": true,
-                  "description": "Required. The parent resource of the `Permission`. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`",
-                  "pattern": "^corpora/[^/]+$",
-                  "location": "path"
-                }
-              },
-              "id": "generativelanguage.corpora.permissions.create",
-              "flatPath": "v1beta/corpora/{corporaId}/permissions",
-              "parameterOrder": [
-                "parent"
-              ],
-              "request": {
-                "$ref": "Permission"
-              },
-              "httpMethod": "POST",
-              "response": {
-                "$ref": "Permission"
-              },
-              "description": "Create a permission to a specific resource."
-            },
-            "patch": {
-              "parameters": {
-                "name": {
-                  "pattern": "^corpora/[^/]+/permissions/[^/]+$",
-                  "required": true,
-                  "description": "Output only. Identifier. The permission name. A unique name will be generated on create. Examples: tunedModels/{tuned_model}/permissions/{permission} corpora/{corpus}/permissions/{permission} Output only.",
-                  "location": "path",
-                  "type": "string"
-                },
-                "updateMask": {
-                  "format": "google-fieldmask",
-                  "location": "query",
-                  "description": "Required. The list of fields to update. Accepted ones: - role (`Permission.role` field)",
-                  "type": "string"
-                }
-              },
-              "parameterOrder": [
-                "name"
-              ],
-              "request": {
-                "$ref": "Permission"
-              },
-              "id": "generativelanguage.corpora.permissions.patch",
-              "description": "Updates the permission.",
-              "httpMethod": "PATCH",
-              "response": {
-                "$ref": "Permission"
-              },
-              "path": "v1beta/{+name}",
-              "flatPath": "v1beta/corpora/{corporaId}/permissions/{permissionsId}"
-            }
-          }
-        },
-        "documents": {
-          "methods": {
-            "create": {
-              "path": "v1beta/{+parent}/documents",
-              "description": "Creates an empty `Document`.",
-              "id": "generativelanguage.corpora.documents.create",
-              "parameterOrder": [
-                "parent"
-              ],
-              "request": {
-                "$ref": "Document"
-              },
-              "response": {
-                "$ref": "Document"
-              },
-              "flatPath": "v1beta/corpora/{corporaId}/documents",
-              "httpMethod": "POST",
-              "parameters": {
-                "parent": {
-                  "type": "string",
-                  "location": "path",
-                  "description": "Required. The name of the `Corpus` where this `Document` will be created. Example: `corpora/my-corpus-123`",
-                  "pattern": "^corpora/[^/]+$",
-                  "required": true
-                }
-              }
-            },
-            "get": {
-              "description": "Gets information about a specific `Document`.",
-              "parameterOrder": [
-                "name"
-              ],
-              "parameters": {
-                "name": {
-                  "type": "string",
-                  "required": true,
-                  "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                  "location": "path",
-                  "description": "Required. The name of the `Document` to retrieve. Example: `corpora/my-corpus-123/documents/the-doc-abc`"
-                }
-              },
-              "path": "v1beta/{+name}",
-              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}",
-              "id": "generativelanguage.corpora.documents.get",
-              "response": {
-                "$ref": "Document"
-              },
-              "httpMethod": "GET"
-            },
-            "delete": {
-              "parameterOrder": [
-                "name"
-              ],
-              "path": "v1beta/{+name}",
-              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}",
-              "id": "generativelanguage.corpora.documents.delete",
-              "parameters": {
-                "force": {
-                  "type": "boolean",
-                  "location": "query",
-                  "description": "Optional. If set to true, any `Chunk`s and objects related to this `Document` will also be deleted. If false (the default), a `FAILED_PRECONDITION` error will be returned if `Document` contains any `Chunk`s."
-                },
-                "name": {
-                  "type": "string",
-                  "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                  "location": "path",
-                  "description": "Required. The resource name of the `Document` to delete. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
-                  "required": true
-                }
-              },
-              "description": "Deletes a `Document`.",
-              "httpMethod": "DELETE",
-              "response": {
-                "$ref": "Empty"
-              }
-            },
-            "patch": {
-              "httpMethod": "PATCH",
-              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}",
-              "parameterOrder": [
-                "name"
-              ],
-              "path": "v1beta/{+name}",
-              "request": {
-                "$ref": "Document"
-              },
-              "description": "Updates a `Document`.",
-              "response": {
-                "$ref": "Document"
-              },
-              "parameters": {
-                "updateMask": {
-                  "format": "google-fieldmask",
-                  "type": "string",
-                  "description": "Required. The list of fields to update. Currently, this only supports updating `display_name` and `custom_metadata`.",
-                  "location": "query"
-                },
-                "name": {
-                  "type": "string",
-                  "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                  "required": true,
-                  "description": "Immutable. Identifier. The `Document` resource name. The ID (name excluding the \"corpora/*/documents/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/{corpus_id}/documents/my-awesome-doc-123a456b789c`",
-                  "location": "path"
-                }
-              },
-              "id": "generativelanguage.corpora.documents.patch"
-            },
-            "query": {
-              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}:query",
-              "request": {
-                "$ref": "QueryDocumentRequest"
-              },
-              "description": "Performs semantic search over a `Document`.",
-              "id": "generativelanguage.corpora.documents.query",
-              "httpMethod": "POST",
-              "response": {
-                "$ref": "QueryDocumentResponse"
-              },
-              "path": "v1beta/{+name}:query",
-              "parameterOrder": [
-                "name"
-              ],
-              "parameters": {
-                "name": {
-                  "location": "path",
-                  "description": "Required. The name of the `Document` to query. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
-                  "type": "string",
-                  "required": true,
-                  "pattern": "^corpora/[^/]+/documents/[^/]+$"
-                }
-              }
-            },
-            "list": {
-              "response": {
-                "$ref": "ListDocumentsResponse"
-              },
-              "parameters": {
-                "pageToken": {
-                  "description": "Optional. A page token, received from a previous `ListDocuments` call. Provide the `next_page_token` returned in the response as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListDocuments` must match the call that provided the page token.",
-                  "location": "query",
-                  "type": "string"
-                },
-                "pageSize": {
-                  "description": "Optional. The maximum number of `Document`s to return (per page). The service may return fewer `Document`s. If unspecified, at most 10 `Document`s will be returned. The maximum size limit is 20 `Document`s per page.",
-                  "type": "integer",
-                  "location": "query",
-                  "format": "int32"
-                },
-                "parent": {
-                  "description": "Required. The name of the `Corpus` containing `Document`s. Example: `corpora/my-corpus-123`",
-                  "required": true,
-                  "pattern": "^corpora/[^/]+$",
-                  "type": "string",
-                  "location": "path"
-                }
-              },
-              "description": "Lists all `Document`s in a `Corpus`.",
-              "id": "generativelanguage.corpora.documents.list",
-              "parameterOrder": [
-                "parent"
-              ],
-              "path": "v1beta/{+parent}/documents",
-              "httpMethod": "GET",
-              "flatPath": "v1beta/corpora/{corporaId}/documents"
-            }
-          },
-          "resources": {
-            "chunks": {
-              "methods": {
-                "patch": {
-                  "parameters": {
-                    "name": {
-                      "type": "string",
-                      "location": "path",
-                      "required": true,
-                      "pattern": "^corpora/[^/]+/documents/[^/]+/chunks/[^/]+$",
-                      "description": "Immutable. Identifier. The `Chunk` resource name. The ID (name excluding the \"corpora/*/documents/*/chunks/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a random 12-character unique ID will be generated. Example: `corpora/{corpus_id}/documents/{document_id}/chunks/123a456b789c`"
-                    },
-                    "updateMask": {
-                      "format": "google-fieldmask",
-                      "type": "string",
-                      "location": "query",
-                      "description": "Required. The list of fields to update. Currently, this only supports updating `custom_metadata` and `data`."
-                    }
-                  },
-                  "httpMethod": "PATCH",
-                  "path": "v1beta/{+name}",
-                  "response": {
-                    "$ref": "Chunk"
-                  },
-                  "description": "Updates a `Chunk`.",
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks/{chunksId}",
-                  "parameterOrder": [
-                    "name"
-                  ],
-                  "id": "generativelanguage.corpora.documents.chunks.patch",
-                  "request": {
-                    "$ref": "Chunk"
-                  }
-                },
-                "batchCreate": {
-                  "parameterOrder": [
-                    "parent"
-                  ],
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks:batchCreate",
-                  "parameters": {
-                    "parent": {
-                      "type": "string",
-                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                      "required": true,
-                      "description": "Optional. The name of the `Document` where this batch of `Chunk`s will be created. The parent field in every `CreateChunkRequest` must match this value. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
-                      "location": "path"
-                    }
-                  },
-                  "path": "v1beta/{+parent}/chunks:batchCreate",
-                  "response": {
-                    "$ref": "BatchCreateChunksResponse"
-                  },
-                  "description": "Batch create `Chunk`s.",
-                  "httpMethod": "POST",
-                  "id": "generativelanguage.corpora.documents.chunks.batchCreate",
-                  "request": {
-                    "$ref": "BatchCreateChunksRequest"
-                  }
-                },
-                "create": {
-                  "description": "Creates a `Chunk`.",
-                  "request": {
-                    "$ref": "Chunk"
-                  },
-                  "httpMethod": "POST",
-                  "response": {
-                    "$ref": "Chunk"
-                  },
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks",
-                  "parameters": {
-                    "parent": {
-                      "description": "Required. The name of the `Document` where this `Chunk` will be created. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
-                      "type": "string",
-                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                      "location": "path",
-                      "required": true
-                    }
-                  },
-                  "id": "generativelanguage.corpora.documents.chunks.create",
-                  "parameterOrder": [
-                    "parent"
-                  ],
-                  "path": "v1beta/{+parent}/chunks"
-                },
-                "get": {
-                  "path": "v1beta/{+name}",
-                  "httpMethod": "GET",
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks/{chunksId}",
-                  "response": {
-                    "$ref": "Chunk"
-                  },
-                  "description": "Gets information about a specific `Chunk`.",
-                  "id": "generativelanguage.corpora.documents.chunks.get",
-                  "parameterOrder": [
-                    "name"
-                  ],
-                  "parameters": {
-                    "name": {
-                      "type": "string",
-                      "location": "path",
-                      "description": "Required. The name of the `Chunk` to retrieve. Example: `corpora/my-corpus-123/documents/the-doc-abc/chunks/some-chunk`",
-                      "pattern": "^corpora/[^/]+/documents/[^/]+/chunks/[^/]+$",
-                      "required": true
-                    }
-                  }
-                },
-                "list": {
-                  "response": {
-                    "$ref": "ListChunksResponse"
-                  },
-                  "httpMethod": "GET",
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks",
-                  "parameters": {
-                    "parent": {
-                      "required": true,
-                      "location": "path",
-                      "description": "Required. The name of the `Document` containing `Chunk`s. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
-                      "type": "string",
-                      "pattern": "^corpora/[^/]+/documents/[^/]+$"
-                    },
-                    "pageSize": {
-                      "type": "integer",
-                      "description": "Optional. The maximum number of `Chunk`s to return (per page). The service may return fewer `Chunk`s. If unspecified, at most 10 `Chunk`s will be returned. The maximum size limit is 100 `Chunk`s per page.",
-                      "location": "query",
-                      "format": "int32"
-                    },
-                    "pageToken": {
-                      "location": "query",
-                      "type": "string",
-                      "description": "Optional. A page token, received from a previous `ListChunks` call. Provide the `next_page_token` returned in the response as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListChunks` must match the call that provided the page token."
-                    }
-                  },
-                  "path": "v1beta/{+parent}/chunks",
-                  "description": "Lists all `Chunk`s in a `Document`.",
-                  "parameterOrder": [
-                    "parent"
-                  ],
-                  "id": "generativelanguage.corpora.documents.chunks.list"
-                },
-                "batchDelete": {
-                  "id": "generativelanguage.corpora.documents.chunks.batchDelete",
-                  "path": "v1beta/{+parent}/chunks:batchDelete",
-                  "description": "Batch delete `Chunk`s.",
-                  "request": {
-                    "$ref": "BatchDeleteChunksRequest"
-                  },
-                  "parameterOrder": [
-                    "parent"
-                  ],
-                  "response": {
-                    "$ref": "Empty"
-                  },
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks:batchDelete",
-                  "parameters": {
-                    "parent": {
-                      "type": "string",
-                      "description": "Optional. The name of the `Document` containing the `Chunk`s to delete. The parent field in every `DeleteChunkRequest` must match this value. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
-                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                      "location": "path",
-                      "required": true
-                    }
-                  },
-                  "httpMethod": "POST"
-                },
-                "delete": {
-                  "httpMethod": "DELETE",
-                  "parameters": {
-                    "name": {
-                      "description": "Required. The resource name of the `Chunk` to delete. Example: `corpora/my-corpus-123/documents/the-doc-abc/chunks/some-chunk`",
-                      "required": true,
-                      "location": "path",
-                      "pattern": "^corpora/[^/]+/documents/[^/]+/chunks/[^/]+$",
-                      "type": "string"
-                    }
-                  },
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks/{chunksId}",
-                  "path": "v1beta/{+name}",
-                  "parameterOrder": [
-                    "name"
-                  ],
-                  "description": "Deletes a `Chunk`.",
-                  "response": {
-                    "$ref": "Empty"
-                  },
-                  "id": "generativelanguage.corpora.documents.chunks.delete"
-                },
-                "batchUpdate": {
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks:batchUpdate",
-                  "id": "generativelanguage.corpora.documents.chunks.batchUpdate",
-                  "httpMethod": "POST",
-                  "path": "v1beta/{+parent}/chunks:batchUpdate",
-                  "request": {
-                    "$ref": "BatchUpdateChunksRequest"
-                  },
-                  "parameters": {
-                    "parent": {
-                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                      "required": true,
-                      "description": "Optional. The name of the `Document` containing the `Chunk`s to update. The parent field in every `UpdateChunkRequest` must match this value. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
-                      "location": "path",
-                      "type": "string"
-                    }
-                  },
-                  "parameterOrder": [
-                    "parent"
-                  ],
-                  "response": {
-                    "$ref": "BatchUpdateChunksResponse"
-                  },
-                  "description": "Batch update `Chunk`s."
-                }
-              }
-            }
-          }
-        }
-      },
-      "methods": {
-        "query": {
-          "parameters": {
-            "name": {
-              "pattern": "^corpora/[^/]+$",
-              "description": "Required. The name of the `Corpus` to query. Example: `corpora/my-corpus-123`",
-              "required": true,
-              "type": "string",
-              "location": "path"
-            }
-          },
-          "response": {
-            "$ref": "QueryCorpusResponse"
-          },
-          "description": "Performs semantic search over a `Corpus`.",
-          "id": "generativelanguage.corpora.query",
-          "parameterOrder": [
-            "name"
-          ],
-          "flatPath": "v1beta/corpora/{corporaId}:query",
-          "request": {
-            "$ref": "QueryCorpusRequest"
-          },
-          "httpMethod": "POST",
-          "path": "v1beta/{+name}:query"
-        },
-        "patch": {
-          "description": "Updates a `Corpus`.",
-          "id": "generativelanguage.corpora.patch",
-          "parameters": {
-            "updateMask": {
-              "description": "Required. The list of fields to update. Currently, this only supports updating `display_name`.",
-              "location": "query",
-              "type": "string",
-              "format": "google-fieldmask"
-            },
-            "name": {
-              "pattern": "^corpora/[^/]+$",
-              "location": "path",
-              "type": "string",
-              "required": true,
-              "description": "Immutable. Identifier. The `Corpus` resource name. The ID (name excluding the \"corpora/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/my-awesome-corpora-123a456b789c`"
-            }
-          },
-          "path": "v1beta/{+name}",
-          "response": {
-            "$ref": "Corpus"
-          },
-          "httpMethod": "PATCH",
-          "request": {
-            "$ref": "Corpus"
-          },
-          "flatPath": "v1beta/corpora/{corporaId}",
-          "parameterOrder": [
-            "name"
-          ]
-        },
-        "get": {
-          "parameterOrder": [
-            "name"
-          ],
-          "response": {
-            "$ref": "Corpus"
-          },
-          "description": "Gets information about a specific `Corpus`.",
-          "flatPath": "v1beta/corpora/{corporaId}",
-          "httpMethod": "GET",
-          "parameters": {
-            "name": {
-              "pattern": "^corpora/[^/]+$",
-              "type": "string",
-              "required": true,
-              "description": "Required. The name of the `Corpus`. Example: `corpora/my-corpus-123`",
-              "location": "path"
-            }
-          },
-          "id": "generativelanguage.corpora.get",
-          "path": "v1beta/{+name}"
-        },
-        "create": {
-          "request": {
-            "$ref": "Corpus"
-          },
-          "description": "Creates an empty `Corpus`.",
-          "httpMethod": "POST",
-          "flatPath": "v1beta/corpora",
-          "parameterOrder": [],
-          "id": "generativelanguage.corpora.create",
-          "path": "v1beta/corpora",
-          "parameters": {},
-          "response": {
-            "$ref": "Corpus"
-          }
-        },
-        "list": {
-          "parameters": {
-            "pageToken": {
-              "description": "Optional. A page token, received from a previous `ListCorpora` call. Provide the `next_page_token` returned in the response as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListCorpora` must match the call that provided the page token.",
-              "location": "query",
-              "type": "string"
-            },
-            "pageSize": {
-              "description": "Optional. The maximum number of `Corpora` to return (per page). The service may return fewer `Corpora`. If unspecified, at most 10 `Corpora` will be returned. The maximum size limit is 20 `Corpora` per page.",
-              "format": "int32",
-              "location": "query",
-              "type": "integer"
-            }
-          },
-          "httpMethod": "GET",
-          "flatPath": "v1beta/corpora",
-          "id": "generativelanguage.corpora.list",
-          "parameterOrder": [],
-          "description": "Lists all `Corpora` owned by the user.",
-          "response": {
-            "$ref": "ListCorporaResponse"
-          },
-          "path": "v1beta/corpora"
-        },
-        "delete": {
-          "response": {
-            "$ref": "Empty"
-          },
-          "flatPath": "v1beta/corpora/{corporaId}",
-          "id": "generativelanguage.corpora.delete",
-          "path": "v1beta/{+name}",
-          "parameters": {
-            "force": {
-              "type": "boolean",
-              "description": "Optional. If set to true, any `Document`s and objects related to this `Corpus` will also be deleted. If false (the default), a `FAILED_PRECONDITION` error will be returned if `Corpus` contains any `Document`s.",
-              "location": "query"
-            },
-            "name": {
-              "pattern": "^corpora/[^/]+$",
-              "description": "Required. The resource name of the `Corpus`. Example: `corpora/my-corpus-123`",
-              "location": "path",
-              "required": true,
-              "type": "string"
-            }
-          },
-          "httpMethod": "DELETE",
-          "parameterOrder": [
-            "name"
-          ],
-          "description": "Deletes a `Corpus`."
-        }
-      }
-    },
-    "models": {
-      "methods": {
-        "generateAnswer": {
-          "request": {
-            "$ref": "GenerateAnswerRequest"
-          },
-          "flatPath": "v1beta/models/{modelsId}:generateAnswer",
-          "id": "generativelanguage.models.generateAnswer",
-          "response": {
-            "$ref": "GenerateAnswerResponse"
-          },
-          "path": "v1beta/{+model}:generateAnswer",
-          "description": "Generates a grounded answer from the model given an input `GenerateAnswerRequest`.",
-          "parameterOrder": [
-            "model"
-          ],
-          "httpMethod": "POST",
-          "parameters": {
-            "model": {
-              "description": "Required. The name of the `Model` to use for generating the grounded response. Format: `model=models/{model}`.",
-              "required": true,
-              "pattern": "^models/[^/]+$",
-              "type": "string",
-              "location": "path"
-            }
-          }
-        },
-        "generateMessage": {
-          "httpMethod": "POST",
-          "parameterOrder": [
-            "model"
-          ],
-          "path": "v1beta/{+model}:generateMessage",
-          "description": "Generates a response from the model given an input `MessagePrompt`.",
-          "id": "generativelanguage.models.generateMessage",
-          "flatPath": "v1beta/models/{modelsId}:generateMessage",
-          "request": {
-            "$ref": "GenerateMessageRequest"
-          },
-          "parameters": {
-            "model": {
-              "pattern": "^models/[^/]+$",
-              "type": "string",
-              "required": true,
-              "description": "Required. The name of the model to use. Format: `name=models/{model}`.",
-              "location": "path"
-            }
-          },
-          "response": {
-            "$ref": "GenerateMessageResponse"
-          }
-        },
-        "streamGenerateContent": {
-          "flatPath": "v1beta/models/{modelsId}:streamGenerateContent",
-          "parameters": {
-            "model": {
-              "location": "path",
-              "type": "string",
-              "pattern": "^models/[^/]+$",
-              "required": true,
-              "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`."
-            }
-          },
-          "parameterOrder": [
-            "model"
-          ],
-          "request": {
-            "$ref": "GenerateContentRequest"
-          },
-          "response": {
-            "$ref": "GenerateContentResponse"
-          },
-          "httpMethod": "POST",
-          "id": "generativelanguage.models.streamGenerateContent",
-          "path": "v1beta/{+model}:streamGenerateContent",
-          "description": "Generates a streamed response from the model given an input `GenerateContentRequest`."
-        },
-        "list": {
-          "id": "generativelanguage.models.list",
-          "flatPath": "v1beta/models",
-          "response": {
-            "$ref": "ListModelsResponse"
-          },
-          "parameters": {
-            "pageToken": {
-              "description": "A page token, received from a previous `ListModels` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListModels` must match the call that provided the page token.",
-              "type": "string",
-              "location": "query"
-            },
-            "pageSize": {
-              "location": "query",
-              "format": "int32",
-              "type": "integer",
-              "description": "The maximum number of `Models` to return (per page). The service may return fewer models. If unspecified, at most 50 models will be returned per page. This method returns at most 1000 models per page, even if you pass a larger page_size."
-            }
-          },
-          "path": "v1beta/models",
-          "httpMethod": "GET",
-          "parameterOrder": [],
-          "description": "Lists models available through the API."
-        },
-        "generateContent": {
-          "parameterOrder": [
-            "model"
-          ],
-          "path": "v1beta/{+model}:generateContent",
-          "request": {
-            "$ref": "GenerateContentRequest"
-          },
-          "httpMethod": "POST",
-          "parameters": {
-            "model": {
-              "required": true,
-              "pattern": "^models/[^/]+$",
-              "location": "path",
-              "type": "string",
-              "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`."
-            }
-          },
-          "flatPath": "v1beta/models/{modelsId}:generateContent",
-          "description": "Generates a response from the model given an input `GenerateContentRequest`. Input capabilities differ between models, including tuned models. See the [model guide](https://ai.google.dev/models/gemini) and [tuning guide](https://ai.google.dev/docs/model_tuning_guidance) for details.",
-          "response": {
-            "$ref": "GenerateContentResponse"
-          },
-          "id": "generativelanguage.models.generateContent"
-        },
-        "batchEmbedText": {
-          "response": {
-            "$ref": "BatchEmbedTextResponse"
-          },
-          "request": {
-            "$ref": "BatchEmbedTextRequest"
-          },
-          "parameterOrder": [
-            "model"
-          ],
-          "path": "v1beta/{+model}:batchEmbedText",
-          "httpMethod": "POST",
-          "description": "Generates multiple embeddings from the model given input text in a synchronous call.",
-          "flatPath": "v1beta/models/{modelsId}:batchEmbedText",
-          "parameters": {
-            "model": {
-              "required": true,
-              "pattern": "^models/[^/]+$",
-              "type": "string",
-              "location": "path",
-              "description": "Required. The name of the `Model` to use for generating the embedding. Examples: models/embedding-gecko-001"
-            }
-          },
-          "id": "generativelanguage.models.batchEmbedText"
-        },
-        "countTokens": {
-          "parameters": {
-            "model": {
-              "type": "string",
-              "required": true,
-              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
-              "pattern": "^models/[^/]+$",
-              "location": "path"
-            }
-          },
-          "description": "Runs a model's tokenizer on input content and returns the token count.",
-          "id": "generativelanguage.models.countTokens",
-          "path": "v1beta/{+model}:countTokens",
-          "parameterOrder": [
-            "model"
-          ],
-          "response": {
-            "$ref": "CountTokensResponse"
-          },
-          "request": {
-            "$ref": "CountTokensRequest"
-          },
-          "httpMethod": "POST",
-          "flatPath": "v1beta/models/{modelsId}:countTokens"
-        },
-        "embedContent": {
-          "httpMethod": "POST",
-          "flatPath": "v1beta/models/{modelsId}:embedContent",
-          "response": {
-            "$ref": "EmbedContentResponse"
-          },
-          "request": {
-            "$ref": "EmbedContentRequest"
-          },
-          "parameterOrder": [
-            "model"
-          ],
-          "parameters": {
-            "model": {
-              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
-              "pattern": "^models/[^/]+$",
-              "type": "string",
-              "location": "path",
-              "required": true
-            }
-          },
-          "description": "Generates an embedding from the model given an input `Content`.",
-          "path": "v1beta/{+model}:embedContent",
-          "id": "generativelanguage.models.embedContent"
-        },
-        "batchEmbedContents": {
-          "parameters": {
-            "model": {
-              "pattern": "^models/[^/]+$",
-              "location": "path",
-              "type": "string",
-              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
-              "required": true
-            }
-          },
-          "flatPath": "v1beta/models/{modelsId}:batchEmbedContents",
-          "httpMethod": "POST",
-          "description": "Generates multiple embeddings from the model given input text in a synchronous call.",
-          "id": "generativelanguage.models.batchEmbedContents",
-          "path": "v1beta/{+model}:batchEmbedContents",
-          "response": {
-            "$ref": "BatchEmbedContentsResponse"
-          },
-          "request": {
-            "$ref": "BatchEmbedContentsRequest"
-          },
-          "parameterOrder": [
-            "model"
-          ]
-        },
-        "get": {
-          "parameters": {
-            "name": {
-              "required": true,
-              "pattern": "^models/[^/]+$",
-              "location": "path",
-              "type": "string",
-              "description": "Required. The resource name of the model. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`"
-            }
-          },
-          "httpMethod": "GET",
-          "description": "Gets information about a specific Model.",
-          "parameterOrder": [
-            "name"
-          ],
-          "path": "v1beta/{+name}",
-          "response": {
-            "$ref": "Model"
-          },
-          "id": "generativelanguage.models.get",
-          "flatPath": "v1beta/models/{modelsId}"
-        },
-        "countTextTokens": {
-          "flatPath": "v1beta/models/{modelsId}:countTextTokens",
-          "path": "v1beta/{+model}:countTextTokens",
-          "request": {
-            "$ref": "CountTextTokensRequest"
-          },
-          "httpMethod": "POST",
-          "parameters": {
-            "model": {
-              "pattern": "^models/[^/]+$",
-              "required": true,
-              "type": "string",
-              "location": "path",
-              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`"
-            }
-          },
-          "description": "Runs a model's tokenizer on a text and returns the token count.",
-          "id": "generativelanguage.models.countTextTokens",
-          "response": {
-            "$ref": "CountTextTokensResponse"
-          },
-          "parameterOrder": [
-            "model"
-          ]
-        },
-        "countMessageTokens": {
-          "description": "Runs a model's tokenizer on a string and returns the token count.",
-          "path": "v1beta/{+model}:countMessageTokens",
-          "parameterOrder": [
-            "model"
-          ],
-          "httpMethod": "POST",
-          "request": {
-            "$ref": "CountMessageTokensRequest"
-          },
-          "id": "generativelanguage.models.countMessageTokens",
-          "flatPath": "v1beta/models/{modelsId}:countMessageTokens",
-          "response": {
-            "$ref": "CountMessageTokensResponse"
-          },
-          "parameters": {
-            "model": {
-              "required": true,
-              "pattern": "^models/[^/]+$",
-              "location": "path",
-              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
-              "type": "string"
-            }
-          }
-        },
-        "embedText": {
-          "parameterOrder": [
-            "model"
-          ],
-          "description": "Generates an embedding from the model given an input message.",
-          "httpMethod": "POST",
-          "response": {
-            "$ref": "EmbedTextResponse"
-          },
-          "flatPath": "v1beta/models/{modelsId}:embedText",
-          "path": "v1beta/{+model}:embedText",
-          "parameters": {
-            "model": {
-              "description": "Required. The model name to use with the format model=models/{model}.",
-              "required": true,
-              "type": "string",
-              "pattern": "^models/[^/]+$",
-              "location": "path"
-            }
-          },
-          "id": "generativelanguage.models.embedText",
-          "request": {
-            "$ref": "EmbedTextRequest"
-          }
-        },
-        "generateText": {
-          "parameters": {
-            "model": {
-              "required": true,
-              "description": "Required. The name of the `Model` or `TunedModel` to use for generating the completion. Examples: models/text-bison-001 tunedModels/sentence-translator-u3b7m",
-              "type": "string",
-              "pattern": "^models/[^/]+$",
-              "location": "path"
-            }
-          },
-          "request": {
-            "$ref": "GenerateTextRequest"
-          },
-          "response": {
-            "$ref": "GenerateTextResponse"
-          },
-          "path": "v1beta/{+model}:generateText",
-          "httpMethod": "POST",
-          "description": "Generates a response from the model given an input message.",
-          "parameterOrder": [
-            "model"
-          ],
-          "id": "generativelanguage.models.generateText",
-          "flatPath": "v1beta/models/{modelsId}:generateText"
-        }
-      }
-    }
-  },
+  "version": "v1beta",
   "version_module": true,
-  "mtlsRootUrl": "https://generativelanguage.mtls.googleapis.com/",
-  "fullyEncodeReservedExpansion": true,
-  "basePath": "",
-  "baseUrl": "https://generativelanguage.googleapis.com/",
-  "parameters": {
-    "$.xgafv": {
-      "location": "query",
-      "enum": [
-        "1",
-        "2"
-      ],
-      "description": "V1 error format.",
-      "type": "string",
-      "enumDescriptions": [
-        "v1 error format",
-        "v2 error format"
-      ]
-    },
-    "upload_protocol": {
-      "type": "string",
-      "location": "query",
-      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\")."
-    },
-    "alt": {
-      "location": "query",
-      "type": "string",
-      "enum": [
-        "json",
-        "media",
-        "proto"
-      ],
-      "enumDescriptions": [
-        "Responses with Content-Type of application/json",
-        "Media download with context-dependent Content-Type",
-        "Responses with Content-Type of application/x-protobuf"
-      ],
-      "description": "Data format for response.",
-      "default": "json"
-    },
-    "key": {
-      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
-      "location": "query",
-      "type": "string"
-    },
-    "access_token": {
-      "location": "query",
-      "type": "string",
-      "description": "OAuth access token."
-    },
-    "uploadType": {
-      "type": "string",
-      "location": "query",
-      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\")."
-    },
-    "callback": {
-      "location": "query",
-      "type": "string",
-      "description": "JSONP"
-    },
-    "oauth_token": {
-      "type": "string",
-      "description": "OAuth 2.0 token for the current user.",
-      "location": "query"
-    },
-    "prettyPrint": {
-      "description": "Returns response with indentations and line breaks.",
-      "location": "query",
-      "type": "boolean",
-      "default": "true"
-    },
-    "quotaUser": {
-      "location": "query",
-      "type": "string",
-      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters."
-    },
-    "fields": {
-      "type": "string",
-      "location": "query",
-      "description": "Selector specifying which fields to include in a partial response."
-    }
+  "ownerName": "Google",
+  "discoveryVersion": "v1",
+  "protocol": "rest",
+  "icons": {
+    "x16": "http://www.google.com/images/icons/product/search-16.gif",
+    "x32": "http://www.google.com/images/icons/product/search-32.gif"
   },
+  "kind": "discovery#restDescription",
+  "name": "generativelanguage",
+  "title": "Generative Language API",
   "schemas": {
-    "Candidate": {
-      "id": "Candidate",
-      "description": "A response candidate generated from the model.",
-      "type": "object",
-      "properties": {
-        "index": {
-          "description": "Output only. Index of the candidate in the list of candidates.",
-          "readOnly": true,
-          "type": "integer",
-          "format": "int32"
-        },
-        "citationMetadata": {
-          "description": "Output only. Citation information for model-generated candidate. This field may be populated with recitation information for any text included in the `content`. These are passages that are \"recited\" from copyrighted material in the foundational LLM's training data.",
-          "readOnly": true,
-          "$ref": "CitationMetadata"
-        },
-        "tokenCount": {
-          "description": "Output only. Token count for this candidate.",
-          "readOnly": true,
-          "type": "integer",
-          "format": "int32"
-        },
-        "finishReason": {
-          "readOnly": true,
-          "type": "string",
-          "enum": [
-            "FINISH_REASON_UNSPECIFIED",
-            "STOP",
-            "MAX_TOKENS",
-            "SAFETY",
-            "RECITATION",
-            "OTHER"
-          ],
-          "enumDescriptions": [
-            "Default value. This value is unused.",
-            "Natural stop point of the model or provided stop sequence.",
-            "The maximum number of tokens as specified in the request was reached.",
-            "The candidate content was flagged for safety reasons.",
-            "The candidate content was flagged for recitation reasons.",
-            "Unknown reason."
-          ],
-          "description": "Optional. Output only. The reason why the model stopped generating tokens. If empty, the model has not stopped generating the tokens."
-        },
-        "groundingAttributions": {
-          "readOnly": true,
-          "items": {
-            "$ref": "GroundingAttribution"
-          },
-          "type": "array",
-          "description": "Output only. Attribution information for sources that contributed to a grounded answer. This field is populated for `GenerateAnswer` calls."
-        },
-        "content": {
-          "$ref": "Content",
-          "description": "Output only. Generated content returned from the model.",
-          "readOnly": true
-        },
-        "safetyRatings": {
-          "items": {
-            "$ref": "SafetyRating"
-          },
-          "description": "List of ratings for the safety of a response candidate. There is at most one rating per category.",
-          "type": "array"
-        }
-      }
-    },
-    "Tool": {
-      "id": "Tool",
-      "description": "Tool details that the model may use to generate response. A `Tool` is a piece of code that enables the system to interact with external systems to perform an action, or set of actions, outside of knowledge and scope of the model.",
-      "type": "object",
-      "properties": {
-        "functionDeclarations": {
-          "type": "array",
-          "description": "Optional. A list of `FunctionDeclarations` available to the model that can be used for function calling. The model or system does not execute the function. Instead the defined function may be returned as a FunctionCall with arguments to the client side for execution. The model may decide to call a subset of these functions by populating FunctionCall in the response. The next conversation turn may contain a FunctionResponse with the [content.role] \"function\" generation context for the next model turn.",
-          "items": {
-            "$ref": "FunctionDeclaration"
-          }
-        }
-      }
-    },
-    "QueryDocumentResponse": {
-      "description": "Response from `QueryDocument` containing a list of relevant chunks.",
-      "type": "object",
-      "id": "QueryDocumentResponse",
-      "properties": {
-        "relevantChunks": {
-          "type": "array",
-          "description": "The returned relevant chunks.",
-          "items": {
-            "$ref": "RelevantChunk"
-          }
-        }
-      }
-    },
-    "GroundingPassage": {
-      "description": "Passage included inline with a grounding configuration.",
-      "type": "object",
-      "id": "GroundingPassage",
-      "properties": {
-        "content": {
-          "$ref": "Content",
-          "description": "Content of the passage."
-        },
-        "id": {
-          "type": "string",
-          "description": "Identifier for the passage for attributing this passage in grounded answers."
-        }
-      }
-    },
-    "BatchCreateChunksResponse": {
-      "id": "BatchCreateChunksResponse",
-      "properties": {
-        "chunks": {
-          "type": "array",
-          "items": {
-            "$ref": "Chunk"
-          },
-          "description": "`Chunk`s created."
-        }
-      },
-      "type": "object",
-      "description": "Response from `BatchCreateChunks` containing a list of created `Chunk`s."
-    },
-    "Model": {
-      "type": "object",
-      "id": "Model",
-      "description": "Information about a Generative Language Model.",
-      "properties": {
-        "supportedGenerationMethods": {
-          "description": "The model's supported generation methods. The method names are defined as Pascal case strings, such as `generateMessage` which correspond to API methods.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "description": {
-          "description": "A short description of the model.",
-          "type": "string"
-        },
-        "temperature": {
-          "type": "number",
-          "description": "Controls the randomness of the output. Values can range over `[0.0,1.0]`, inclusive. A value closer to `1.0` will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model. This value specifies default to be used by the backend while making the call to the model.",
-          "format": "float"
-        },
-        "inputTokenLimit": {
-          "type": "integer",
-          "description": "Maximum number of input tokens allowed for this model.",
-          "format": "int32"
-        },
-        "topP": {
-          "format": "float",
-          "type": "number",
-          "description": "For Nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`. This value specifies default to be used by the backend while making the call to the model."
-        },
-        "outputTokenLimit": {
-          "type": "integer",
-          "description": "Maximum number of output tokens available for this model.",
-          "format": "int32"
-        },
-        "baseModelId": {
-          "type": "string",
-          "description": "Required. The name of the base model, pass this to the generation request. Examples: * `chat-bison`"
-        },
-        "displayName": {
-          "type": "string",
-          "description": "The human-readable name of the model. E.g. \"Chat Bison\". The name can be up to 128 characters long and can consist of any UTF-8 characters."
-        },
-        "topK": {
-          "format": "int32",
-          "type": "integer",
-          "description": "For Top-k sampling. Top-k sampling considers the set of `top_k` most probable tokens. This value specifies default to be used by the backend while making the call to the model. If empty, indicates the model doesn't use top-k sampling, and `top_k` isn't allowed as a generation parameter."
-        },
-        "version": {
-          "type": "string",
-          "description": "Required. The version number of the model. This represents the major version"
-        },
-        "name": {
-          "description": "Required. The resource name of the `Model`. Format: `models/{model}` with a `{model}` naming convention of: * \"{base_model_id}-{version}\" Examples: * `models/chat-bison-001`",
-          "type": "string"
-        }
-      }
-    },
-    "ListChunksResponse": {
-      "id": "ListChunksResponse",
-      "type": "object",
-      "description": "Response from `ListChunks` containing a paginated list of `Chunk`s. The `Chunk`s are sorted by ascending `chunk.create_time`.",
+    "ListTunedModelsResponse": {
+      "id": "ListTunedModelsResponse",
       "properties": {
         "nextPageToken": {
           "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages.",
           "type": "string"
         },
-        "chunks": {
+        "tunedModels": {
           "type": "array",
-          "description": "The returned `Chunk`s.",
+          "description": "The returned Models.",
           "items": {
-            "$ref": "Chunk"
+            "$ref": "TunedModel"
           }
         }
-      }
-    },
-    "BatchUpdateChunksRequest": {
-      "id": "BatchUpdateChunksRequest",
-      "type": "object",
-      "properties": {
-        "requests": {
-          "items": {
-            "$ref": "UpdateChunkRequest"
-          },
-          "type": "array",
-          "description": "Required. The request messages specifying the `Chunk`s to update. A maximum of 100 `Chunk`s can be updated in a batch."
-        }
       },
-      "description": "Request to batch update `Chunk`s."
-    },
-    "RelevantChunk": {
       "type": "object",
-      "id": "RelevantChunk",
-      "properties": {
-        "chunk": {
-          "description": "`Chunk` associated with the query.",
-          "$ref": "Chunk"
-        },
-        "chunkRelevanceScore": {
-          "description": "`Chunk` relevance to the query.",
-          "format": "float",
-          "type": "number"
-        }
-      },
-      "description": "The information for a chunk relevant to a query."
+      "description": "Response from `ListTunedModels` containing a paginated list of Models."
     },
     "GenerateMessageResponse": {
       "type": "object",
+      "description": "The response from the model. This includes candidate messages and conversation history in the form of chronologically-ordered messages.",
+      "id": "GenerateMessageResponse",
       "properties": {
-        "candidates": {
+        "filters": {
+          "description": "A set of content filtering metadata for the prompt and response text. This indicates which `SafetyCategory`(s) blocked a candidate from this response, the lowest `HarmProbability` that triggered a block, and the HarmThreshold setting for that category.",
           "type": "array",
-          "description": "Candidate response messages from the model.",
           "items": {
-            "$ref": "Message"
+            "$ref": "ContentFilter"
           }
         },
         "messages": {
@@ -1800,47 +50,100 @@
           },
           "type": "array"
         },
-        "filters": {
-          "items": {
-            "$ref": "ContentFilter"
-          },
+        "candidates": {
+          "description": "Candidate response messages from the model.",
           "type": "array",
-          "description": "A set of content filtering metadata for the prompt and response text. This indicates which `SafetyCategory`(s) blocked a candidate from this response, the lowest `HarmProbability` that triggered a block, and the HarmThreshold setting for that category."
+          "items": {
+            "$ref": "Message"
+          }
+        }
+      }
+    },
+    "QueryCorpusResponse": {
+      "properties": {
+        "relevantChunks": {
+          "type": "array",
+          "description": "The relevant chunks.",
+          "items": {
+            "$ref": "RelevantChunk"
+          }
         }
       },
-      "description": "The response from the model. This includes candidate messages and conversation history in the form of chronologically-ordered messages.",
-      "id": "GenerateMessageResponse"
+      "description": "Response from `QueryCorpus` containing a list of relevant chunks.",
+      "id": "QueryCorpusResponse",
+      "type": "object"
     },
-    "Part": {
-      "type": "object",
-      "description": "A datatype containing media that is part of a multi-part `Content` message. A `Part` consists of data which has an associated datatype. A `Part` can only contain one of the accepted types in `Part.data`. A `Part` must have a fixed IANA MIME type identifying the type and subtype of the media if the `inline_data` field is filled with raw bytes.",
-      "id": "Part",
+    "CreateChunkRequest": {
+      "id": "CreateChunkRequest",
+      "description": "Request to create a `Chunk`.",
       "properties": {
-        "functionCall": {
-          "$ref": "FunctionCall",
-          "description": "A predicted `FunctionCall` returned from the model that contains a string representing the `FunctionDeclaration.name` with the arguments and their values."
+        "parent": {
+          "description": "Required. The name of the `Document` where this `Chunk` will be created. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
+          "type": "string"
         },
-        "fileData": {
-          "$ref": "FileData",
-          "description": "URI based data."
+        "chunk": {
+          "description": "Required. The `Chunk` to create.",
+          "$ref": "Chunk"
+        }
+      },
+      "type": "object"
+    },
+    "CountTokensRequest": {
+      "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`.",
+      "type": "object",
+      "id": "CountTokensRequest",
+      "properties": {
+        "generateContentRequest": {
+          "$ref": "GenerateContentRequest",
+          "description": "Optional. The overall input given to the model. CountTokens will count prompt, function calling, etc."
         },
-        "text": {
+        "contents": {
+          "description": "Optional. The input given to the model as a prompt. This field is ignored when `generate_content_request` is set.",
+          "items": {
+            "$ref": "Content"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "EmbedContentResponse": {
+      "id": "EmbedContentResponse",
+      "type": "object",
+      "description": "The response to an `EmbedContentRequest`.",
+      "properties": {
+        "embedding": {
+          "$ref": "ContentEmbedding",
+          "description": "Output only. The embedding generated from the input content.",
+          "readOnly": true
+        }
+      }
+    },
+    "ContentFilter": {
+      "id": "ContentFilter",
+      "type": "object",
+      "description": "Content filtering metadata associated with processing a single request. ContentFilter contains a reason and an optional supporting string. The reason may be unspecified.",
+      "properties": {
+        "message": {
           "type": "string",
-          "description": "Inline text."
+          "description": "A string that describes the filtering behavior in more detail."
         },
-        "inlineData": {
-          "$ref": "Blob",
-          "description": "Inline media bytes."
-        },
-        "functionResponse": {
-          "description": "The result output of a `FunctionCall` that contains a string representing the `FunctionDeclaration.name` and a structured JSON object containing any output from the function is used as context to the model.",
-          "$ref": "FunctionResponse"
+        "reason": {
+          "description": "The reason content was blocked during request processing.",
+          "type": "string",
+          "enum": [
+            "BLOCKED_REASON_UNSPECIFIED",
+            "SAFETY",
+            "OTHER"
+          ],
+          "enumDescriptions": [
+            "A blocked reason was not specified.",
+            "Content was blocked by safety settings.",
+            "Content was blocked, but the reason is uncategorized."
+          ]
         }
       }
     },
     "GroundingPassages": {
-      "id": "GroundingPassages",
-      "type": "object",
       "description": "A repeated list of passages.",
       "properties": {
         "passages": {
@@ -1850,202 +153,762 @@
           },
           "type": "array"
         }
-      }
-    },
-    "BatchEmbedTextRequest": {
-      "type": "object",
-      "id": "BatchEmbedTextRequest",
-      "description": "Batch request to get a text embedding from the model.",
-      "properties": {
-        "requests": {
-          "items": {
-            "$ref": "EmbedTextRequest"
-          },
-          "description": "Optional. Embed requests for the batch. Only one of `texts` or `requests` can be set.",
-          "type": "array"
-        },
-        "texts": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Optional. The free-form input texts that the model will turn into an embedding. The current limit is 100 texts, over which an error will be thrown."
-        }
-      }
-    },
-    "CountTextTokensRequest": {
-      "type": "object",
-      "properties": {
-        "prompt": {
-          "description": "Required. The free-form input text given to the model as a prompt.",
-          "$ref": "TextPrompt"
-        }
-      },
-      "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`.",
-      "id": "CountTextTokensRequest"
-    },
-    "GroundingAttribution": {
-      "description": "Attribution for a source that contributed to an answer.",
-      "properties": {
-        "content": {
-          "$ref": "Content",
-          "description": "Grounding source content that makes up this attribution."
-        },
-        "sourceId": {
-          "description": "Output only. Identifier for the source contributing to this attribution.",
-          "$ref": "AttributionSourceId",
-          "readOnly": true
-        }
       },
       "type": "object",
-      "id": "GroundingAttribution"
+      "id": "GroundingPassages"
     },
-    "TuningExample": {
-      "type": "object",
-      "properties": {
-        "output": {
-          "type": "string",
-          "description": "Required. The expected model output."
-        },
-        "textInput": {
-          "type": "string",
-          "description": "Optional. Text model input."
-        }
-      },
-      "id": "TuningExample",
-      "description": "A single example for tuning."
-    },
-    "Permission": {
-      "type": "object",
-      "id": "Permission",
-      "description": "Permission resource grants user, group or the rest of the world access to the PaLM API resource (e.g. a tuned model, corpus). A role is a collection of permitted operations that allows users to perform specific actions on PaLM API resources. To make them available to users, groups, or service accounts, you assign roles. When you assign a role, you grant permissions that the role contains. There are three concentric roles. Each role is a superset of the previous role's permitted operations: - reader can use the resource (e.g. tuned model, corpus) for inference - writer has reader's permissions and additionally can edit and share - owner has writer's permissions and additionally can delete",
+    "TransferOwnershipRequest": {
       "properties": {
         "emailAddress": {
-          "description": "Optional. Immutable. The email address of the user of group which this permission refers. Field is not set when permission's grantee type is EVERYONE.",
-          "type": "string"
-        },
-        "name": {
-          "readOnly": true,
-          "description": "Output only. Identifier. The permission name. A unique name will be generated on create. Examples: tunedModels/{tuned_model}/permissions/{permission} corpora/{corpus}/permissions/{permission} Output only.",
-          "type": "string"
-        },
+          "type": "string",
+          "description": "Required. The email address of the user to whom the tuned model is being transferred to."
+        }
+      },
+      "type": "object",
+      "id": "TransferOwnershipRequest",
+      "description": "Request to transfer the ownership of the tuned model."
+    },
+    "CitationMetadata": {
+      "type": "object",
+      "id": "CitationMetadata",
+      "properties": {
+        "citationSources": {
+          "items": {
+            "$ref": "CitationSource"
+          },
+          "type": "array",
+          "description": "Citations to sources for a specific response."
+        }
+      },
+      "description": "A collection of source attributions for a piece of content."
+    },
+    "Permission": {
+      "description": "Permission resource grants user, group or the rest of the world access to the PaLM API resource (e.g. a tuned model, corpus). A role is a collection of permitted operations that allows users to perform specific actions on PaLM API resources. To make them available to users, groups, or service accounts, you assign roles. When you assign a role, you grant permissions that the role contains. There are three concentric roles. Each role is a superset of the previous role's permitted operations: - reader can use the resource (e.g. tuned model, corpus) for inference - writer has reader's permissions and additionally can edit and share - owner has writer's permissions and additionally can delete",
+      "type": "object",
+      "id": "Permission",
+      "properties": {
         "granteeType": {
+          "enumDescriptions": [
+            "The default value. This value is unused.",
+            "Represents a user. When set, you must provide email_address for the user.",
+            "Represents a group. When set, you must provide email_address for the group.",
+            "Represents access to everyone. No extra information is required."
+          ],
           "enum": [
             "GRANTEE_TYPE_UNSPECIFIED",
             "USER",
             "GROUP",
             "EVERYONE"
           ],
-          "description": "Optional. Immutable. The type of the grantee.",
           "type": "string",
-          "enumDescriptions": [
-            "The default value. This value is unused.",
-            "Represents a user. When set, you must provide email_address for the user.",
-            "Represents a group. When set, you must provide email_address for the group.",
-            "Represents access to everyone. No extra information is required."
-          ]
+          "description": "Optional. Immutable. The type of the grantee."
+        },
+        "name": {
+          "type": "string",
+          "description": "Output only. Identifier. The permission name. A unique name will be generated on create. Examples: tunedModels/{tuned_model}/permissions/{permission} corpora/{corpus}/permissions/{permission} Output only.",
+          "readOnly": true
         },
         "role": {
-          "type": "string",
-          "description": "Required. The role granted by this permission.",
+          "enum": [
+            "ROLE_UNSPECIFIED",
+            "OWNER",
+            "WRITER",
+            "READER"
+          ],
           "enumDescriptions": [
             "The default value. This value is unused.",
             "Owner can use, update, share and delete the resource.",
             "Writer can use, update and share the resource.",
             "Reader can use the resource."
           ],
-          "enum": [
-            "ROLE_UNSPECIFIED",
-            "OWNER",
-            "WRITER",
-            "READER"
-          ]
+          "description": "Required. The role granted by this permission.",
+          "type": "string"
+        },
+        "emailAddress": {
+          "description": "Optional. Immutable. The email address of the user of group which this permission refers. Field is not set when permission's grantee type is EVERYONE.",
+          "type": "string"
+        }
+      }
+    },
+    "EmbedTextRequest": {
+      "id": "EmbedTextRequest",
+      "description": "Request to get a text embedding from the model.",
+      "type": "object",
+      "properties": {
+        "text": {
+          "description": "Optional. The free-form input text that the model will turn into an embedding.",
+          "type": "string"
+        },
+        "model": {
+          "description": "Required. The model name to use with the format model=models/{model}.",
+          "type": "string"
         }
       }
     },
     "Content": {
+      "description": "The base structured datatype containing multi-part content of a message. A `Content` includes a `role` field designating the producer of the `Content` and a `parts` field containing multi-part data that contains the content of the message turn.",
       "properties": {
         "parts": {
+          "description": "Ordered `Parts` that constitute a single message. Parts may have different MIME types.",
+          "type": "array",
           "items": {
             "$ref": "Part"
-          },
-          "type": "array",
-          "description": "Ordered `Parts` that constitute a single message. Parts may have different MIME types."
+          }
         },
         "role": {
           "type": "string",
           "description": "Optional. The producer of the content. Must be either 'user' or 'model'. Useful to set for multi-turn conversations, otherwise can be left blank or unset."
         }
       },
-      "description": "The base structured datatype containing multi-part content of a message. A `Content` includes a `role` field designating the producer of the `Content` and a `parts` field containing multi-part data that contains the content of the message turn.",
-      "type": "object",
-      "id": "Content"
+      "id": "Content",
+      "type": "object"
     },
-    "UsageMetadata": {
-      "description": "Metadata on the generation request's token usage.",
+    "VideoMetadata": {
+      "id": "VideoMetadata",
+      "type": "object",
       "properties": {
-        "totalTokenCount": {
+        "videoDuration": {
+          "description": "Duration of the video.",
+          "format": "google-duration",
+          "type": "string"
+        }
+      },
+      "description": "Metadata for a video `File`."
+    },
+    "FunctionDeclaration": {
+      "id": "FunctionDeclaration",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Required. The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
+        },
+        "parameters": {
+          "$ref": "Schema",
+          "description": "Optional. Describes the parameters to this function. Reflects the Open API 3.03 Parameter Object string Key: the name of the parameter. Parameter names are case sensitive. Schema Value: the Schema defining the type used for the parameter."
+        },
+        "description": {
+          "description": "Required. A brief description of the function.",
+          "type": "string"
+        }
+      },
+      "description": "Structured representation of a function declaration as defined by the [OpenAPI 3.03 specification](https://spec.openapis.org/oas/v3.0.3). Included in this declaration are the function name and parameters. This FunctionDeclaration is a representation of a block of code that can be used as a `Tool` by the model and executed by the client.",
+      "type": "object"
+    },
+    "QueryCorpusRequest": {
+      "id": "QueryCorpusRequest",
+      "properties": {
+        "query": {
+          "description": "Required. Query string to perform semantic search.",
+          "type": "string"
+        },
+        "metadataFilters": {
+          "description": "Optional. Filter for `Chunk` and `Document` metadata. Each `MetadataFilter` object should correspond to a unique key. Multiple `MetadataFilter` objects are joined by logical \"AND\"s. Example query at document level: (year \u003e= 2020 OR year \u003c 2010) AND (genre = drama OR genre = action) `MetadataFilter` object list: metadata_filters = [ {key = \"document.custom_metadata.year\" conditions = [{int_value = 2020, operation = GREATER_EQUAL}, {int_value = 2010, operation = LESS}]}, {key = \"document.custom_metadata.year\" conditions = [{int_value = 2020, operation = GREATER_EQUAL}, {int_value = 2010, operation = LESS}]}, {key = \"document.custom_metadata.genre\" conditions = [{string_value = \"drama\", operation = EQUAL}, {string_value = \"action\", operation = EQUAL}]}] Example query at chunk level for a numeric range of values: (year \u003e 2015 AND year \u003c= 2020) `MetadataFilter` object list: metadata_filters = [ {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2015, operation = GREATER}]}, {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2020, operation = LESS_EQUAL}]}] Note: \"AND\"s for the same key are only supported for numeric values. String values only support \"OR\"s for the same key.",
+          "type": "array",
+          "items": {
+            "$ref": "MetadataFilter"
+          }
+        },
+        "resultsCount": {
+          "format": "int32",
+          "description": "Optional. The maximum number of `Chunk`s to return. The service may return fewer `Chunk`s. If unspecified, at most 10 `Chunk`s will be returned. The maximum specified result count is 100.",
+          "type": "integer"
+        }
+      },
+      "description": "Request for querying a `Corpus`.",
+      "type": "object"
+    },
+    "GenerateContentResponse": {
+      "description": "Response from the model supporting multiple candidates. Note on safety ratings and content filtering. They are reported for both prompt in `GenerateContentResponse.prompt_feedback` and for each candidate in `finish_reason` and in `safety_ratings`. The API contract is that: - either all requested candidates are returned or no candidates at all - no candidates are returned only if there was something wrong with the prompt (see `prompt_feedback`) - feedback on each candidate is reported on `finish_reason` and `safety_ratings`.",
+      "properties": {
+        "candidates": {
+          "items": {
+            "$ref": "Candidate"
+          },
+          "type": "array",
+          "description": "Candidate responses from the model."
+        },
+        "usageMetadata": {
+          "description": "Output only. Metadata on the generation requests' token usage.",
+          "readOnly": true,
+          "$ref": "UsageMetadata"
+        },
+        "promptFeedback": {
+          "$ref": "PromptFeedback",
+          "description": "Returns the prompt's feedback related to the content filters."
+        }
+      },
+      "id": "GenerateContentResponse",
+      "type": "object"
+    },
+    "TuningExample": {
+      "properties": {
+        "output": {
+          "description": "Required. The expected model output.",
+          "type": "string"
+        },
+        "textInput": {
+          "description": "Optional. Text model input.",
+          "type": "string"
+        }
+      },
+      "id": "TuningExample",
+      "description": "A single example for tuning.",
+      "type": "object"
+    },
+    "Embedding": {
+      "properties": {
+        "value": {
+          "items": {
+            "format": "float",
+            "type": "number"
+          },
+          "description": "The embedding values.",
+          "type": "array"
+        }
+      },
+      "id": "Embedding",
+      "description": "A list of floats representing the embedding.",
+      "type": "object"
+    },
+    "BatchEmbedTextResponse": {
+      "description": "The response to a EmbedTextRequest.",
+      "type": "object",
+      "id": "BatchEmbedTextResponse",
+      "properties": {
+        "embeddings": {
+          "description": "Output only. The embeddings generated from the input text.",
+          "items": {
+            "$ref": "Embedding"
+          },
+          "readOnly": true,
+          "type": "array"
+        }
+      }
+    },
+    "BatchEmbedContentsRequest": {
+      "id": "BatchEmbedContentsRequest",
+      "properties": {
+        "requests": {
+          "description": "Required. Embed requests for the batch. The model in each of these requests must match the model specified `BatchEmbedContentsRequest.model`.",
+          "type": "array",
+          "items": {
+            "$ref": "EmbedContentRequest"
+          }
+        }
+      },
+      "type": "object",
+      "description": "Batch request to get embeddings from the model for a list of prompts."
+    },
+    "Part": {
+      "properties": {
+        "inlineData": {
+          "$ref": "Blob",
+          "description": "Inline media bytes."
+        },
+        "functionCall": {
+          "$ref": "FunctionCall",
+          "description": "A predicted `FunctionCall` returned from the model that contains a string representing the `FunctionDeclaration.name` with the arguments and their values."
+        },
+        "fileData": {
+          "description": "URI based data.",
+          "$ref": "FileData"
+        },
+        "functionResponse": {
+          "$ref": "FunctionResponse",
+          "description": "The result output of a `FunctionCall` that contains a string representing the `FunctionDeclaration.name` and a structured JSON object containing any output from the function is used as context to the model."
+        },
+        "text": {
+          "description": "Inline text.",
+          "type": "string"
+        }
+      },
+      "description": "A datatype containing media that is part of a multi-part `Content` message. A `Part` consists of data which has an associated datatype. A `Part` can only contain one of the accepted types in `Part.data`. A `Part` must have a fixed IANA MIME type identifying the type and subtype of the media if the `inline_data` field is filled with raw bytes.",
+      "id": "Part",
+      "type": "object"
+    },
+    "Blob": {
+      "type": "object",
+      "description": "Raw media bytes. Text should not be sent as raw bytes, use the 'text' field.",
+      "properties": {
+        "data": {
+          "format": "byte",
+          "description": "Raw bytes for media formats.",
+          "type": "string"
+        },
+        "mimeType": {
+          "description": "The IANA standard MIME type of the source data. Examples: - image/png - image/jpeg If an unsupported MIME type is provided, an error will be returned. For a complete list of supported types, see [Supported file formats](https://ai.google.dev/gemini-api/docs/prompting_with_media#supported_file_formats).",
+          "type": "string"
+        }
+      },
+      "id": "Blob"
+    },
+    "Candidate": {
+      "type": "object",
+      "properties": {
+        "tokenCount": {
+          "description": "Output only. Token count for this candidate.",
           "format": "int32",
           "type": "integer",
-          "description": "Total token count for the generation request (prompt + candidates)."
+          "readOnly": true
         },
-        "candidatesTokenCount": {
+        "groundingAttributions": {
+          "items": {
+            "$ref": "GroundingAttribution"
+          },
+          "type": "array",
+          "readOnly": true,
+          "description": "Output only. Attribution information for sources that contributed to a grounded answer. This field is populated for `GenerateAnswer` calls."
+        },
+        "content": {
+          "description": "Output only. Generated content returned from the model.",
+          "$ref": "Content",
+          "readOnly": true
+        },
+        "index": {
           "type": "integer",
           "format": "int32",
-          "description": "Total number of tokens across the generated candidates."
+          "readOnly": true,
+          "description": "Output only. Index of the candidate in the list of candidates."
         },
-        "promptTokenCount": {
-          "description": "Number of tokens in the prompt.",
+        "safetyRatings": {
+          "items": {
+            "$ref": "SafetyRating"
+          },
+          "type": "array",
+          "description": "List of ratings for the safety of a response candidate. There is at most one rating per category."
+        },
+        "citationMetadata": {
+          "description": "Output only. Citation information for model-generated candidate. This field may be populated with recitation information for any text included in the `content`. These are passages that are \"recited\" from copyrighted material in the foundational LLM's training data.",
+          "readOnly": true,
+          "$ref": "CitationMetadata"
+        },
+        "finishReason": {
+          "description": "Optional. Output only. The reason why the model stopped generating tokens. If empty, the model has not stopped generating the tokens.",
+          "readOnly": true,
+          "enumDescriptions": [
+            "Default value. This value is unused.",
+            "Natural stop point of the model or provided stop sequence.",
+            "The maximum number of tokens as specified in the request was reached.",
+            "The candidate content was flagged for safety reasons.",
+            "The candidate content was flagged for recitation reasons.",
+            "Unknown reason."
+          ],
+          "enum": [
+            "FINISH_REASON_UNSPECIFIED",
+            "STOP",
+            "MAX_TOKENS",
+            "SAFETY",
+            "RECITATION",
+            "OTHER"
+          ],
+          "type": "string"
+        }
+      },
+      "id": "Candidate",
+      "description": "A response candidate generated from the model."
+    },
+    "QueryDocumentResponse": {
+      "type": "object",
+      "description": "Response from `QueryDocument` containing a list of relevant chunks.",
+      "id": "QueryDocumentResponse",
+      "properties": {
+        "relevantChunks": {
+          "description": "The returned relevant chunks.",
+          "type": "array",
+          "items": {
+            "$ref": "RelevantChunk"
+          }
+        }
+      }
+    },
+    "Operation": {
+      "type": "object",
+      "properties": {
+        "done": {
+          "description": "If the value is `false`, it means the operation is still in progress. If `true`, the operation is completed, and either `error` or `response` is available.",
+          "type": "boolean"
+        },
+        "error": {
+          "description": "The error result of the operation in case of failure or cancellation.",
+          "$ref": "Status"
+        },
+        "name": {
+          "description": "The server-assigned name, which is only unique within the same service that originally returns it. If you use the default HTTP mapping, the `name` should be a resource name ending with `operations/{unique_id}`.",
+          "type": "string"
+        },
+        "response": {
+          "description": "The normal, successful response of the operation. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`.",
+          "type": "object",
+          "additionalProperties": {
+            "description": "Properties of the object. Contains field @type with type URL.",
+            "type": "any"
+          }
+        },
+        "metadata": {
+          "additionalProperties": {
+            "description": "Properties of the object. Contains field @type with type URL.",
+            "type": "any"
+          },
+          "description": "Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any.",
+          "type": "object"
+        }
+      },
+      "id": "Operation",
+      "description": "This resource represents a long-running operation that is the result of a network API call."
+    },
+    "GenerateAnswerResponse": {
+      "type": "object",
+      "properties": {
+        "answerableProbability": {
+          "type": "number",
+          "readOnly": true,
+          "format": "float",
+          "description": "Output only. The model's estimate of the probability that its answer is correct and grounded in the input passages. A low answerable_probability indicates that the answer might not be grounded in the sources. When `answerable_probability` is low, some clients may wish to: * Display a message to the effect of \"We couldn’t answer that question\" to the user. * Fall back to a general-purpose LLM that answers the question from world knowledge. The threshold and nature of such fallbacks will depend on individual clients’ use cases. 0.5 is a good starting threshold."
+        },
+        "answer": {
+          "description": "Candidate answer from the model. Note: The model *always* attempts to provide a grounded answer, even when the answer is unlikely to be answerable from the given passages. In that case, a low-quality or ungrounded answer may be provided, along with a low `answerable_probability`.",
+          "$ref": "Candidate"
+        },
+        "inputFeedback": {
+          "$ref": "InputFeedback",
+          "readOnly": true,
+          "description": "Output only. Feedback related to the input data used to answer the question, as opposed to model-generated response to the question. \"Input data\" can be one or more of the following: - Question specified by the last entry in `GenerateAnswerRequest.content` - Conversation history specified by the other entries in `GenerateAnswerRequest.content` - Grounding sources (`GenerateAnswerRequest.semantic_retriever` or `GenerateAnswerRequest.inline_passages`)"
+        }
+      },
+      "id": "GenerateAnswerResponse",
+      "description": "Response from the model for a grounded answer."
+    },
+    "GenerateContentRequest": {
+      "properties": {
+        "contents": {
+          "description": "Required. The content of the current conversation with the model. For single-turn queries, this is a single instance. For multi-turn queries, this is a repeated field that contains conversation history + latest request.",
+          "type": "array",
+          "items": {
+            "$ref": "Content"
+          }
+        },
+        "model": {
+          "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`.",
+          "type": "string"
+        },
+        "safetySettings": {
+          "type": "array",
+          "items": {
+            "$ref": "SafetySetting"
+          },
+          "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content. This will be enforced on the `GenerateContentRequest.contents` and `GenerateContentResponse.candidates`. There should not be more than one setting for each `SafetyCategory` type. The API will block any contents and responses that fail to meet the thresholds set by these settings. This list overrides the default settings for each `SafetyCategory` specified in the safety_settings. If there is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use the default safety setting for that category. Harm categories HARM_CATEGORY_HATE_SPEECH, HARM_CATEGORY_SEXUALLY_EXPLICIT, HARM_CATEGORY_DANGEROUS_CONTENT, HARM_CATEGORY_HARASSMENT are supported."
+        },
+        "toolConfig": {
+          "description": "Optional. Tool configuration for any `Tool` specified in the request.",
+          "$ref": "ToolConfig"
+        },
+        "tools": {
+          "items": {
+            "$ref": "Tool"
+          },
+          "type": "array",
+          "description": "Optional. A list of `Tools` the model may use to generate the next response. A `Tool` is a piece of code that enables the system to interact with external systems to perform an action, or set of actions, outside of knowledge and scope of the model. The only supported tool is currently `Function`."
+        },
+        "systemInstruction": {
+          "$ref": "Content",
+          "description": "Optional. Developer set system instruction. Currently, text only."
+        },
+        "generationConfig": {
+          "$ref": "GenerationConfig",
+          "description": "Optional. Configuration options for model generation and outputs."
+        }
+      },
+      "description": "Request to generate a completion from the model.",
+      "type": "object",
+      "id": "GenerateContentRequest"
+    },
+    "InputFeedback": {
+      "type": "object",
+      "properties": {
+        "safetyRatings": {
+          "type": "array",
+          "description": "Ratings for safety of the input. There is at most one rating per category.",
+          "items": {
+            "$ref": "SafetyRating"
+          }
+        },
+        "blockReason": {
+          "type": "string",
+          "enumDescriptions": [
+            "Default value. This value is unused.",
+            "Input was blocked due to safety reasons. You can inspect `safety_ratings` to understand which safety category blocked it.",
+            "Input was blocked due to other reasons."
+          ],
+          "enum": [
+            "BLOCK_REASON_UNSPECIFIED",
+            "SAFETY",
+            "OTHER"
+          ],
+          "description": "Optional. If set, the input was blocked and no candidates are returned. Rephrase your input."
+        }
+      },
+      "id": "InputFeedback",
+      "description": "Feedback related to the input data used to answer the question, as opposed to model-generated response to the question."
+    },
+    "GenerateTextRequest": {
+      "properties": {
+        "candidateCount": {
+          "type": "integer",
+          "description": "Optional. Number of generated responses to return. This value must be between [1, 8], inclusive. If unset, this will default to 1.",
+          "format": "int32"
+        },
+        "prompt": {
+          "$ref": "TextPrompt",
+          "description": "Required. The free-form input text given to the model as a prompt. Given a prompt, the model will generate a TextCompletion response it predicts as the completion of the input text."
+        },
+        "safetySettings": {
+          "type": "array",
+          "items": {
+            "$ref": "SafetySetting"
+          },
+          "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content. that will be enforced on the `GenerateTextRequest.prompt` and `GenerateTextResponse.candidates`. There should not be more than one setting for each `SafetyCategory` type. The API will block any prompts and responses that fail to meet the thresholds set by these settings. This list overrides the default settings for each `SafetyCategory` specified in the safety_settings. If there is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use the default safety setting for that category. Harm categories HARM_CATEGORY_DEROGATORY, HARM_CATEGORY_TOXICITY, HARM_CATEGORY_VIOLENCE, HARM_CATEGORY_SEXUAL, HARM_CATEGORY_MEDICAL, HARM_CATEGORY_DANGEROUS are supported in text service."
+        },
+        "topP": {
+          "type": "number",
+          "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Tokens are sorted based on their assigned probabilities so that only the most likely tokens are considered. Top-k sampling directly limits the maximum number of tokens to consider, while Nucleus sampling limits number of tokens based on the cumulative probability. Note: The default value varies by model, see the `Model.top_p` attribute of the `Model` returned the `getModel` function.",
+          "format": "float"
+        },
+        "maxOutputTokens": {
+          "description": "Optional. The maximum number of tokens to include in a candidate. If unset, this will default to output_token_limit specified in the `Model` specification.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "stopSequences": {
+          "type": "array",
+          "description": "The set of character sequences (up to 5) that will stop output generation. If specified, the API will stop at the first appearance of a stop sequence. The stop sequence will not be included as part of the response.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "temperature": {
+          "format": "float",
+          "description": "Optional. Controls the randomness of the output. Note: The default value varies by model, see the `Model.temperature` attribute of the `Model` returned the `getModel` function. Values can range from [0.0,1.0], inclusive. A value closer to 1.0 will produce responses that are more varied and creative, while a value closer to 0.0 will typically result in more straightforward responses from the model.",
+          "type": "number"
+        },
+        "topK": {
+          "description": "Optional. The maximum number of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens. Defaults to 40. Note: The default value varies by model, see the `Model.top_k` attribute of the `Model` returned the `getModel` function.",
           "format": "int32",
           "type": "integer"
         }
       },
-      "id": "UsageMetadata",
+      "id": "GenerateTextRequest",
+      "type": "object",
+      "description": "Request to generate a text completion response from the model."
+    },
+    "RelevantChunk": {
+      "properties": {
+        "chunkRelevanceScore": {
+          "type": "number",
+          "format": "float",
+          "description": "`Chunk` relevance to the query."
+        },
+        "chunk": {
+          "$ref": "Chunk",
+          "description": "`Chunk` associated with the query."
+        }
+      },
+      "id": "RelevantChunk",
+      "type": "object",
+      "description": "The information for a chunk relevant to a query."
+    },
+    "Empty": {
+      "description": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); }",
+      "id": "Empty",
+      "properties": {},
       "type": "object"
     },
-    "TransferOwnershipResponse": {
-      "properties": {},
+    "SemanticRetrieverConfig": {
+      "id": "SemanticRetrieverConfig",
+      "description": "Configuration for retrieving grounding content from a `Corpus` or `Document` created using the Semantic Retriever API.",
       "type": "object",
-      "description": "Response from `TransferOwnership`.",
-      "id": "TransferOwnershipResponse"
+      "properties": {
+        "maxChunksCount": {
+          "type": "integer",
+          "description": "Optional. Maximum number of relevant `Chunk`s to retrieve.",
+          "format": "int32"
+        },
+        "metadataFilters": {
+          "type": "array",
+          "items": {
+            "$ref": "MetadataFilter"
+          },
+          "description": "Optional. Filters for selecting `Document`s and/or `Chunk`s from the resource."
+        },
+        "query": {
+          "description": "Required. Query to use for similarity matching `Chunk`s in the given resource.",
+          "$ref": "Content"
+        },
+        "minimumRelevanceScore": {
+          "format": "float",
+          "description": "Optional. Minimum relevance score for retrieved relevant `Chunk`s.",
+          "type": "number"
+        },
+        "source": {
+          "type": "string",
+          "description": "Required. Name of the resource for retrieval, e.g. corpora/123 or corpora/123/documents/abc."
+        }
+      }
+    },
+    "GenerateTextResponse": {
+      "properties": {
+        "candidates": {
+          "description": "Candidate responses from the model.",
+          "items": {
+            "$ref": "TextCompletion"
+          },
+          "type": "array"
+        },
+        "safetyFeedback": {
+          "description": "Returns any safety feedback related to content filtering.",
+          "type": "array",
+          "items": {
+            "$ref": "SafetyFeedback"
+          }
+        },
+        "filters": {
+          "description": "A set of content filtering metadata for the prompt and response text. This indicates which `SafetyCategory`(s) blocked a candidate from this response, the lowest `HarmProbability` that triggered a block, and the HarmThreshold setting for that category. This indicates the smallest change to the `SafetySettings` that would be necessary to unblock at least 1 response. The blocking is configured by the `SafetySettings` in the request (or the default `SafetySettings` of the API).",
+          "items": {
+            "$ref": "ContentFilter"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "description": "The response from the model, including candidate completions.",
+      "id": "GenerateTextResponse"
+    },
+    "Chunk": {
+      "properties": {
+        "customMetadata": {
+          "description": "Optional. User provided custom metadata stored as key-value pairs. The maximum number of `CustomMetadata` per chunk is 20.",
+          "type": "array",
+          "items": {
+            "$ref": "CustomMetadata"
+          }
+        },
+        "updateTime": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. The Timestamp of when the `Chunk` was last updated.",
+          "format": "google-datetime"
+        },
+        "createTime": {
+          "format": "google-datetime",
+          "description": "Output only. The Timestamp of when the `Chunk` was created.",
+          "type": "string",
+          "readOnly": true
+        },
+        "data": {
+          "$ref": "ChunkData",
+          "description": "Required. The content for the `Chunk`, such as the text string. The maximum number of tokens per chunk is 2043."
+        },
+        "name": {
+          "type": "string",
+          "description": "Immutable. Identifier. The `Chunk` resource name. The ID (name excluding the \"corpora/*/documents/*/chunks/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a random 12-character unique ID will be generated. Example: `corpora/{corpus_id}/documents/{document_id}/chunks/123a456b789c`"
+        },
+        "state": {
+          "type": "string",
+          "enumDescriptions": [
+            "The default value. This value is used if the state is omitted.",
+            "`Chunk` is being processed (embedding and vector storage).",
+            "`Chunk` is processed and available for querying.",
+            "`Chunk` failed processing."
+          ],
+          "enum": [
+            "STATE_UNSPECIFIED",
+            "STATE_PENDING_PROCESSING",
+            "STATE_ACTIVE",
+            "STATE_FAILED"
+          ],
+          "description": "Output only. Current state of the `Chunk`.",
+          "readOnly": true
+        }
+      },
+      "description": "A `Chunk` is a subpart of a `Document` that is treated as an independent unit for the purposes of vector representation and storage. A `Corpus` can have a maximum of 1 million `Chunk`s.",
+      "type": "object",
+      "id": "Chunk"
+    },
+    "Schema": {
+      "description": "The `Schema` object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. Represents a select subset of an [OpenAPI 3.0 schema object](https://spec.openapis.org/oas/v3.0.3#schema).",
+      "properties": {
+        "items": {
+          "description": "Optional. Schema of the elements of Type.ARRAY.",
+          "$ref": "Schema"
+        },
+        "properties": {
+          "description": "Optional. Properties of Type.OBJECT.",
+          "additionalProperties": {
+            "$ref": "Schema"
+          },
+          "type": "object"
+        },
+        "required": {
+          "type": "array",
+          "description": "Optional. Required properties of Type.OBJECT.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "description": "Required. Data type.",
+          "enumDescriptions": [
+            "Not specified, should not be used.",
+            "String type.",
+            "Number type.",
+            "Integer type.",
+            "Boolean type.",
+            "Array type.",
+            "Object type."
+          ],
+          "type": "string",
+          "enum": [
+            "TYPE_UNSPECIFIED",
+            "STRING",
+            "NUMBER",
+            "INTEGER",
+            "BOOLEAN",
+            "ARRAY",
+            "OBJECT"
+          ]
+        },
+        "enum": {
+          "type": "array",
+          "description": "Optional. Possible values of the element of Type.STRING with enum format. For example we can define an Enum Direction as : {type:STRING, format:enum, enum:[\"EAST\", NORTH\", \"SOUTH\", \"WEST\"]}",
+          "items": {
+            "type": "string"
+          }
+        },
+        "format": {
+          "type": "string",
+          "description": "Optional. The format of the data. This is used only for primitive datatypes. Supported formats: for NUMBER type: float, double for INTEGER type: int32, int64"
+        },
+        "description": {
+          "type": "string",
+          "description": "Optional. A brief description of the parameter. This could contain examples of use. Parameter description may be formatted as Markdown."
+        },
+        "nullable": {
+          "description": "Optional. Indicates if the value may be null.",
+          "type": "boolean"
+        }
+      },
+      "id": "Schema",
+      "type": "object"
     },
     "SafetyRating": {
       "id": "SafetyRating",
       "type": "object",
       "properties": {
-        "probability": {
-          "enum": [
-            "HARM_PROBABILITY_UNSPECIFIED",
-            "NEGLIGIBLE",
-            "LOW",
-            "MEDIUM",
-            "HIGH"
-          ],
-          "type": "string",
-          "enumDescriptions": [
-            "Probability is unspecified.",
-            "Content has a negligible chance of being unsafe.",
-            "Content has a low chance of being unsafe.",
-            "Content has a medium chance of being unsafe.",
-            "Content has a high chance of being unsafe."
-          ],
-          "description": "Required. The probability of harm for this content."
+        "blocked": {
+          "type": "boolean",
+          "description": "Was this content blocked because of this rating?"
         },
         "category": {
-          "enum": [
-            "HARM_CATEGORY_UNSPECIFIED",
-            "HARM_CATEGORY_DEROGATORY",
-            "HARM_CATEGORY_TOXICITY",
-            "HARM_CATEGORY_VIOLENCE",
-            "HARM_CATEGORY_SEXUAL",
-            "HARM_CATEGORY_MEDICAL",
-            "HARM_CATEGORY_DANGEROUS",
-            "HARM_CATEGORY_HARASSMENT",
-            "HARM_CATEGORY_HATE_SPEECH",
-            "HARM_CATEGORY_SEXUALLY_EXPLICIT",
-            "HARM_CATEGORY_DANGEROUS_CONTENT"
-          ],
-          "type": "string",
+          "description": "Required. The category for this rating.",
           "enumDescriptions": [
             "Category is unspecified.",
             "Negative or harmful comments targeting identity and/or protected attribute.",
@@ -2059,251 +922,273 @@
             "Sexually explicit content.",
             "Dangerous content."
           ],
-          "description": "Required. The category for this rating."
+          "type": "string",
+          "enum": [
+            "HARM_CATEGORY_UNSPECIFIED",
+            "HARM_CATEGORY_DEROGATORY",
+            "HARM_CATEGORY_TOXICITY",
+            "HARM_CATEGORY_VIOLENCE",
+            "HARM_CATEGORY_SEXUAL",
+            "HARM_CATEGORY_MEDICAL",
+            "HARM_CATEGORY_DANGEROUS",
+            "HARM_CATEGORY_HARASSMENT",
+            "HARM_CATEGORY_HATE_SPEECH",
+            "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+            "HARM_CATEGORY_DANGEROUS_CONTENT"
+          ]
         },
-        "blocked": {
-          "type": "boolean",
-          "description": "Was this content blocked because of this rating?"
+        "probability": {
+          "type": "string",
+          "description": "Required. The probability of harm for this content.",
+          "enumDescriptions": [
+            "Probability is unspecified.",
+            "Content has a negligible chance of being unsafe.",
+            "Content has a low chance of being unsafe.",
+            "Content has a medium chance of being unsafe.",
+            "Content has a high chance of being unsafe."
+          ],
+          "enum": [
+            "HARM_PROBABILITY_UNSPECIFIED",
+            "NEGLIGIBLE",
+            "LOW",
+            "MEDIUM",
+            "HIGH"
+          ]
         }
       },
       "description": "Safety rating for a piece of content. The safety rating contains the category of harm and the harm probability level in that category for a piece of content. Content is classified for safety across a number of harm categories and the probability of the harm classification is included here."
     },
-    "Operation": {
+    "File": {
       "type": "object",
-      "description": "This resource represents a long-running operation that is the result of a network API call.",
-      "id": "Operation",
+      "description": "A file uploaded to the API.",
+      "id": "File",
       "properties": {
-        "name": {
-          "description": "The server-assigned name, which is only unique within the same service that originally returns it. If you use the default HTTP mapping, the `name` should be a resource name ending with `operations/{unique_id}`.",
-          "type": "string"
-        },
-        "response": {
-          "additionalProperties": {
-            "description": "Properties of the object. Contains field @type with type URL.",
-            "type": "any"
-          },
-          "description": "The normal, successful response of the operation. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`.",
-          "type": "object"
-        },
         "error": {
           "$ref": "Status",
-          "description": "The error result of the operation in case of failure or cancellation."
-        },
-        "done": {
-          "description": "If the value is `false`, it means the operation is still in progress. If `true`, the operation is completed, and either `error` or `response` is available.",
-          "type": "boolean"
-        },
-        "metadata": {
-          "type": "object",
-          "description": "Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any.",
-          "additionalProperties": {
-            "description": "Properties of the object. Contains field @type with type URL.",
-            "type": "any"
-          }
-        }
-      }
-    },
-    "TextPrompt": {
-      "type": "object",
-      "description": "Text given to the model as a prompt. The Model will use this TextPrompt to Generate a text completion.",
-      "properties": {
-        "text": {
-          "type": "string",
-          "description": "Required. The prompt text."
-        }
-      },
-      "id": "TextPrompt"
-    },
-    "FunctionResponse": {
-      "id": "FunctionResponse",
-      "description": "The result output from a `FunctionCall` that contains a string representing the `FunctionDeclaration.name` and a structured JSON object containing any output from the function is used as context to the model. This should contain the result of a`FunctionCall` made based on model prediction.",
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Required. The name of the function to call. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
-        },
-        "response": {
-          "description": "Required. The function response in JSON object format.",
-          "additionalProperties": {
-            "description": "Properties of the object.",
-            "type": "any"
-          },
-          "type": "object"
-        }
-      }
-    },
-    "Empty": {
-      "type": "object",
-      "description": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); }",
-      "id": "Empty",
-      "properties": {}
-    },
-    "Condition": {
-      "id": "Condition",
-      "properties": {
-        "stringValue": {
-          "type": "string",
-          "description": "The string value to filter the metadata on."
-        },
-        "numericValue": {
-          "description": "The numeric value to filter the metadata on.",
-          "format": "float",
-          "type": "number"
-        },
-        "operation": {
-          "type": "string",
-          "enum": [
-            "OPERATOR_UNSPECIFIED",
-            "LESS",
-            "LESS_EQUAL",
-            "EQUAL",
-            "GREATER_EQUAL",
-            "GREATER",
-            "NOT_EQUAL",
-            "INCLUDES",
-            "EXCLUDES"
-          ],
-          "description": "Required. Operator applied to the given key-value pair to trigger the condition.",
-          "enumDescriptions": [
-            "The default value. This value is unused.",
-            "Supported by numeric.",
-            "Supported by numeric.",
-            "Supported by numeric & string.",
-            "Supported by numeric.",
-            "Supported by numeric.",
-            "Supported by numeric & string.",
-            "Supported by string only when `CustomMetadata` value type for the given key has a `string_list_value`.",
-            "Supported by string only when `CustomMetadata` value type for the given key has a `string_list_value`."
-          ]
-        }
-      },
-      "type": "object",
-      "description": "Filter condition applicable to a single key."
-    },
-    "TunedModel": {
-      "properties": {
-        "displayName": {
-          "type": "string",
-          "description": "Optional. The name to display for this model in user interfaces. The display name must be up to 40 characters including spaces."
+          "readOnly": true,
+          "description": "Output only. Error status if File processing failed."
         },
         "updateTime": {
-          "readOnly": true,
-          "description": "Output only. The timestamp when this model was updated.",
+          "description": "Output only. The timestamp of when the `File` was last updated.",
           "format": "google-datetime",
+          "readOnly": true,
           "type": "string"
         },
-        "baseModel": {
-          "description": "Immutable. The name of the `Model` to tune. Example: `models/text-bison-001`",
+        "name": {
+          "description": "Immutable. Identifier. The `File` resource name. The ID (name excluding the \"files/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be generated. Example: `files/123-456`",
           "type": "string"
         },
-        "topK": {
-          "format": "int32",
-          "type": "integer",
-          "description": "Optional. For Top-k sampling. Top-k sampling considers the set of `top_k` most probable tokens. This value specifies default to be used by the backend while making the call to the model. This value specifies default to be the one used by the base model while creating the model."
+        "createTime": {
+          "type": "string",
+          "format": "google-datetime",
+          "description": "Output only. The timestamp of when the `File` was created.",
+          "readOnly": true
+        },
+        "sizeBytes": {
+          "type": "string",
+          "description": "Output only. Size of the file in bytes.",
+          "readOnly": true,
+          "format": "int64"
+        },
+        "sha256Hash": {
+          "type": "string",
+          "description": "Output only. SHA-256 hash of the uploaded bytes.",
+          "readOnly": true,
+          "format": "byte"
         },
         "state": {
           "readOnly": true,
-          "enumDescriptions": [
-            "The default value. This value is unused.",
-            "The model is being created.",
-            "The model is ready to be used.",
-            "The model failed to be created."
-          ],
+          "description": "Output only. Processing state of the File.",
           "enum": [
             "STATE_UNSPECIFIED",
-            "CREATING",
+            "PROCESSING",
             "ACTIVE",
             "FAILED"
           ],
-          "description": "Output only. The state of the tuned model.",
+          "enumDescriptions": [
+            "The default value. This value is used if the state is omitted.",
+            "File is being processed and cannot be used for inference yet.",
+            "File is processed and available for inference.",
+            "File failed processing."
+          ],
           "type": "string"
         },
-        "description": {
+        "displayName": {
           "type": "string",
-          "description": "Optional. A short description of this model."
+          "description": "Optional. The human-readable display name for the `File`. The display name must be no more than 512 characters in length, including spaces. Example: \"Welcome Image\""
         },
-        "temperature": {
-          "type": "number",
-          "description": "Optional. Controls the randomness of the output. Values can range over `[0.0,1.0]`, inclusive. A value closer to `1.0` will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model. This value specifies default to be the one used by the base model while creating the model.",
-          "format": "float"
+        "videoMetadata": {
+          "$ref": "VideoMetadata",
+          "readOnly": true,
+          "description": "Output only. Metadata for a video."
         },
-        "topP": {
-          "format": "float",
-          "type": "number",
-          "description": "Optional. For Nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`. This value specifies default to be the one used by the base model while creating the model."
-        },
-        "tunedModelSource": {
-          "$ref": "TunedModelSource",
-          "description": "Optional. TunedModel to use as the starting point for training the new model."
-        },
-        "tuningTask": {
-          "description": "Required. The tuning task that creates the tuned model.",
-          "$ref": "TuningTask"
-        },
-        "createTime": {
-          "description": "Output only. The timestamp when this model was created.",
-          "format": "google-datetime",
-          "type": "string",
-          "readOnly": true
-        },
-        "name": {
+        "uri": {
           "readOnly": true,
           "type": "string",
-          "description": "Output only. The tuned model name. A unique name will be generated on create. Example: `tunedModels/az2mb0bpw6i` If display_name is set on create, the id portion of the name will be set by concatenating the words of the display_name with hyphens and adding a random portion for uniqueness. Example: display_name = \"Sentence Translator\" name = \"tunedModels/sentence-translator-u3b7m\""
-        }
-      },
-      "description": "A fine-tuned model created using ModelService.CreateTunedModel.",
-      "type": "object",
-      "id": "TunedModel"
-    },
-    "GenerateMessageRequest": {
-      "id": "GenerateMessageRequest",
-      "description": "Request to generate a message response from the model.",
-      "type": "object",
-      "properties": {
-        "topK": {
-          "format": "int32",
-          "type": "integer",
-          "description": "Optional. The maximum number of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens."
+          "description": "Output only. The uri of the `File`."
         },
-        "topP": {
-          "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`.",
-          "format": "float",
-          "type": "number"
+        "expirationTime": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Output only. The timestamp of when the `File` will be deleted. Only set if the `File` is scheduled to expire.",
+          "format": "google-datetime"
         },
-        "prompt": {
-          "$ref": "MessagePrompt",
-          "description": "Required. The structured textual input given to the model as a prompt. Given a prompt, the model will return what it predicts is the next message in the discussion."
-        },
-        "candidateCount": {
-          "description": "Optional. The number of generated response messages to return. This value must be between `[1, 8]`, inclusive. If unset, this will default to `1`.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "temperature": {
-          "description": "Optional. Controls the randomness of the output. Values can range over `[0.0,1.0]`, inclusive. A value closer to `1.0` will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model.",
-          "format": "float",
-          "type": "number"
+        "mimeType": {
+          "type": "string",
+          "description": "Output only. MIME type of the file.",
+          "readOnly": true
         }
       }
     },
-    "Embedding": {
-      "id": "Embedding",
+    "BatchUpdateChunksRequest": {
+      "description": "Request to batch update `Chunk`s.",
+      "id": "BatchUpdateChunksRequest",
       "type": "object",
-      "description": "A list of floats representing the embedding.",
       "properties": {
-        "value": {
-          "type": "array",
-          "description": "The embedding values.",
+        "requests": {
           "items": {
-            "format": "float",
-            "type": "number"
-          }
+            "$ref": "UpdateChunkRequest"
+          },
+          "type": "array",
+          "description": "Required. The request messages specifying the `Chunk`s to update. A maximum of 100 `Chunk`s can be updated in a batch."
+        }
+      }
+    },
+    "CountMessageTokensResponse": {
+      "id": "CountMessageTokensResponse",
+      "properties": {
+        "tokenCount": {
+          "format": "int32",
+          "type": "integer",
+          "description": "The number of tokens that the `model` tokenizes the `prompt` into. Always non-negative."
+        }
+      },
+      "description": "A response from `CountMessageTokens`. It returns the model's `token_count` for the `prompt`.",
+      "type": "object"
+    },
+    "Corpus": {
+      "properties": {
+        "updateTime": {
+          "readOnly": true,
+          "description": "Output only. The Timestamp of when the `Corpus` was last updated.",
+          "type": "string",
+          "format": "google-datetime"
+        },
+        "createTime": {
+          "description": "Output only. The Timestamp of when the `Corpus` was created.",
+          "type": "string",
+          "format": "google-datetime",
+          "readOnly": true
+        },
+        "displayName": {
+          "description": "Optional. The human-readable display name for the `Corpus`. The display name must be no more than 512 characters in length, including spaces. Example: \"Docs on Semantic Retriever\"",
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "description": "Immutable. Identifier. The `Corpus` resource name. The ID (name excluding the \"corpora/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/my-awesome-corpora-123a456b789c`"
+        }
+      },
+      "id": "Corpus",
+      "description": "A `Corpus` is a collection of `Document`s. A project can create up to 5 corpora.",
+      "type": "object"
+    },
+    "TuningExamples": {
+      "id": "TuningExamples",
+      "description": "A set of tuning examples. Can be training or validation data.",
+      "type": "object",
+      "properties": {
+        "examples": {
+          "items": {
+            "$ref": "TuningExample"
+          },
+          "type": "array",
+          "description": "Required. The examples. Example input can be for text or discuss, but all examples in a set must be of the same type."
+        }
+      }
+    },
+    "Example": {
+      "description": "An input/output example used to instruct the Model. It demonstrates how the model should respond or format its response.",
+      "id": "Example",
+      "properties": {
+        "input": {
+          "$ref": "Message",
+          "description": "Required. An example of an input `Message` from the user."
+        },
+        "output": {
+          "$ref": "Message",
+          "description": "Required. An example of what the model should output given the input."
+        }
+      },
+      "type": "object"
+    },
+    "StringList": {
+      "id": "StringList",
+      "properties": {
+        "values": {
+          "description": "The string values of the metadata to store.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "description": "User provided string values assigned to a single metadata key.",
+      "type": "object"
+    },
+    "SafetyFeedback": {
+      "type": "object",
+      "description": "Safety feedback for an entire request. This field is populated if content in the input and/or response is blocked due to safety settings. SafetyFeedback may not exist for every HarmCategory. Each SafetyFeedback will return the safety settings used by the request as well as the lowest HarmProbability that should be allowed in order to return a result.",
+      "id": "SafetyFeedback",
+      "properties": {
+        "rating": {
+          "description": "Safety rating evaluated from content.",
+          "$ref": "SafetyRating"
+        },
+        "setting": {
+          "$ref": "SafetySetting",
+          "description": "Safety settings applied to the request."
+        }
+      }
+    },
+    "CountMessageTokensRequest": {
+      "properties": {
+        "prompt": {
+          "description": "Required. The prompt, whose token count is to be returned.",
+          "$ref": "MessagePrompt"
+        }
+      },
+      "type": "object",
+      "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`.",
+      "id": "CountMessageTokensRequest"
+    },
+    "CustomMetadata": {
+      "id": "CustomMetadata",
+      "type": "object",
+      "description": "User provided metadata stored as key-value pairs.",
+      "properties": {
+        "stringValue": {
+          "description": "The string value of the metadata to store.",
+          "type": "string"
+        },
+        "key": {
+          "description": "Required. The key of the metadata to store.",
+          "type": "string"
+        },
+        "numericValue": {
+          "description": "The numeric value of the metadata to store.",
+          "type": "number",
+          "format": "float"
+        },
+        "stringListValue": {
+          "description": "The StringList value of the metadata to store.",
+          "$ref": "StringList"
         }
       }
     },
     "MessagePrompt": {
+      "type": "object",
+      "id": "MessagePrompt",
       "properties": {
         "messages": {
           "type": "array",
@@ -2318,648 +1203,46 @@
         },
         "examples": {
           "type": "array",
-          "description": "Optional. Examples of what the model should generate. This includes both user input and the response that the model should emulate. These `examples` are treated identically to conversation messages except that they take precedence over the history in `messages`: If the total input size exceeds the model's `input_token_limit` the input will be truncated. Items will be dropped from `messages` before `examples`.",
           "items": {
             "$ref": "Example"
-          }
+          },
+          "description": "Optional. Examples of what the model should generate. This includes both user input and the response that the model should emulate. These `examples` are treated identically to conversation messages except that they take precedence over the history in `messages`: If the total input size exceeds the model's `input_token_limit` the input will be truncated. Items will be dropped from `messages` before `examples`."
         }
       },
-      "id": "MessagePrompt",
-      "type": "object",
       "description": "All of the structured input text passed to the model as a prompt. A `MessagePrompt` contains a structured set of fields that provide context for the conversation, examples of user input/model output message pairs that prime the model to respond in different ways, and the conversation history or list of messages representing the alternating turns of the conversation between the user and the model."
     },
-    "ContentEmbedding": {
-      "description": "A list of floats representing an embedding.",
+    "CreateFileRequest": {
       "type": "object",
-      "properties": {
-        "values": {
-          "type": "array",
-          "items": {
-            "format": "float",
-            "type": "number"
-          },
-          "description": "The embedding values."
-        }
-      },
-      "id": "ContentEmbedding"
-    },
-    "Chunk": {
-      "type": "object",
-      "id": "Chunk",
-      "properties": {
-        "customMetadata": {
-          "type": "array",
-          "items": {
-            "$ref": "CustomMetadata"
-          },
-          "description": "Optional. User provided custom metadata stored as key-value pairs. The maximum number of `CustomMetadata` per chunk is 20."
-        },
-        "state": {
-          "enumDescriptions": [
-            "The default value. This value is used if the state is omitted.",
-            "`Chunk` is being processed (embedding and vector storage).",
-            "`Chunk` is processed and available for querying.",
-            "`Chunk` failed processing."
-          ],
-          "readOnly": true,
-          "description": "Output only. Current state of the `Chunk`.",
-          "type": "string",
-          "enum": [
-            "STATE_UNSPECIFIED",
-            "STATE_PENDING_PROCESSING",
-            "STATE_ACTIVE",
-            "STATE_FAILED"
-          ]
-        },
-        "updateTime": {
-          "description": "Output only. The Timestamp of when the `Chunk` was last updated.",
-          "format": "google-datetime",
-          "readOnly": true,
-          "type": "string"
-        },
-        "createTime": {
-          "description": "Output only. The Timestamp of when the `Chunk` was created.",
-          "type": "string",
-          "format": "google-datetime",
-          "readOnly": true
-        },
-        "name": {
-          "description": "Immutable. Identifier. The `Chunk` resource name. The ID (name excluding the \"corpora/*/documents/*/chunks/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a random 12-character unique ID will be generated. Example: `corpora/{corpus_id}/documents/{document_id}/chunks/123a456b789c`",
-          "type": "string"
-        },
-        "data": {
-          "$ref": "ChunkData",
-          "description": "Required. The content for the `Chunk`, such as the text string. The maximum number of tokens per chunk is 2043."
-        }
-      },
-      "description": "A `Chunk` is a subpart of a `Document` that is treated as an independent unit for the purposes of vector representation and storage. A `Corpus` can have a maximum of 1 million `Chunk`s."
-    },
-    "Schema": {
-      "description": "The `Schema` object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. Represents a select subset of an [OpenAPI 3.0 schema object](https://spec.openapis.org/oas/v3.0.3#schema).",
-      "type": "object",
-      "id": "Schema",
-      "properties": {
-        "nullable": {
-          "description": "Optional. Indicates if the value may be null.",
-          "type": "boolean"
-        },
-        "items": {
-          "description": "Optional. Schema of the elements of Type.ARRAY.",
-          "$ref": "Schema"
-        },
-        "required": {
-          "type": "array",
-          "description": "Optional. Required properties of Type.OBJECT.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "enum": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Optional. Possible values of the element of Type.STRING with enum format. For example we can define an Enum Direction as : {type:STRING, format:enum, enum:[\"EAST\", NORTH\", \"SOUTH\", \"WEST\"]}"
-        },
-        "type": {
-          "enum": [
-            "TYPE_UNSPECIFIED",
-            "STRING",
-            "NUMBER",
-            "INTEGER",
-            "BOOLEAN",
-            "ARRAY",
-            "OBJECT"
-          ],
-          "description": "Required. Data type.",
-          "type": "string",
-          "enumDescriptions": [
-            "Not specified, should not be used.",
-            "String type.",
-            "Number type.",
-            "Integer type.",
-            "Boolean type.",
-            "Array type.",
-            "Object type."
-          ]
-        },
-        "properties": {
-          "type": "object",
-          "description": "Optional. Properties of Type.OBJECT.",
-          "additionalProperties": {
-            "$ref": "Schema"
-          }
-        },
-        "format": {
-          "type": "string",
-          "description": "Optional. The format of the data. This is used only for primitive datatypes. Supported formats: for NUMBER type: float, double for INTEGER type: int32, int64"
-        },
-        "description": {
-          "description": "Optional. A brief description of the parameter. This could contain examples of use. Parameter description may be formatted as Markdown.",
-          "type": "string"
-        }
-      }
-    },
-    "QueryCorpusRequest": {
-      "description": "Request for querying a `Corpus`.",
-      "type": "object",
-      "id": "QueryCorpusRequest",
-      "properties": {
-        "metadataFilters": {
-          "items": {
-            "$ref": "MetadataFilter"
-          },
-          "type": "array",
-          "description": "Optional. Filter for `Chunk` and `Document` metadata. Each `MetadataFilter` object should correspond to a unique key. Multiple `MetadataFilter` objects are joined by logical \"AND\"s. Example query at document level: (year \u003e= 2020 OR year \u003c 2010) AND (genre = drama OR genre = action) `MetadataFilter` object list: metadata_filters = [ {key = \"document.custom_metadata.year\" conditions = [{int_value = 2020, operation = GREATER_EQUAL}, {int_value = 2010, operation = LESS}]}, {key = \"document.custom_metadata.year\" conditions = [{int_value = 2020, operation = GREATER_EQUAL}, {int_value = 2010, operation = LESS}]}, {key = \"document.custom_metadata.genre\" conditions = [{string_value = \"drama\", operation = EQUAL}, {string_value = \"action\", operation = EQUAL}]}] Example query at chunk level for a numeric range of values: (year \u003e 2015 AND year \u003c= 2020) `MetadataFilter` object list: metadata_filters = [ {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2015, operation = GREATER}]}, {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2020, operation = LESS_EQUAL}]}] Note: \"AND\"s for the same key are only supported for numeric values. String values only support \"OR\"s for the same key."
-        },
-        "query": {
-          "type": "string",
-          "description": "Required. Query string to perform semantic search."
-        },
-        "resultsCount": {
-          "format": "int32",
-          "description": "Optional. The maximum number of `Chunk`s to return. The service may return fewer `Chunk`s. If unspecified, at most 10 `Chunk`s will be returned. The maximum specified result count is 100.",
-          "type": "integer"
-        }
-      }
-    },
-    "GroundingPassageId": {
-      "description": "Identifier for a part within a `GroundingPassage`.",
-      "id": "GroundingPassageId",
-      "type": "object",
-      "properties": {
-        "passageId": {
-          "type": "string",
-          "description": "Output only. ID of the passage matching the `GenerateAnswerRequest`'s `GroundingPassage.id`.",
-          "readOnly": true
-        },
-        "partIndex": {
-          "format": "int32",
-          "description": "Output only. Index of the part within the `GenerateAnswerRequest`'s `GroundingPassage.content`.",
-          "readOnly": true,
-          "type": "integer"
-        }
-      }
-    },
-    "TransferOwnershipRequest": {
-      "type": "object",
-      "description": "Request to transfer the ownership of the tuned model.",
-      "id": "TransferOwnershipRequest",
-      "properties": {
-        "emailAddress": {
-          "description": "Required. The email address of the user to whom the tuned model is being transferred to.",
-          "type": "string"
-        }
-      }
-    },
-    "GenerateTextResponse": {
-      "description": "The response from the model, including candidate completions.",
-      "id": "GenerateTextResponse",
-      "type": "object",
-      "properties": {
-        "filters": {
-          "description": "A set of content filtering metadata for the prompt and response text. This indicates which `SafetyCategory`(s) blocked a candidate from this response, the lowest `HarmProbability` that triggered a block, and the HarmThreshold setting for that category. This indicates the smallest change to the `SafetySettings` that would be necessary to unblock at least 1 response. The blocking is configured by the `SafetySettings` in the request (or the default `SafetySettings` of the API).",
-          "type": "array",
-          "items": {
-            "$ref": "ContentFilter"
-          }
-        },
-        "safetyFeedback": {
-          "items": {
-            "$ref": "SafetyFeedback"
-          },
-          "type": "array",
-          "description": "Returns any safety feedback related to content filtering."
-        },
-        "candidates": {
-          "type": "array",
-          "description": "Candidate responses from the model.",
-          "items": {
-            "$ref": "TextCompletion"
-          }
-        }
-      }
-    },
-    "BatchUpdateChunksResponse": {
-      "type": "object",
-      "properties": {
-        "chunks": {
-          "items": {
-            "$ref": "Chunk"
-          },
-          "description": "`Chunk`s updated.",
-          "type": "array"
-        }
-      },
-      "description": "Response from `BatchUpdateChunks` containing a list of updated `Chunk`s.",
-      "id": "BatchUpdateChunksResponse"
-    },
-    "ListPermissionsResponse": {
-      "description": "Response from `ListPermissions` containing a paginated list of permissions.",
-      "id": "ListPermissionsResponse",
-      "properties": {
-        "nextPageToken": {
-          "type": "string",
-          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
-        },
-        "permissions": {
-          "items": {
-            "$ref": "Permission"
-          },
-          "type": "array",
-          "description": "Returned permissions."
-        }
-      },
-      "type": "object"
-    },
-    "ContentFilter": {
-      "id": "ContentFilter",
-      "type": "object",
-      "description": "Content filtering metadata associated with processing a single request. ContentFilter contains a reason and an optional supporting string. The reason may be unspecified.",
-      "properties": {
-        "message": {
-          "type": "string",
-          "description": "A string that describes the filtering behavior in more detail."
-        },
-        "reason": {
-          "enum": [
-            "BLOCKED_REASON_UNSPECIFIED",
-            "SAFETY",
-            "OTHER"
-          ],
-          "description": "The reason content was blocked during request processing.",
-          "type": "string",
-          "enumDescriptions": [
-            "A blocked reason was not specified.",
-            "Content was blocked by safety settings.",
-            "Content was blocked, but the reason is uncategorized."
-          ]
-        }
-      }
-    },
-    "GenerateAnswerResponse": {
-      "properties": {
-        "answer": {
-          "$ref": "Candidate",
-          "description": "Candidate answer from the model. Note: The model *always* attempts to provide a grounded answer, even when the answer is unlikely to be answerable from the given passages. In that case, a low-quality or ungrounded answer may be provided, along with a low `answerable_probability`."
-        },
-        "inputFeedback": {
-          "description": "Output only. Feedback related to the input data used to answer the question, as opposed to model-generated response to the question. \"Input data\" can be one or more of the following: - Question specified by the last entry in `GenerateAnswerRequest.content` - Conversation history specified by the other entries in `GenerateAnswerRequest.content` - Grounding sources (`GenerateAnswerRequest.semantic_retriever` or `GenerateAnswerRequest.inline_passages`)",
-          "readOnly": true,
-          "$ref": "InputFeedback"
-        },
-        "answerableProbability": {
-          "format": "float",
-          "description": "Output only. The model's estimate of the probability that its answer is correct and grounded in the input passages. A low answerable_probability indicates that the answer might not be grounded in the sources. When `answerable_probability` is low, some clients may wish to: * Display a message to the effect of \"We couldn’t answer that question\" to the user. * Fall back to a general-purpose LLM that answers the question from world knowledge. The threshold and nature of such fallbacks will depend on individual clients’ use cases. 0.5 is a good starting threshold.",
-          "readOnly": true,
-          "type": "number"
-        }
-      },
-      "type": "object",
-      "id": "GenerateAnswerResponse",
-      "description": "Response from the model for a grounded answer."
-    },
-    "GenerateContentResponse": {
-      "description": "Response from the model supporting multiple candidates. Note on safety ratings and content filtering. They are reported for both prompt in `GenerateContentResponse.prompt_feedback` and for each candidate in `finish_reason` and in `safety_ratings`. The API contract is that: - either all requested candidates are returned or no candidates at all - no candidates are returned only if there was something wrong with the prompt (see `prompt_feedback`) - feedback on each candidate is reported on `finish_reason` and `safety_ratings`.",
-      "type": "object",
-      "properties": {
-        "usageMetadata": {
-          "$ref": "UsageMetadata",
-          "readOnly": true,
-          "description": "Output only. Metadata on the generation requests' token usage."
-        },
-        "promptFeedback": {
-          "description": "Returns the prompt's feedback related to the content filters.",
-          "$ref": "PromptFeedback"
-        },
-        "candidates": {
-          "type": "array",
-          "description": "Candidate responses from the model.",
-          "items": {
-            "$ref": "Candidate"
-          }
-        }
-      },
-      "id": "GenerateContentResponse"
-    },
-    "QueryDocumentRequest": {
-      "properties": {
-        "metadataFilters": {
-          "items": {
-            "$ref": "MetadataFilter"
-          },
-          "description": "Optional. Filter for `Chunk` metadata. Each `MetadataFilter` object should correspond to a unique key. Multiple `MetadataFilter` objects are joined by logical \"AND\"s. Note: `Document`-level filtering is not supported for this request because a `Document` name is already specified. Example query: (year \u003e= 2020 OR year \u003c 2010) AND (genre = drama OR genre = action) `MetadataFilter` object list: metadata_filters = [ {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2020, operation = GREATER_EQUAL}, {int_value = 2010, operation = LESS}}, {key = \"chunk.custom_metadata.genre\" conditions = [{string_value = \"drama\", operation = EQUAL}, {string_value = \"action\", operation = EQUAL}}] Example query for a numeric range of values: (year \u003e 2015 AND year \u003c= 2020) `MetadataFilter` object list: metadata_filters = [ {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2015, operation = GREATER}]}, {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2020, operation = LESS_EQUAL}]}] Note: \"AND\"s for the same key are only supported for numeric values. String values only support \"OR\"s for the same key.",
-          "type": "array"
-        },
-        "query": {
-          "description": "Required. Query string to perform semantic search.",
-          "type": "string"
-        },
-        "resultsCount": {
-          "format": "int32",
-          "type": "integer",
-          "description": "Optional. The maximum number of `Chunk`s to return. The service may return fewer `Chunk`s. If unspecified, at most 10 `Chunk`s will be returned. The maximum specified result count is 100."
-        }
-      },
-      "type": "object",
-      "description": "Request for querying a `Document`.",
-      "id": "QueryDocumentRequest"
-    },
-    "PromptFeedback": {
-      "id": "PromptFeedback",
-      "properties": {
-        "safetyRatings": {
-          "type": "array",
-          "items": {
-            "$ref": "SafetyRating"
-          },
-          "description": "Ratings for safety of the prompt. There is at most one rating per category."
-        },
-        "blockReason": {
-          "enum": [
-            "BLOCK_REASON_UNSPECIFIED",
-            "SAFETY",
-            "OTHER"
-          ],
-          "enumDescriptions": [
-            "Default value. This value is unused.",
-            "Prompt was blocked due to safety reasons. You can inspect `safety_ratings` to understand which safety category blocked it.",
-            "Prompt was blocked due to unknown reaasons."
-          ],
-          "type": "string",
-          "description": "Optional. If set, the prompt was blocked and no candidates are returned. Rephrase your prompt."
-        }
-      },
-      "description": "A set of the feedback metadata the prompt specified in `GenerateContentRequest.content`.",
-      "type": "object"
-    },
-    "FunctionCall": {
-      "id": "FunctionCall",
-      "description": "A predicted `FunctionCall` returned from the model that contains a string representing the `FunctionDeclaration.name` with the arguments and their values.",
-      "type": "object",
-      "properties": {
-        "args": {
-          "type": "object",
-          "description": "Optional. The function parameters and values in JSON object format.",
-          "additionalProperties": {
-            "type": "any",
-            "description": "Properties of the object."
-          }
-        },
-        "name": {
-          "type": "string",
-          "description": "Required. The name of the function to call. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
-        }
-      }
-    },
-    "Example": {
-      "id": "Example",
-      "type": "object",
-      "properties": {
-        "input": {
-          "$ref": "Message",
-          "description": "Required. An example of an input `Message` from the user."
-        },
-        "output": {
-          "description": "Required. An example of what the model should output given the input.",
-          "$ref": "Message"
-        }
-      },
-      "description": "An input/output example used to instruct the Model. It demonstrates how the model should respond or format its response."
-    },
-    "MetadataFilter": {
-      "description": "User provided filter to limit retrieval based on `Chunk` or `Document` level metadata values. Example (genre = drama OR genre = action): key = \"document.custom_metadata.genre\" conditions = [{string_value = \"drama\", operation = EQUAL}, {string_value = \"action\", operation = EQUAL}]",
-      "id": "MetadataFilter",
-      "properties": {
-        "conditions": {
-          "description": "Required. The `Condition`s for the given key that will trigger this filter. Multiple `Condition`s are joined by logical ORs.",
-          "type": "array",
-          "items": {
-            "$ref": "Condition"
-          }
-        },
-        "key": {
-          "description": "Required. The key of the metadata to filter on.",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "Document": {
-      "description": "A `Document` is a collection of `Chunk`s. A `Corpus` can have a maximum of 10,000 `Document`s.",
-      "id": "Document",
-      "type": "object",
-      "properties": {
-        "customMetadata": {
-          "items": {
-            "$ref": "CustomMetadata"
-          },
-          "description": "Optional. User provided custom metadata stored as key-value pairs used for querying. A `Document` can have a maximum of 20 `CustomMetadata`.",
-          "type": "array"
-        },
-        "name": {
-          "description": "Immutable. Identifier. The `Document` resource name. The ID (name excluding the \"corpora/*/documents/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/{corpus_id}/documents/my-awesome-doc-123a456b789c`",
-          "type": "string"
-        },
-        "createTime": {
-          "description": "Output only. The Timestamp of when the `Document` was created.",
-          "type": "string",
-          "format": "google-datetime",
-          "readOnly": true
-        },
-        "displayName": {
-          "description": "Optional. The human-readable display name for the `Document`. The display name must be no more than 512 characters in length, including spaces. Example: \"Semantic Retriever Documentation\"",
-          "type": "string"
-        },
-        "updateTime": {
-          "type": "string",
-          "format": "google-datetime",
-          "description": "Output only. The Timestamp of when the `Document` was last updated.",
-          "readOnly": true
-        }
-      }
-    },
-    "ListCorporaResponse": {
-      "description": "Response from `ListCorpora` containing a paginated list of `Corpora`. The results are sorted by ascending `corpus.create_time`.",
-      "properties": {
-        "nextPageToken": {
-          "type": "string",
-          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
-        },
-        "corpora": {
-          "description": "The returned corpora.",
-          "type": "array",
-          "items": {
-            "$ref": "Corpus"
-          }
-        }
-      },
-      "type": "object",
-      "id": "ListCorporaResponse"
-    },
-    "File": {
-      "type": "object",
-      "id": "File",
-      "description": "A file uploaded to the API.",
-      "properties": {
-        "displayName": {
-          "type": "string",
-          "description": "Optional. The human-readable display name for the `File`. The display name must be no more than 512 characters in length, including spaces. Example: \"Welcome Image\""
-        },
-        "sha256Hash": {
-          "type": "string",
-          "description": "Output only. SHA-256 hash of the uploaded bytes.",
-          "format": "byte",
-          "readOnly": true
-        },
-        "uri": {
-          "readOnly": true,
-          "description": "Output only. The uri of the `File`.",
-          "type": "string"
-        },
-        "state": {
-          "description": "Output only. Processing state of the File.",
-          "enumDescriptions": [
-            "The default value. This value is used if the state is omitted.",
-            "File is being processed and cannot be used for inference yet.",
-            "File is processed and available for inference.",
-            "File failed processing."
-          ],
-          "readOnly": true,
-          "enum": [
-            "STATE_UNSPECIFIED",
-            "PROCESSING",
-            "ACTIVE",
-            "FAILED"
-          ],
-          "type": "string"
-        },
-        "name": {
-          "type": "string",
-          "description": "Immutable. Identifier. The `File` resource name. The ID (name excluding the \"files/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be generated. Example: `files/123-456`"
-        },
-        "sizeBytes": {
-          "format": "int64",
-          "readOnly": true,
-          "description": "Output only. Size of the file in bytes.",
-          "type": "string"
-        },
-        "mimeType": {
-          "description": "Output only. MIME type of the file.",
-          "type": "string",
-          "readOnly": true
-        },
-        "updateTime": {
-          "readOnly": true,
-          "description": "Output only. The timestamp of when the `File` was last updated.",
-          "type": "string",
-          "format": "google-datetime"
-        },
-        "expirationTime": {
-          "description": "Output only. The timestamp of when the `File` will be deleted. Only set if the `File` is scheduled to expire.",
-          "readOnly": true,
-          "format": "google-datetime",
-          "type": "string"
-        },
-        "createTime": {
-          "description": "Output only. The timestamp of when the `File` was created.",
-          "type": "string",
-          "format": "google-datetime",
-          "readOnly": true
-        }
-      }
-    },
-    "CreateFileResponse": {
-      "description": "Response for `CreateFile`.",
-      "id": "CreateFileResponse",
       "properties": {
         "file": {
-          "$ref": "File",
-          "description": "Metadata for the created file."
+          "description": "Optional. Metadata for the file to create.",
+          "$ref": "File"
         }
       },
-      "type": "object"
-    },
-    "QueryCorpusResponse": {
-      "type": "object",
-      "properties": {
-        "relevantChunks": {
-          "items": {
-            "$ref": "RelevantChunk"
-          },
-          "type": "array",
-          "description": "The relevant chunks."
-        }
-      },
-      "id": "QueryCorpusResponse",
-      "description": "Response from `QueryCorpus` containing a list of relevant chunks."
-    },
-    "CitationMetadata": {
-      "type": "object",
-      "id": "CitationMetadata",
-      "properties": {
-        "citationSources": {
-          "items": {
-            "$ref": "CitationSource"
-          },
-          "description": "Citations to sources for a specific response.",
-          "type": "array"
-        }
-      },
-      "description": "A collection of source attributions for a piece of content."
-    },
-    "CustomMetadata": {
-      "id": "CustomMetadata",
-      "description": "User provided metadata stored as key-value pairs.",
-      "properties": {
-        "stringValue": {
-          "description": "The string value of the metadata to store.",
-          "type": "string"
-        },
-        "numericValue": {
-          "format": "float",
-          "type": "number",
-          "description": "The numeric value of the metadata to store."
-        },
-        "stringListValue": {
-          "$ref": "StringList",
-          "description": "The StringList value of the metadata to store."
-        },
-        "key": {
-          "type": "string",
-          "description": "Required. The key of the metadata to store."
-        }
-      },
-      "type": "object"
-    },
-    "BatchEmbedTextResponse": {
-      "id": "BatchEmbedTextResponse",
-      "description": "The response to a EmbedTextRequest.",
-      "type": "object",
-      "properties": {
-        "embeddings": {
-          "items": {
-            "$ref": "Embedding"
-          },
-          "type": "array",
-          "readOnly": true,
-          "description": "Output only. The embeddings generated from the input text."
-        }
-      }
+      "description": "Request for `CreateFile`.",
+      "id": "CreateFileRequest"
     },
     "GenerateAnswerRequest": {
+      "description": "Request to generate a grounded answer from the model.",
       "properties": {
-        "temperature": {
-          "description": "Optional. Controls the randomness of the output. Values can range from [0.0,1.0], inclusive. A value closer to 1.0 will produce responses that are more varied and creative, while a value closer to 0.0 will typically result in more straightforward responses from the model. A low temperature (~0.2) is usually recommended for Attributed-Question-Answering use cases.",
-          "format": "float",
-          "type": "number"
-        },
         "safetySettings": {
           "type": "array",
           "items": {
             "$ref": "SafetySetting"
           },
           "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content. This will be enforced on the `GenerateAnswerRequest.contents` and `GenerateAnswerResponse.candidate`. There should not be more than one setting for each `SafetyCategory` type. The API will block any contents and responses that fail to meet the thresholds set by these settings. This list overrides the default settings for each `SafetyCategory` specified in the safety_settings. If there is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use the default safety setting for that category. Harm categories HARM_CATEGORY_HATE_SPEECH, HARM_CATEGORY_SEXUALLY_EXPLICIT, HARM_CATEGORY_DANGEROUS_CONTENT, HARM_CATEGORY_HARASSMENT are supported."
+        },
+        "contents": {
+          "type": "array",
+          "items": {
+            "$ref": "Content"
+          },
+          "description": "Required. The content of the current conversation with the model. For single-turn queries, this is a single question to answer. For multi-turn queries, this is a repeated field that contains conversation history and the last `Content` in the list containing the question. Note: GenerateAnswer currently only supports queries in English."
+        },
+        "temperature": {
+          "type": "number",
+          "format": "float",
+          "description": "Optional. Controls the randomness of the output. Values can range from [0.0,1.0], inclusive. A value closer to 1.0 will produce responses that are more varied and creative, while a value closer to 0.0 will typically result in more straightforward responses from the model. A low temperature (~0.2) is usually recommended for Attributed-Question-Answering use cases."
         },
         "answerStyle": {
           "enumDescriptions": [
@@ -2977,195 +1260,695 @@
           "description": "Required. Style in which answers should be returned.",
           "type": "string"
         },
-        "contents": {
-          "items": {
-            "$ref": "Content"
-          },
-          "type": "array",
-          "description": "Required. The content of the current conversation with the model. For single-turn queries, this is a single question to answer. For multi-turn queries, this is a repeated field that contains conversation history and the last `Content` in the list containing the question. Note: GenerateAnswer currently only supports queries in English."
-        },
-        "inlinePassages": {
-          "description": "Passages provided inline with the request.",
-          "$ref": "GroundingPassages"
-        },
         "semanticRetriever": {
           "$ref": "SemanticRetrieverConfig",
           "description": "Content retrieved from resources created via the Semantic Retriever API."
+        },
+        "inlinePassages": {
+          "$ref": "GroundingPassages",
+          "description": "Passages provided inline with the request."
+        }
+      },
+      "id": "GenerateAnswerRequest",
+      "type": "object"
+    },
+    "Message": {
+      "id": "Message",
+      "properties": {
+        "author": {
+          "type": "string",
+          "description": "Optional. The author of this Message. This serves as a key for tagging the content of this Message when it is fed to the model as text. The author can be any alphanumeric string."
+        },
+        "citationMetadata": {
+          "readOnly": true,
+          "$ref": "CitationMetadata",
+          "description": "Output only. Citation information for model-generated `content` in this `Message`. If this `Message` was generated as output from the model, this field may be populated with attribution information for any text included in the `content`. This field is used only on output."
+        },
+        "content": {
+          "description": "Required. The text content of the structured `Message`.",
+          "type": "string"
+        }
+      },
+      "description": "The base unit of structured text. A `Message` includes an `author` and the `content` of the `Message`. The `author` is used to tag messages when they are fed to the model as text.",
+      "type": "object"
+    },
+    "CitationSource": {
+      "properties": {
+        "startIndex": {
+          "format": "int32",
+          "description": "Optional. Start of segment of the response that is attributed to this source. Index indicates the start of the segment, measured in bytes.",
+          "type": "integer"
+        },
+        "license": {
+          "description": "Optional. License for the GitHub project that is attributed as a source for segment. License info is required for code citations.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "Optional. URI that is attributed as a source for a portion of the text.",
+          "type": "string"
+        },
+        "endIndex": {
+          "description": "Optional. End of the attributed segment, exclusive.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "description": "A citation to a source for a portion of a specific response.",
+      "id": "CitationSource",
+      "type": "object"
+    },
+    "GenerateMessageRequest": {
+      "type": "object",
+      "description": "Request to generate a message response from the model.",
+      "properties": {
+        "prompt": {
+          "description": "Required. The structured textual input given to the model as a prompt. Given a prompt, the model will return what it predicts is the next message in the discussion.",
+          "$ref": "MessagePrompt"
+        },
+        "topP": {
+          "type": "number",
+          "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`.",
+          "format": "float"
+        },
+        "temperature": {
+          "type": "number",
+          "format": "float",
+          "description": "Optional. Controls the randomness of the output. Values can range over `[0.0,1.0]`, inclusive. A value closer to `1.0` will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model."
+        },
+        "candidateCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. The number of generated response messages to return. This value must be between `[1, 8]`, inclusive. If unset, this will default to `1`."
+        },
+        "topK": {
+          "description": "Optional. The maximum number of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens.",
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "id": "GenerateMessageRequest"
+    },
+    "CreateFileResponse": {
+      "description": "Response for `CreateFile`.",
+      "id": "CreateFileResponse",
+      "type": "object",
+      "properties": {
+        "file": {
+          "$ref": "File",
+          "description": "Metadata for the created file."
+        }
+      }
+    },
+    "CountTextTokensResponse": {
+      "id": "CountTextTokensResponse",
+      "properties": {
+        "tokenCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of tokens that the `model` tokenizes the `prompt` into. Always non-negative."
         }
       },
       "type": "object",
-      "description": "Request to generate a grounded answer from the model.",
-      "id": "GenerateAnswerRequest"
+      "description": "A response from `CountTextTokens`. It returns the model's `token_count` for the `prompt`."
     },
-    "ListDocumentsResponse": {
+    "ListChunksResponse": {
       "type": "object",
-      "description": "Response from `ListDocuments` containing a paginated list of `Document`s. The `Document`s are sorted by ascending `document.create_time`.",
-      "id": "ListDocumentsResponse",
+      "id": "ListChunksResponse",
       "properties": {
-        "documents": {
-          "description": "The returned `Document`s.",
+        "nextPageToken": {
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages.",
+          "type": "string"
+        },
+        "chunks": {
+          "type": "array",
+          "description": "The returned `Chunk`s.",
           "items": {
-            "$ref": "Document"
+            "$ref": "Chunk"
+          }
+        }
+      },
+      "description": "Response from `ListChunks` containing a paginated list of `Chunk`s. The `Chunk`s are sorted by ascending `chunk.create_time`."
+    },
+    "TransferOwnershipResponse": {
+      "type": "object",
+      "description": "Response from `TransferOwnership`.",
+      "properties": {},
+      "id": "TransferOwnershipResponse"
+    },
+    "BatchDeleteChunksRequest": {
+      "id": "BatchDeleteChunksRequest",
+      "properties": {
+        "requests": {
+          "items": {
+            "$ref": "DeleteChunkRequest"
           },
+          "description": "Required. The request messages specifying the `Chunk`s to delete.",
           "type": "array"
+        }
+      },
+      "type": "object",
+      "description": "Request to batch delete `Chunk`s."
+    },
+    "ListPermissionsResponse": {
+      "properties": {
+        "permissions": {
+          "description": "Returned permissions.",
+          "type": "array",
+          "items": {
+            "$ref": "Permission"
+          }
         },
         "nextPageToken": {
           "type": "string",
           "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
         }
-      }
-    },
-    "EmbedContentRequest": {
+      },
       "type": "object",
-      "description": "Request containing the `Content` for the model to embed.",
-      "id": "EmbedContentRequest",
+      "id": "ListPermissionsResponse",
+      "description": "Response from `ListPermissions` containing a paginated list of permissions."
+    },
+    "DeleteChunkRequest": {
       "properties": {
-        "content": {
-          "description": "Required. The content to embed. Only the `parts.text` fields will be counted.",
-          "$ref": "Content"
-        },
-        "model": {
-          "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
+        "name": {
+          "type": "string",
+          "description": "Required. The resource name of the `Chunk` to delete. Example: `corpora/my-corpus-123/documents/the-doc-abc/chunks/some-chunk`"
+        }
+      },
+      "id": "DeleteChunkRequest",
+      "description": "Request to delete a `Chunk`.",
+      "type": "object"
+    },
+    "Status": {
+      "properties": {
+        "message": {
+          "description": "A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client.",
           "type": "string"
         },
-        "outputDimensionality": {
-          "description": "Optional. Optional reduced dimension for the output embedding. If set, excessive values in the output embedding are truncated from the end. Supported by newer models since 2024, and the earlier model (`models/embedding-001`) cannot specify this value.",
+        "code": {
           "type": "integer",
+          "description": "The status code, which should be an enum value of google.rpc.Code.",
           "format": "int32"
         },
-        "title": {
-          "type": "string",
-          "description": "Optional. An optional title for the text. Only applicable when TaskType is `RETRIEVAL_DOCUMENT`. Note: Specifying a `title` for `RETRIEVAL_DOCUMENT` provides better quality embeddings for retrieval."
-        },
-        "taskType": {
-          "enumDescriptions": [
-            "Unset value, which will default to one of the other enum values.",
-            "Specifies the given text is a query in a search/retrieval setting.",
-            "Specifies the given text is a document from the corpus being searched.",
-            "Specifies the given text will be used for STS.",
-            "Specifies that the given text will be classified.",
-            "Specifies that the embeddings will be used for clustering.",
-            "Specifies that the given text will be used for question answering.",
-            "Specifies that the given text will be used for fact verification."
-          ],
-          "description": "Optional. Optional task type for which the embeddings will be used. Can only be set for `models/embedding-001`.",
-          "type": "string",
-          "enum": [
-            "TASK_TYPE_UNSPECIFIED",
-            "RETRIEVAL_QUERY",
-            "RETRIEVAL_DOCUMENT",
-            "SEMANTIC_SIMILARITY",
-            "CLASSIFICATION",
-            "CLUSTERING",
-            "QUESTION_ANSWERING",
-            "FACT_VERIFICATION"
-          ]
+        "details": {
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "description": "Properties of the object. Contains field @type with type URL.",
+              "type": "any"
+            }
+          },
+          "description": "A list of messages that carry the error details. There is a common set of message types for APIs to use.",
+          "type": "array"
         }
-      }
+      },
+      "id": "Status",
+      "description": "The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).",
+      "type": "object"
     },
-    "EmbedTextRequest": {
-      "id": "EmbedTextRequest",
+    "Hyperparameters": {
+      "type": "object",
       "properties": {
-        "model": {
-          "description": "Required. The model name to use with the format model=models/{model}.",
-          "type": "string"
+        "batchSize": {
+          "format": "int32",
+          "description": "Immutable. The batch size hyperparameter for tuning. If not set, a default of 4 or 16 will be used based on the number of training examples.",
+          "type": "integer"
         },
-        "text": {
-          "type": "string",
-          "description": "Optional. The free-form input text that the model will turn into an embedding."
+        "epochCount": {
+          "format": "int32",
+          "description": "Immutable. The number of training epochs. An epoch is one pass through the training data. If not set, a default of 5 will be used.",
+          "type": "integer"
+        },
+        "learningRateMultiplier": {
+          "format": "float",
+          "type": "number",
+          "description": "Optional. Immutable. The learning rate multiplier is used to calculate a final learning_rate based on the default (recommended) value. Actual learning rate := learning_rate_multiplier * default learning rate Default learning rate is dependent on base model and dataset size. If not set, a default of 1.0 will be used."
+        },
+        "learningRate": {
+          "type": "number",
+          "format": "float",
+          "description": "Optional. Immutable. The learning rate hyperparameter for tuning. If not set, a default of 0.001 or 0.0002 will be calculated based on the number of training examples."
+        }
+      },
+      "id": "Hyperparameters",
+      "description": "Hyperparameters controlling the tuning process. Read more at https://ai.google.dev/docs/model_tuning_guidance"
+    },
+    "BatchCreateChunksResponse": {
+      "id": "BatchCreateChunksResponse",
+      "properties": {
+        "chunks": {
+          "type": "array",
+          "description": "`Chunk`s created.",
+          "items": {
+            "$ref": "Chunk"
+          }
+        }
+      },
+      "description": "Response from `BatchCreateChunks` containing a list of created `Chunk`s.",
+      "type": "object"
+    },
+    "GroundingAttribution": {
+      "description": "Attribution for a source that contributed to an answer.",
+      "properties": {
+        "sourceId": {
+          "$ref": "AttributionSourceId",
+          "readOnly": true,
+          "description": "Output only. Identifier for the source contributing to this attribution."
+        },
+        "content": {
+          "description": "Grounding source content that makes up this attribution.",
+          "$ref": "Content"
         }
       },
       "type": "object",
-      "description": "Request to get a text embedding from the model."
+      "id": "GroundingAttribution"
     },
-    "GenerateContentRequest": {
-      "id": "GenerateContentRequest",
-      "description": "Request to generate a completion from the model.",
+    "Condition": {
+      "id": "Condition",
+      "type": "object",
       "properties": {
-        "safetySettings": {
-          "type": "array",
-          "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content. This will be enforced on the `GenerateContentRequest.contents` and `GenerateContentResponse.candidates`. There should not be more than one setting for each `SafetyCategory` type. The API will block any contents and responses that fail to meet the thresholds set by these settings. This list overrides the default settings for each `SafetyCategory` specified in the safety_settings. If there is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use the default safety setting for that category. Harm categories HARM_CATEGORY_HATE_SPEECH, HARM_CATEGORY_SEXUALLY_EXPLICIT, HARM_CATEGORY_DANGEROUS_CONTENT, HARM_CATEGORY_HARASSMENT are supported.",
+        "stringValue": {
+          "type": "string",
+          "description": "The string value to filter the metadata on."
+        },
+        "operation": {
+          "description": "Required. Operator applied to the given key-value pair to trigger the condition.",
+          "type": "string",
+          "enum": [
+            "OPERATOR_UNSPECIFIED",
+            "LESS",
+            "LESS_EQUAL",
+            "EQUAL",
+            "GREATER_EQUAL",
+            "GREATER",
+            "NOT_EQUAL",
+            "INCLUDES",
+            "EXCLUDES"
+          ],
+          "enumDescriptions": [
+            "The default value. This value is unused.",
+            "Supported by numeric.",
+            "Supported by numeric.",
+            "Supported by numeric & string.",
+            "Supported by numeric.",
+            "Supported by numeric.",
+            "Supported by numeric & string.",
+            "Supported by string only when `CustomMetadata` value type for the given key has a `string_list_value`.",
+            "Supported by string only when `CustomMetadata` value type for the given key has a `string_list_value`."
+          ]
+        },
+        "numericValue": {
+          "type": "number",
+          "description": "The numeric value to filter the metadata on.",
+          "format": "float"
+        }
+      },
+      "description": "Filter condition applicable to a single key."
+    },
+    "ContentEmbedding": {
+      "description": "A list of floats representing an embedding.",
+      "properties": {
+        "values": {
           "items": {
-            "$ref": "SafetySetting"
-          }
-        },
-        "model": {
-          "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`.",
-          "type": "string"
-        },
-        "systemInstruction": {
-          "$ref": "Content",
-          "description": "Optional. Developer set system instruction. Currently, text only."
-        },
-        "tools": {
-          "type": "array",
-          "items": {
-            "$ref": "Tool"
+            "format": "float",
+            "type": "number"
           },
-          "description": "Optional. A list of `Tools` the model may use to generate the next response. A `Tool` is a piece of code that enables the system to interact with external systems to perform an action, or set of actions, outside of knowledge and scope of the model. The only supported tool is currently `Function`."
+          "type": "array",
+          "description": "The embedding values."
+        }
+      },
+      "id": "ContentEmbedding",
+      "type": "object"
+    },
+    "UsageMetadata": {
+      "type": "object",
+      "description": "Metadata on the generation request's token usage.",
+      "id": "UsageMetadata",
+      "properties": {
+        "promptTokenCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of tokens in the prompt."
         },
-        "toolConfig": {
-          "description": "Optional. Tool configuration for any `Tool` specified in the request.",
-          "$ref": "ToolConfig"
+        "candidatesTokenCount": {
+          "format": "int32",
+          "description": "Total number of tokens across the generated candidates.",
+          "type": "integer"
         },
-        "contents": {
-          "description": "Required. The content of the current conversation with the model. For single-turn queries, this is a single instance. For multi-turn queries, this is a repeated field that contains conversation history + latest request.",
+        "totalTokenCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Total token count for the generation request (prompt + candidates)."
+        }
+      }
+    },
+    "TuningTask": {
+      "properties": {
+        "trainingData": {
+          "description": "Required. Input only. Immutable. The model training data.",
+          "$ref": "Dataset"
+        },
+        "snapshots": {
           "items": {
-            "$ref": "Content"
+            "$ref": "TuningSnapshot"
           },
+          "description": "Output only. Metrics collected during tuning.",
+          "readOnly": true,
           "type": "array"
         },
-        "generationConfig": {
-          "description": "Optional. Configuration options for model generation and outputs.",
-          "$ref": "GenerationConfig"
+        "completeTime": {
+          "format": "google-datetime",
+          "description": "Output only. The timestamp when tuning this model completed.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "hyperparameters": {
+          "$ref": "Hyperparameters",
+          "description": "Immutable. Hyperparameters controlling the tuning process. If not provided, default values will be used."
+        },
+        "startTime": {
+          "format": "google-datetime",
+          "description": "Output only. The timestamp when tuning this model started.",
+          "readOnly": true,
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "description": "Tuning tasks that create tuned models.",
+      "id": "TuningTask"
+    },
+    "QueryDocumentRequest": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "Required. Query string to perform semantic search."
+        },
+        "resultsCount": {
+          "description": "Optional. The maximum number of `Chunk`s to return. The service may return fewer `Chunk`s. If unspecified, at most 10 `Chunk`s will be returned. The maximum specified result count is 100.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "metadataFilters": {
+          "type": "array",
+          "items": {
+            "$ref": "MetadataFilter"
+          },
+          "description": "Optional. Filter for `Chunk` metadata. Each `MetadataFilter` object should correspond to a unique key. Multiple `MetadataFilter` objects are joined by logical \"AND\"s. Note: `Document`-level filtering is not supported for this request because a `Document` name is already specified. Example query: (year \u003e= 2020 OR year \u003c 2010) AND (genre = drama OR genre = action) `MetadataFilter` object list: metadata_filters = [ {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2020, operation = GREATER_EQUAL}, {int_value = 2010, operation = LESS}}, {key = \"chunk.custom_metadata.genre\" conditions = [{string_value = \"drama\", operation = EQUAL}, {string_value = \"action\", operation = EQUAL}}] Example query for a numeric range of values: (year \u003e 2015 AND year \u003c= 2020) `MetadataFilter` object list: metadata_filters = [ {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2015, operation = GREATER}]}, {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2020, operation = LESS_EQUAL}]}] Note: \"AND\"s for the same key are only supported for numeric values. String values only support \"OR\"s for the same key."
+        }
+      },
+      "description": "Request for querying a `Document`.",
+      "id": "QueryDocumentRequest"
+    },
+    "BatchEmbedTextRequest": {
+      "id": "BatchEmbedTextRequest",
+      "type": "object",
+      "properties": {
+        "texts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional. The free-form input texts that the model will turn into an embedding. The current limit is 100 texts, over which an error will be thrown."
+        },
+        "requests": {
+          "items": {
+            "$ref": "EmbedTextRequest"
+          },
+          "type": "array",
+          "description": "Optional. Embed requests for the batch. Only one of `texts` or `requests` can be set."
+        }
+      },
+      "description": "Batch request to get a text embedding from the model."
+    },
+    "AttributionSourceId": {
+      "id": "AttributionSourceId",
+      "type": "object",
+      "properties": {
+        "semanticRetrieverChunk": {
+          "$ref": "SemanticRetrieverChunk",
+          "description": "Identifier for a `Chunk` fetched via Semantic Retriever."
+        },
+        "groundingPassage": {
+          "$ref": "GroundingPassageId",
+          "description": "Identifier for an inline passage."
+        }
+      },
+      "description": "Identifier for the source contributing to this attribution."
+    },
+    "EmbedTextResponse": {
+      "properties": {
+        "embedding": {
+          "description": "Output only. The embedding generated from the input text.",
+          "$ref": "Embedding",
+          "readOnly": true
+        }
+      },
+      "type": "object",
+      "description": "The response to a EmbedTextRequest.",
+      "id": "EmbedTextResponse"
+    },
+    "GroundingPassage": {
+      "id": "GroundingPassage",
+      "type": "object",
+      "description": "Passage included inline with a grounding configuration.",
+      "properties": {
+        "content": {
+          "$ref": "Content",
+          "description": "Content of the passage."
+        },
+        "id": {
+          "description": "Identifier for the passage for attributing this passage in grounded answers.",
+          "type": "string"
+        }
+      }
+    },
+    "FunctionCall": {
+      "id": "FunctionCall",
+      "properties": {
+        "args": {
+          "type": "object",
+          "description": "Optional. The function parameters and values in JSON object format.",
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          }
+        },
+        "name": {
+          "type": "string",
+          "description": "Required. The name of the function to call. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
+        }
+      },
+      "description": "A predicted `FunctionCall` returned from the model that contains a string representing the `FunctionDeclaration.name` with the arguments and their values.",
+      "type": "object"
+    },
+    "GenerationConfig": {
+      "id": "GenerationConfig",
+      "properties": {
+        "topK": {
+          "type": "integer",
+          "description": "Optional. The maximum number of tokens to consider when sampling. Models use nucleus sampling or combined Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens. Models running with nucleus sampling don't allow top_k setting. Note: The default value varies by model, see the `Model.top_k` attribute of the `Model` returned from the `getModel` function. Empty `top_k` field in `Model` indicates the model doesn't apply top-k sampling and doesn't allow setting `top_k` on requests.",
+          "format": "int32"
+        },
+        "maxOutputTokens": {
+          "type": "integer",
+          "description": "Optional. The maximum number of tokens to include in a candidate. Note: The default value varies by model, see the `Model.output_token_limit` attribute of the `Model` returned from the `getModel` function.",
+          "format": "int32"
+        },
+        "candidateCount": {
+          "type": "integer",
+          "description": "Optional. Number of generated responses to return. Currently, this value can only be set to 1. If unset, this will default to 1.",
+          "format": "int32"
+        },
+        "topP": {
+          "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Tokens are sorted based on their assigned probabilities so that only the most likely tokens are considered. Top-k sampling directly limits the maximum number of tokens to consider, while Nucleus sampling limits number of tokens based on the cumulative probability. Note: The default value varies by model, see the `Model.top_p` attribute of the `Model` returned from the `getModel` function.",
+          "format": "float",
+          "type": "number"
+        },
+        "responseMimeType": {
+          "type": "string",
+          "description": "Optional. Output response mimetype of the generated candidate text. Supported mimetype: `text/plain`: (default) Text output. `application/json`: JSON response in the candidates."
+        },
+        "temperature": {
+          "type": "number",
+          "format": "float",
+          "description": "Optional. Controls the randomness of the output. Note: The default value varies by model, see the `Model.temperature` attribute of the `Model` returned from the `getModel` function. Values can range from [0.0, 2.0]."
+        },
+        "responseSchema": {
+          "$ref": "Schema",
+          "description": "Optional. Output response schema of the generated candidate text when response mime type can have schema. Schema can be objects, primitives or arrays and is a subset of [OpenAPI schema](https://spec.openapis.org/oas/v3.0.3#schema). If set, a compatible response_mime_type must also be set. Compatible mimetypes: `application/json`: Schema for JSON response."
+        },
+        "stopSequences": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Optional. The set of character sequences (up to 5) that will stop output generation. If specified, the API will stop at the first appearance of a stop sequence. The stop sequence will not be included as part of the response."
+        }
+      },
+      "description": "Configuration options for model generation and outputs. Not all parameters may be configurable for every model.",
+      "type": "object"
+    },
+    "TextCompletion": {
+      "id": "TextCompletion",
+      "type": "object",
+      "description": "Output text returned from a model.",
+      "properties": {
+        "safetyRatings": {
+          "items": {
+            "$ref": "SafetyRating"
+          },
+          "type": "array",
+          "description": "Ratings for the safety of a response. There is at most one rating per category."
+        },
+        "citationMetadata": {
+          "readOnly": true,
+          "description": "Output only. Citation information for model-generated `output` in this `TextCompletion`. This field may be populated with attribution information for any text included in the `output`.",
+          "$ref": "CitationMetadata"
+        },
+        "output": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. The generated text returned from the model."
+        }
+      }
+    },
+    "BatchUpdateChunksResponse": {
+      "properties": {
+        "chunks": {
+          "description": "`Chunk`s updated.",
+          "items": {
+            "$ref": "Chunk"
+          },
+          "type": "array"
+        }
+      },
+      "description": "Response from `BatchUpdateChunks` containing a list of updated `Chunk`s.",
+      "type": "object",
+      "id": "BatchUpdateChunksResponse"
+    },
+    "ListCorporaResponse": {
+      "properties": {
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
+        },
+        "corpora": {
+          "description": "The returned corpora.",
+          "type": "array",
+          "items": {
+            "$ref": "Corpus"
+          }
+        }
+      },
+      "description": "Response from `ListCorpora` containing a paginated list of `Corpora`. The results are sorted by ascending `corpus.create_time`.",
+      "id": "ListCorporaResponse",
+      "type": "object"
+    },
+    "ListDocumentsResponse": {
+      "description": "Response from `ListDocuments` containing a paginated list of `Document`s. The `Document`s are sorted by ascending `document.create_time`.",
+      "id": "ListDocumentsResponse",
+      "properties": {
+        "documents": {
+          "description": "The returned `Document`s.",
+          "type": "array",
+          "items": {
+            "$ref": "Document"
+          }
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
         }
       },
       "type": "object"
     },
-    "FunctionCallingConfig": {
+    "Dataset": {
+      "description": "Dataset for training or validation.",
       "properties": {
-        "allowedFunctionNames": {
-          "items": {
-            "type": "string"
-          },
-          "description": "Optional. A set of function names that, when provided, limits the functions the model will call. This should only be set when the Mode is ANY. Function names should match [FunctionDeclaration.name]. With mode set to ANY, model will predict a function call from the set of function names provided.",
-          "type": "array"
-        },
-        "mode": {
-          "description": "Optional. Specifies the mode in which function calling should execute. If unspecified, the default value will be set to AUTO.",
-          "type": "string",
-          "enumDescriptions": [
-            "Unspecified function calling mode. This value should not be used.",
-            "Default model behavior, model decides to predict either a function call or a natural language repspose.",
-            "Model is constrained to always predicting a function call only. If \"allowed_function_names\" are set, the predicted function call will be limited to any one of \"allowed_function_names\", else the predicted function call will be any one of the provided \"function_declarations\".",
-            "Model will not predict any function call. Model behavior is same as when not passing any function declarations."
-          ],
-          "enum": [
-            "MODE_UNSPECIFIED",
-            "AUTO",
-            "ANY",
-            "NONE"
-          ]
+        "examples": {
+          "$ref": "TuningExamples",
+          "description": "Optional. Inline examples."
         }
       },
-      "id": "FunctionCallingConfig",
-      "type": "object",
-      "description": "Configuration for specifying function calling behavior."
+      "id": "Dataset",
+      "type": "object"
     },
-    "EmbedContentResponse": {
-      "description": "The response to an `EmbedContentRequest`.",
-      "id": "EmbedContentResponse",
+    "UpdateChunkRequest": {
       "type": "object",
       "properties": {
-        "embedding": {
-          "readOnly": true,
-          "description": "Output only. The embedding generated from the input content.",
-          "$ref": "ContentEmbedding"
+        "updateMask": {
+          "description": "Required. The list of fields to update. Currently, this only supports updating `custom_metadata` and `data`.",
+          "type": "string",
+          "format": "google-fieldmask"
+        },
+        "chunk": {
+          "description": "Required. The `Chunk` to update.",
+          "$ref": "Chunk"
+        }
+      },
+      "id": "UpdateChunkRequest",
+      "description": "Request to update a `Chunk`."
+    },
+    "TextPrompt": {
+      "id": "TextPrompt",
+      "description": "Text given to the model as a prompt. The Model will use this TextPrompt to Generate a text completion.",
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "Required. The prompt text."
+        }
+      },
+      "type": "object"
+    },
+    "ListModelsResponse": {
+      "description": "Response from `ListModel` containing a paginated list of Models.",
+      "properties": {
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
+        },
+        "models": {
+          "items": {
+            "$ref": "Model"
+          },
+          "description": "The returned Models.",
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "id": "ListModelsResponse"
+    },
+    "PromptFeedback": {
+      "id": "PromptFeedback",
+      "type": "object",
+      "description": "A set of the feedback metadata the prompt specified in `GenerateContentRequest.content`.",
+      "properties": {
+        "safetyRatings": {
+          "type": "array",
+          "description": "Ratings for safety of the prompt. There is at most one rating per category.",
+          "items": {
+            "$ref": "SafetyRating"
+          }
+        },
+        "blockReason": {
+          "description": "Optional. If set, the prompt was blocked and no candidates are returned. Rephrase your prompt.",
+          "enumDescriptions": [
+            "Default value. This value is unused.",
+            "Prompt was blocked due to safety reasons. You can inspect `safety_ratings` to understand which safety category blocked it.",
+            "Prompt was blocked due to unknown reaasons."
+          ],
+          "enum": [
+            "BLOCK_REASON_UNSPECIFIED",
+            "SAFETY",
+            "OTHER"
+          ],
+          "type": "string"
         }
       }
     },
     "ListFilesResponse": {
       "id": "ListFilesResponse",
+      "description": "Response for `ListFiles`.",
       "type": "object",
       "properties": {
         "files": {
@@ -3179,548 +1962,134 @@
           "description": "A token that can be sent as a `page_token` into a subsequent `ListFiles` call.",
           "type": "string"
         }
-      },
-      "description": "Response for `ListFiles`."
+      }
     },
-    "ListTunedModelsResponse": {
-      "id": "ListTunedModelsResponse",
+    "EmbedContentRequest": {
       "type": "object",
       "properties": {
-        "tunedModels": {
-          "type": "array",
-          "description": "The returned Models.",
-          "items": {
-            "$ref": "TunedModel"
-          }
-        },
-        "nextPageToken": {
+        "model": {
           "type": "string",
-          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
-        }
-      },
-      "description": "Response from `ListTunedModels` containing a paginated list of Models."
-    },
-    "SemanticRetrieverChunk": {
-      "properties": {
-        "chunk": {
-          "description": "Output only. Name of the `Chunk` containing the attributed text. Example: `corpora/123/documents/abc/chunks/xyz`",
-          "readOnly": true,
-          "type": "string"
+          "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`"
         },
-        "source": {
-          "readOnly": true,
-          "type": "string",
-          "description": "Output only. Name of the source matching the request's `SemanticRetrieverConfig.source`. Example: `corpora/123` or `corpora/123/documents/abc`"
-        }
-      },
-      "type": "object",
-      "id": "SemanticRetrieverChunk",
-      "description": "Identifier for a `Chunk` retrieved via Semantic Retriever specified in the `GenerateAnswerRequest` using `SemanticRetrieverConfig`."
-    },
-    "GenerateTextRequest": {
-      "id": "GenerateTextRequest",
-      "properties": {
-        "maxOutputTokens": {
-          "format": "int32",
-          "description": "Optional. The maximum number of tokens to include in a candidate. If unset, this will default to output_token_limit specified in the `Model` specification.",
-          "type": "integer"
-        },
-        "topK": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Optional. The maximum number of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens. Defaults to 40. Note: The default value varies by model, see the `Model.top_k` attribute of the `Model` returned the `getModel` function."
-        },
-        "prompt": {
-          "$ref": "TextPrompt",
-          "description": "Required. The free-form input text given to the model as a prompt. Given a prompt, the model will generate a TextCompletion response it predicts as the completion of the input text."
-        },
-        "candidateCount": {
-          "description": "Optional. Number of generated responses to return. This value must be between [1, 8], inclusive. If unset, this will default to 1.",
+        "outputDimensionality": {
+          "description": "Optional. Optional reduced dimension for the output embedding. If set, excessive values in the output embedding are truncated from the end. Supported by newer models since 2024, and the earlier model (`models/embedding-001`) cannot specify this value.",
           "type": "integer",
           "format": "int32"
         },
-        "stopSequences": {
-          "type": "array",
-          "description": "The set of character sequences (up to 5) that will stop output generation. If specified, the API will stop at the first appearance of a stop sequence. The stop sequence will not be included as part of the response.",
-          "items": {
-            "type": "string"
-          }
+        "taskType": {
+          "type": "string",
+          "enum": [
+            "TASK_TYPE_UNSPECIFIED",
+            "RETRIEVAL_QUERY",
+            "RETRIEVAL_DOCUMENT",
+            "SEMANTIC_SIMILARITY",
+            "CLASSIFICATION",
+            "CLUSTERING",
+            "QUESTION_ANSWERING",
+            "FACT_VERIFICATION"
+          ],
+          "enumDescriptions": [
+            "Unset value, which will default to one of the other enum values.",
+            "Specifies the given text is a query in a search/retrieval setting.",
+            "Specifies the given text is a document from the corpus being searched.",
+            "Specifies the given text will be used for STS.",
+            "Specifies that the given text will be classified.",
+            "Specifies that the embeddings will be used for clustering.",
+            "Specifies that the given text will be used for question answering.",
+            "Specifies that the given text will be used for fact verification."
+          ],
+          "description": "Optional. Optional task type for which the embeddings will be used. Can only be set for `models/embedding-001`."
         },
-        "topP": {
-          "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Tokens are sorted based on their assigned probabilities so that only the most likely tokens are considered. Top-k sampling directly limits the maximum number of tokens to consider, while Nucleus sampling limits number of tokens based on the cumulative probability. Note: The default value varies by model, see the `Model.top_p` attribute of the `Model` returned the `getModel` function.",
-          "format": "float",
-          "type": "number"
+        "title": {
+          "type": "string",
+          "description": "Optional. An optional title for the text. Only applicable when TaskType is `RETRIEVAL_DOCUMENT`. Note: Specifying a `title` for `RETRIEVAL_DOCUMENT` provides better quality embeddings for retrieval."
+        },
+        "content": {
+          "description": "Required. The content to embed. Only the `parts.text` fields will be counted.",
+          "$ref": "Content"
+        }
+      },
+      "description": "Request containing the `Content` for the model to embed.",
+      "id": "EmbedContentRequest"
+    },
+    "TunedModel": {
+      "properties": {
+        "state": {
+          "readOnly": true,
+          "description": "Output only. The state of the tuned model.",
+          "type": "string",
+          "enumDescriptions": [
+            "The default value. This value is unused.",
+            "The model is being created.",
+            "The model is ready to be used.",
+            "The model failed to be created."
+          ],
+          "enum": [
+            "STATE_UNSPECIFIED",
+            "CREATING",
+            "ACTIVE",
+            "FAILED"
+          ]
+        },
+        "updateTime": {
+          "description": "Output only. The timestamp when this model was updated.",
+          "readOnly": true,
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. The tuned model name. A unique name will be generated on create. Example: `tunedModels/az2mb0bpw6i` If display_name is set on create, the id portion of the name will be set by concatenating the words of the display_name with hyphens and adding a random portion for uniqueness. Example: display_name = \"Sentence Translator\" name = \"tunedModels/sentence-translator-u3b7m\""
+        },
+        "tuningTask": {
+          "description": "Required. The tuning task that creates the tuned model.",
+          "$ref": "TuningTask"
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Optional. The name to display for this model in user interfaces. The display name must be up to 40 characters including spaces."
+        },
+        "createTime": {
+          "type": "string",
+          "format": "google-datetime",
+          "readOnly": true,
+          "description": "Output only. The timestamp when this model was created."
         },
         "temperature": {
           "format": "float",
-          "description": "Optional. Controls the randomness of the output. Note: The default value varies by model, see the `Model.temperature` attribute of the `Model` returned the `getModel` function. Values can range from [0.0,1.0], inclusive. A value closer to 1.0 will produce responses that are more varied and creative, while a value closer to 0.0 will typically result in more straightforward responses from the model.",
-          "type": "number"
-        },
-        "safetySettings": {
-          "type": "array",
-          "items": {
-            "$ref": "SafetySetting"
-          },
-          "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content. that will be enforced on the `GenerateTextRequest.prompt` and `GenerateTextResponse.candidates`. There should not be more than one setting for each `SafetyCategory` type. The API will block any prompts and responses that fail to meet the thresholds set by these settings. This list overrides the default settings for each `SafetyCategory` specified in the safety_settings. If there is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use the default safety setting for that category. Harm categories HARM_CATEGORY_DEROGATORY, HARM_CATEGORY_TOXICITY, HARM_CATEGORY_VIOLENCE, HARM_CATEGORY_SEXUAL, HARM_CATEGORY_MEDICAL, HARM_CATEGORY_DANGEROUS are supported in text service."
-        }
-      },
-      "description": "Request to generate a text completion response from the model.",
-      "type": "object"
-    },
-    "SafetyFeedback": {
-      "description": "Safety feedback for an entire request. This field is populated if content in the input and/or response is blocked due to safety settings. SafetyFeedback may not exist for every HarmCategory. Each SafetyFeedback will return the safety settings used by the request as well as the lowest HarmProbability that should be allowed in order to return a result.",
-      "id": "SafetyFeedback",
-      "type": "object",
-      "properties": {
-        "rating": {
-          "description": "Safety rating evaluated from content.",
-          "$ref": "SafetyRating"
-        },
-        "setting": {
-          "description": "Safety settings applied to the request.",
-          "$ref": "SafetySetting"
-        }
-      }
-    },
-    "TextCompletion": {
-      "id": "TextCompletion",
-      "type": "object",
-      "description": "Output text returned from a model.",
-      "properties": {
-        "output": {
-          "description": "Output only. The generated text returned from the model.",
-          "type": "string",
-          "readOnly": true
-        },
-        "safetyRatings": {
-          "type": "array",
-          "description": "Ratings for the safety of a response. There is at most one rating per category.",
-          "items": {
-            "$ref": "SafetyRating"
-          }
-        },
-        "citationMetadata": {
-          "readOnly": true,
-          "$ref": "CitationMetadata",
-          "description": "Output only. Citation information for model-generated `output` in this `TextCompletion`. This field may be populated with attribution information for any text included in the `output`."
-        }
-      }
-    },
-    "InputFeedback": {
-      "id": "InputFeedback",
-      "type": "object",
-      "properties": {
-        "blockReason": {
-          "enum": [
-            "BLOCK_REASON_UNSPECIFIED",
-            "SAFETY",
-            "OTHER"
-          ],
-          "enumDescriptions": [
-            "Default value. This value is unused.",
-            "Input was blocked due to safety reasons. You can inspect `safety_ratings` to understand which safety category blocked it.",
-            "Input was blocked due to other reasons."
-          ],
-          "description": "Optional. If set, the input was blocked and no candidates are returned. Rephrase your input.",
-          "type": "string"
-        },
-        "safetyRatings": {
-          "items": {
-            "$ref": "SafetyRating"
-          },
-          "description": "Ratings for safety of the input. There is at most one rating per category.",
-          "type": "array"
-        }
-      },
-      "description": "Feedback related to the input data used to answer the question, as opposed to model-generated response to the question."
-    },
-    "CountTokensRequest": {
-      "type": "object",
-      "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`.",
-      "properties": {
-        "generateContentRequest": {
-          "description": "Optional. The overall input given to the model. CountTokens will count prompt, function calling, etc.",
-          "$ref": "GenerateContentRequest"
-        },
-        "contents": {
-          "type": "array",
-          "description": "Optional. The input given to the model as a prompt.",
-          "items": {
-            "$ref": "Content"
-          }
-        }
-      },
-      "id": "CountTokensRequest"
-    },
-    "Hyperparameters": {
-      "properties": {
-        "learningRateMultiplier": {
           "type": "number",
-          "description": "Optional. Immutable. The learning rate multiplier is used to calculate a final learning_rate based on the default (recommended) value. Actual learning rate := learning_rate_multiplier * default learning rate Default learning rate is dependent on base model and dataset size. If not set, a default of 1.0 will be used.",
-          "format": "float"
+          "description": "Optional. Controls the randomness of the output. Values can range over `[0.0,1.0]`, inclusive. A value closer to `1.0` will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model. This value specifies default to be the one used by the base model while creating the model."
         },
-        "epochCount": {
-          "type": "integer",
-          "description": "Immutable. The number of training epochs. An epoch is one pass through the training data. If not set, a default of 5 will be used.",
-          "format": "int32"
-        },
-        "batchSize": {
-          "description": "Immutable. The batch size hyperparameter for tuning. If not set, a default of 4 or 16 will be used based on the number of training examples.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "learningRate": {
-          "type": "number",
-          "format": "float",
-          "description": "Optional. Immutable. The learning rate hyperparameter for tuning. If not set, a default of 0.001 or 0.0002 will be calculated based on the number of training examples."
-        }
-      },
-      "id": "Hyperparameters",
-      "type": "object",
-      "description": "Hyperparameters controlling the tuning process. Read more at https://ai.google.dev/docs/model_tuning_guidance"
-    },
-    "CitationSource": {
-      "id": "CitationSource",
-      "properties": {
-        "uri": {
-          "type": "string",
-          "description": "Optional. URI that is attributed as a source for a portion of the text."
-        },
-        "startIndex": {
-          "type": "integer",
-          "description": "Optional. Start of segment of the response that is attributed to this source. Index indicates the start of the segment, measured in bytes.",
-          "format": "int32"
-        },
-        "endIndex": {
-          "format": "int32",
-          "type": "integer",
-          "description": "Optional. End of the attributed segment, exclusive."
-        },
-        "license": {
-          "type": "string",
-          "description": "Optional. License for the GitHub project that is attributed as a source for segment. License info is required for code citations."
-        }
-      },
-      "type": "object",
-      "description": "A citation to a source for a portion of a specific response."
-    },
-    "DeleteChunkRequest": {
-      "id": "DeleteChunkRequest",
-      "type": "object",
-      "properties": {
-        "name": {
-          "description": "Required. The resource name of the `Chunk` to delete. Example: `corpora/my-corpus-123/documents/the-doc-abc/chunks/some-chunk`",
-          "type": "string"
-        }
-      },
-      "description": "Request to delete a `Chunk`."
-    },
-    "Status": {
-      "id": "Status",
-      "type": "object",
-      "description": "The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).",
-      "properties": {
-        "details": {
-          "items": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "any",
-              "description": "Properties of the object. Contains field @type with type URL."
-            }
-          },
-          "description": "A list of messages that carry the error details. There is a common set of message types for APIs to use.",
-          "type": "array"
-        },
-        "message": {
-          "type": "string",
-          "description": "A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client."
-        },
-        "code": {
-          "type": "integer",
-          "format": "int32",
-          "description": "The status code, which should be an enum value of google.rpc.Code."
-        }
-      }
-    },
-    "FileData": {
-      "description": "URI based data.",
-      "properties": {
-        "mimeType": {
-          "type": "string",
-          "description": "Optional. The IANA standard MIME type of the source data."
-        },
-        "fileUri": {
-          "type": "string",
-          "description": "Required. URI."
-        }
-      },
-      "type": "object",
-      "id": "FileData"
-    },
-    "ToolConfig": {
-      "description": "The Tool configuration containing parameters for specifying `Tool` use in the request.",
-      "type": "object",
-      "properties": {
-        "functionCallingConfig": {
-          "description": "Optional. Function calling config.",
-          "$ref": "FunctionCallingConfig"
-        }
-      },
-      "id": "ToolConfig"
-    },
-    "CountTextTokensResponse": {
-      "id": "CountTextTokensResponse",
-      "properties": {
-        "tokenCount": {
-          "format": "int32",
-          "description": "The number of tokens that the `model` tokenizes the `prompt` into. Always non-negative.",
-          "type": "integer"
-        }
-      },
-      "type": "object",
-      "description": "A response from `CountTextTokens`. It returns the model's `token_count` for the `prompt`."
-    },
-    "Dataset": {
-      "type": "object",
-      "id": "Dataset",
-      "properties": {
-        "examples": {
-          "$ref": "TuningExamples",
-          "description": "Optional. Inline examples."
-        }
-      },
-      "description": "Dataset for training or validation."
-    },
-    "TuningSnapshot": {
-      "description": "Record for a single tuning step.",
-      "properties": {
-        "epoch": {
-          "format": "int32",
-          "description": "Output only. The epoch this step was part of.",
-          "type": "integer",
-          "readOnly": true
-        },
-        "step": {
-          "type": "integer",
-          "description": "Output only. The tuning step.",
-          "readOnly": true,
-          "format": "int32"
-        },
-        "computeTime": {
-          "description": "Output only. The timestamp when this metric was computed.",
-          "readOnly": true,
-          "type": "string",
-          "format": "google-datetime"
-        },
-        "meanLoss": {
-          "type": "number",
-          "description": "Output only. The mean loss of the training examples for this step.",
-          "format": "float",
-          "readOnly": true
-        }
-      },
-      "id": "TuningSnapshot",
-      "type": "object"
-    },
-    "FunctionDeclaration": {
-      "type": "object",
-      "description": "Structured representation of a function declaration as defined by the [OpenAPI 3.03 specification](https://spec.openapis.org/oas/v3.0.3). Included in this declaration are the function name and parameters. This FunctionDeclaration is a representation of a block of code that can be used as a `Tool` by the model and executed by the client.",
-      "properties": {
         "description": {
           "type": "string",
-          "description": "Required. A brief description of the function."
+          "description": "Optional. A short description of this model."
         },
-        "parameters": {
-          "description": "Optional. Describes the parameters to this function. Reflects the Open API 3.03 Parameter Object string Key: the name of the parameter. Parameter names are case sensitive. Schema Value: the Schema defining the type used for the parameter.",
-          "$ref": "Schema"
+        "topP": {
+          "description": "Optional. For Nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`. This value specifies default to be the one used by the base model while creating the model.",
+          "type": "number",
+          "format": "float"
         },
-        "name": {
-          "type": "string",
-          "description": "Required. The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
-        }
-      },
-      "id": "FunctionDeclaration"
-    },
-    "CreateChunkRequest": {
-      "type": "object",
-      "properties": {
-        "parent": {
-          "description": "Required. The name of the `Document` where this `Chunk` will be created. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
-          "type": "string"
-        },
-        "chunk": {
-          "$ref": "Chunk",
-          "description": "Required. The `Chunk` to create."
-        }
-      },
-      "id": "CreateChunkRequest",
-      "description": "Request to create a `Chunk`."
-    },
-    "TuningTask": {
-      "properties": {
-        "startTime": {
-          "format": "google-datetime",
-          "description": "Output only. The timestamp when tuning this model started.",
-          "type": "string",
-          "readOnly": true
-        },
-        "trainingData": {
-          "description": "Required. Input only. Immutable. The model training data.",
-          "$ref": "Dataset"
-        },
-        "snapshots": {
-          "type": "array",
-          "readOnly": true,
-          "items": {
-            "$ref": "TuningSnapshot"
-          },
-          "description": "Output only. Metrics collected during tuning."
-        },
-        "completeTime": {
-          "format": "google-datetime",
-          "readOnly": true,
-          "description": "Output only. The timestamp when tuning this model completed.",
-          "type": "string"
-        },
-        "hyperparameters": {
-          "$ref": "Hyperparameters",
-          "description": "Immutable. Hyperparameters controlling the tuning process. If not provided, default values will be used."
-        }
-      },
-      "id": "TuningTask",
-      "description": "Tuning tasks that create tuned models.",
-      "type": "object"
-    },
-    "EmbedTextResponse": {
-      "properties": {
-        "embedding": {
-          "description": "Output only. The embedding generated from the input text.",
-          "$ref": "Embedding",
-          "readOnly": true
-        }
-      },
-      "description": "The response to a EmbedTextRequest.",
-      "type": "object",
-      "id": "EmbedTextResponse"
-    },
-    "TuningExamples": {
-      "description": "A set of tuning examples. Can be training or validation data.",
-      "type": "object",
-      "id": "TuningExamples",
-      "properties": {
-        "examples": {
-          "description": "Required. The examples. Example input can be for text or discuss, but all examples in a set must be of the same type.",
-          "items": {
-            "$ref": "TuningExample"
-          },
-          "type": "array"
-        }
-      }
-    },
-    "CountMessageTokensResponse": {
-      "description": "A response from `CountMessageTokens`. It returns the model's `token_count` for the `prompt`.",
-      "id": "CountMessageTokensResponse",
-      "properties": {
-        "tokenCount": {
+        "topK": {
           "format": "int32",
-          "type": "integer",
-          "description": "The number of tokens that the `model` tokenizes the `prompt` into. Always non-negative."
-        }
-      },
-      "type": "object"
-    },
-    "TunedModelSource": {
-      "id": "TunedModelSource",
-      "description": "Tuned model as a source for training a new model.",
-      "properties": {
+          "description": "Optional. For Top-k sampling. Top-k sampling considers the set of `top_k` most probable tokens. This value specifies default to be used by the backend while making the call to the model. This value specifies default to be the one used by the base model while creating the model.",
+          "type": "integer"
+        },
         "baseModel": {
-          "description": "Output only. The name of the base `Model` this `TunedModel` was tuned from. Example: `models/text-bison-001`",
-          "readOnly": true,
-          "type": "string"
-        },
-        "tunedModel": {
           "type": "string",
-          "description": "Immutable. The name of the `TunedModel` to use as the starting point for training the new model. Example: `tunedModels/my-tuned-model`"
-        }
-      },
-      "type": "object"
-    },
-    "ListModelsResponse": {
-      "type": "object",
-      "id": "ListModelsResponse",
-      "description": "Response from `ListModel` containing a paginated list of Models.",
-      "properties": {
-        "nextPageToken": {
-          "type": "string",
-          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
+          "description": "Immutable. The name of the `Model` to tune. Example: `models/text-bison-001`"
         },
-        "models": {
-          "items": {
-            "$ref": "Model"
-          },
-          "type": "array",
-          "description": "The returned Models."
-        }
-      }
-    },
-    "Blob": {
-      "properties": {
-        "data": {
-          "format": "byte",
-          "description": "Raw bytes for media formats.",
-          "type": "string"
-        },
-        "mimeType": {
-          "description": "The IANA standard MIME type of the source data. Examples: - image/png - image/jpeg If an unsupported MIME type is provided, an error will be returned. For a complete list of supported types, see [Supported file formats](https://ai.google.dev/gemini-api/docs/prompting_with_media#supported_file_formats).",
-          "type": "string"
+        "tunedModelSource": {
+          "description": "Optional. TunedModel to use as the starting point for training the new model.",
+          "$ref": "TunedModelSource"
         }
       },
-      "id": "Blob",
+      "description": "A fine-tuned model created using ModelService.CreateTunedModel.",
       "type": "object",
-      "description": "Raw media bytes. Text should not be sent as raw bytes, use the 'text' field."
-    },
-    "CountMessageTokensRequest": {
-      "properties": {
-        "prompt": {
-          "description": "Required. The prompt, whose token count is to be returned.",
-          "$ref": "MessagePrompt"
-        }
-      },
-      "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`.",
-      "type": "object",
-      "id": "CountMessageTokensRequest"
-    },
-    "UpdateChunkRequest": {
-      "type": "object",
-      "description": "Request to update a `Chunk`.",
-      "id": "UpdateChunkRequest",
-      "properties": {
-        "chunk": {
-          "$ref": "Chunk",
-          "description": "Required. The `Chunk` to update."
-        },
-        "updateMask": {
-          "format": "google-fieldmask",
-          "description": "Required. The list of fields to update. Currently, this only supports updating `custom_metadata` and `data`.",
-          "type": "string"
-        }
-      }
-    },
-    "StringList": {
-      "id": "StringList",
-      "properties": {
-        "values": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "The string values of the metadata to store."
-        }
-      },
-      "type": "object",
-      "description": "User provided string values assigned to a single metadata key."
+      "id": "TunedModel"
     },
     "BatchCreateChunksRequest": {
+      "type": "object",
       "properties": {
         "requests": {
           "type": "array",
@@ -3731,69 +2100,53 @@
         }
       },
       "id": "BatchCreateChunksRequest",
-      "description": "Request to batch create `Chunk`s.",
-      "type": "object"
+      "description": "Request to batch create `Chunk`s."
     },
-    "Corpus": {
-      "type": "object",
-      "id": "Corpus",
+    "ChunkData": {
       "properties": {
-        "displayName": {
-          "type": "string",
-          "description": "Optional. The human-readable display name for the `Corpus`. The display name must be no more than 512 characters in length, including spaces. Example: \"Docs on Semantic Retriever\""
-        },
-        "name": {
-          "description": "Immutable. Identifier. The `Corpus` resource name. The ID (name excluding the \"corpora/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/my-awesome-corpora-123a456b789c`",
-          "type": "string"
-        },
-        "createTime": {
-          "format": "google-datetime",
-          "readOnly": true,
-          "description": "Output only. The Timestamp of when the `Corpus` was created.",
-          "type": "string"
-        },
-        "updateTime": {
-          "format": "google-datetime",
-          "description": "Output only. The Timestamp of when the `Corpus` was last updated.",
-          "readOnly": true,
+        "stringValue": {
+          "description": "The `Chunk` content as a string. The maximum number of tokens per chunk is 2043.",
           "type": "string"
         }
       },
-      "description": "A `Corpus` is a collection of `Document`s. A project can create up to 5 corpora."
-    },
-    "BatchEmbedContentsRequest": {
-      "description": "Batch request to get embeddings from the model for a list of prompts.",
-      "id": "BatchEmbedContentsRequest",
       "type": "object",
-      "properties": {
-        "requests": {
-          "type": "array",
-          "items": {
-            "$ref": "EmbedContentRequest"
-          },
-          "description": "Required. Embed requests for the batch. The model in each of these requests must match the model specified `BatchEmbedContentsRequest.model`."
-        }
-      }
+      "description": "Extracted data that represents the `Chunk` content.",
+      "id": "ChunkData"
     },
-    "BatchEmbedContentsResponse": {
-      "description": "The response to a `BatchEmbedContentsRequest`.",
-      "type": "object",
-      "id": "BatchEmbedContentsResponse",
+    "FunctionCallingConfig": {
       "properties": {
-        "embeddings": {
+        "mode": {
+          "enum": [
+            "MODE_UNSPECIFIED",
+            "AUTO",
+            "ANY",
+            "NONE"
+          ],
+          "description": "Optional. Specifies the mode in which function calling should execute. If unspecified, the default value will be set to AUTO.",
+          "type": "string",
+          "enumDescriptions": [
+            "Unspecified function calling mode. This value should not be used.",
+            "Default model behavior, model decides to predict either a function call or a natural language repspose.",
+            "Model is constrained to always predicting a function call only. If \"allowed_function_names\" are set, the predicted function call will be limited to any one of \"allowed_function_names\", else the predicted function call will be any one of the provided \"function_declarations\".",
+            "Model will not predict any function call. Model behavior is same as when not passing any function declarations."
+          ]
+        },
+        "allowedFunctionNames": {
+          "description": "Optional. A set of function names that, when provided, limits the functions the model will call. This should only be set when the Mode is ANY. Function names should match [FunctionDeclaration.name]. With mode set to ANY, model will predict a function call from the set of function names provided.",
           "items": {
-            "$ref": "ContentEmbedding"
+            "type": "string"
           },
-          "description": "Output only. The embeddings for each request, in the same order as provided in the batch request.",
-          "readOnly": true,
           "type": "array"
         }
-      }
+      },
+      "description": "Configuration for specifying function calling behavior.",
+      "id": "FunctionCallingConfig",
+      "type": "object"
     },
     "SafetySetting": {
-      "type": "object",
-      "description": "Safety setting, affecting the safety-blocking behavior. Passing a safety setting for a category changes the allowed proability that content is blocked.",
       "id": "SafetySetting",
+      "description": "Safety setting, affecting the safety-blocking behavior. Passing a safety setting for a category changes the allowed probability that content is blocked.",
+      "type": "object",
       "properties": {
         "category": {
           "description": "Required. The category for this setting.",
@@ -3826,14 +2179,6 @@
           ]
         },
         "threshold": {
-          "description": "Required. Controls the probability threshold at which harm is blocked.",
-          "enum": [
-            "HARM_BLOCK_THRESHOLD_UNSPECIFIED",
-            "BLOCK_LOW_AND_ABOVE",
-            "BLOCK_MEDIUM_AND_ABOVE",
-            "BLOCK_ONLY_HIGH",
-            "BLOCK_NONE"
-          ],
           "type": "string",
           "enumDescriptions": [
             "Threshold is unspecified.",
@@ -3841,186 +2186,1867 @@
             "Content with NEGLIGIBLE and LOW will be allowed.",
             "Content with NEGLIGIBLE, LOW, and MEDIUM will be allowed.",
             "All content will be allowed."
-          ]
+          ],
+          "enum": [
+            "HARM_BLOCK_THRESHOLD_UNSPECIFIED",
+            "BLOCK_LOW_AND_ABOVE",
+            "BLOCK_MEDIUM_AND_ABOVE",
+            "BLOCK_ONLY_HIGH",
+            "BLOCK_NONE"
+          ],
+          "description": "Required. Controls the probability threshold at which harm is blocked."
         }
       }
     },
-    "CountTokensResponse": {
+    "Document": {
       "properties": {
-        "totalTokens": {
-          "type": "integer",
-          "description": "The number of tokens that the `model` tokenizes the `prompt` into. Always non-negative.",
-          "format": "int32"
+        "name": {
+          "type": "string",
+          "description": "Immutable. Identifier. The `Document` resource name. The ID (name excluding the \"corpora/*/documents/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/{corpus_id}/documents/my-awesome-doc-123a456b789c`"
+        },
+        "displayName": {
+          "description": "Optional. The human-readable display name for the `Document`. The display name must be no more than 512 characters in length, including spaces. Example: \"Semantic Retriever Documentation\"",
+          "type": "string"
+        },
+        "customMetadata": {
+          "description": "Optional. User provided custom metadata stored as key-value pairs used for querying. A `Document` can have a maximum of 20 `CustomMetadata`.",
+          "type": "array",
+          "items": {
+            "$ref": "CustomMetadata"
+          }
+        },
+        "createTime": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Output only. The Timestamp of when the `Document` was created.",
+          "format": "google-datetime"
+        },
+        "updateTime": {
+          "readOnly": true,
+          "format": "google-datetime",
+          "type": "string",
+          "description": "Output only. The Timestamp of when the `Document` was last updated."
         }
       },
+      "description": "A `Document` is a collection of `Chunk`s. A `Corpus` can have a maximum of 10,000 `Document`s.",
       "type": "object",
-      "id": "CountTokensResponse",
-      "description": "A response from `CountTokens`. It returns the model's `token_count` for the `prompt`."
+      "id": "Document"
     },
-    "CreateFileRequest": {
+    "FunctionResponse": {
+      "id": "FunctionResponse",
       "properties": {
-        "file": {
-          "description": "Optional. Metadata for the file to create.",
-          "$ref": "File"
+        "name": {
+          "type": "string",
+          "description": "Required. The name of the function to call. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
+        },
+        "response": {
+          "description": "Required. The function response in JSON object format.",
+          "additionalProperties": {
+            "type": "any",
+            "description": "Properties of the object."
+          },
+          "type": "object"
         }
       },
-      "id": "CreateFileRequest",
-      "description": "Request for `CreateFile`.",
+      "description": "The result output from a `FunctionCall` that contains a string representing the `FunctionDeclaration.name` and a structured JSON object containing any output from the function is used as context to the model. This should contain the result of a`FunctionCall` made based on model prediction.",
       "type": "object"
     },
-    "ChunkData": {
-      "id": "ChunkData",
-      "type": "object",
-      "description": "Extracted data that represents the `Chunk` content.",
+    "BatchEmbedContentsResponse": {
       "properties": {
-        "stringValue": {
-          "type": "string",
-          "description": "The `Chunk` content as a string. The maximum number of tokens per chunk is 2043."
-        }
-      }
-    },
-    "BatchDeleteChunksRequest": {
-      "id": "BatchDeleteChunksRequest",
-      "type": "object",
-      "properties": {
-        "requests": {
+        "embeddings": {
+          "readOnly": true,
           "type": "array",
-          "description": "Required. The request messages specifying the `Chunk`s to delete.",
+          "description": "Output only. The embeddings for each request, in the same order as provided in the batch request.",
           "items": {
-            "$ref": "DeleteChunkRequest"
+            "$ref": "ContentEmbedding"
           }
         }
       },
-      "description": "Request to batch delete `Chunk`s."
-    },
-    "SemanticRetrieverConfig": {
+      "id": "BatchEmbedContentsResponse",
       "type": "object",
+      "description": "The response to a `BatchEmbedContentsRequest`."
+    },
+    "TunedModelSource": {
+      "id": "TunedModelSource",
+      "description": "Tuned model as a source for training a new model.",
       "properties": {
-        "minimumRelevanceScore": {
-          "type": "number",
-          "description": "Optional. Minimum relevance score for retrieved relevant `Chunk`s.",
-          "format": "float"
-        },
-        "source": {
-          "description": "Required. Name of the resource for retrieval, e.g. corpora/123 or corpora/123/documents/abc.",
+        "baseModel": {
+          "description": "Output only. The name of the base `Model` this `TunedModel` was tuned from. Example: `models/text-bison-001`",
+          "readOnly": true,
           "type": "string"
         },
-        "maxChunksCount": {
-          "format": "int32",
-          "description": "Optional. Maximum number of relevant `Chunk`s to retrieve.",
-          "type": "integer"
-        },
-        "metadataFilters": {
+        "tunedModel": {
+          "type": "string",
+          "description": "Immutable. The name of the `TunedModel` to use as the starting point for training the new model. Example: `tunedModels/my-tuned-model`"
+        }
+      },
+      "type": "object"
+    },
+    "Tool": {
+      "properties": {
+        "functionDeclarations": {
           "type": "array",
           "items": {
-            "$ref": "MetadataFilter"
+            "$ref": "FunctionDeclaration"
           },
-          "description": "Optional. Filters for selecting `Document`s and/or `Chunk`s from the resource."
-        },
-        "query": {
-          "$ref": "Content",
-          "description": "Required. Query to use for similarity matching `Chunk`s in the given resource."
+          "description": "Optional. A list of `FunctionDeclarations` available to the model that can be used for function calling. The model or system does not execute the function. Instead the defined function may be returned as a FunctionCall with arguments to the client side for execution. The model may decide to call a subset of these functions by populating FunctionCall in the response. The next conversation turn may contain a FunctionResponse with the [content.role] \"function\" generation context for the next model turn."
         }
       },
-      "description": "Configuration for retrieving grounding content from a `Corpus` or `Document` created using the Semantic Retriever API.",
-      "id": "SemanticRetrieverConfig"
-    },
-    "AttributionSourceId": {
+      "id": "Tool",
       "type": "object",
-      "description": "Identifier for the source contributing to this attribution.",
+      "description": "Tool details that the model may use to generate response. A `Tool` is a piece of code that enables the system to interact with external systems to perform an action, or set of actions, outside of knowledge and scope of the model."
+    },
+    "CountTokensResponse": {
+      "type": "object",
       "properties": {
-        "semanticRetrieverChunk": {
-          "description": "Identifier for a `Chunk` fetched via Semantic Retriever.",
-          "$ref": "SemanticRetrieverChunk"
-        },
-        "groundingPassage": {
-          "description": "Identifier for an inline passage.",
-          "$ref": "GroundingPassageId"
+        "totalTokens": {
+          "description": "The number of tokens that the `model` tokenizes the `prompt` into. Always non-negative.",
+          "type": "integer",
+          "format": "int32"
         }
       },
-      "id": "AttributionSourceId"
+      "description": "A response from `CountTokens`. It returns the model's `token_count` for the `prompt`.",
+      "id": "CountTokensResponse"
     },
-    "Message": {
-      "description": "The base unit of structured text. A `Message` includes an `author` and the `content` of the `Message`. The `author` is used to tag messages when they are fed to the model as text.",
-      "id": "Message",
+    "FileData": {
+      "id": "FileData",
       "type": "object",
       "properties": {
-        "citationMetadata": {
-          "$ref": "CitationMetadata",
+        "fileUri": {
+          "type": "string",
+          "description": "Required. URI."
+        },
+        "mimeType": {
+          "type": "string",
+          "description": "Optional. The IANA standard MIME type of the source data."
+        }
+      },
+      "description": "URI based data."
+    },
+    "SemanticRetrieverChunk": {
+      "type": "object",
+      "description": "Identifier for a `Chunk` retrieved via Semantic Retriever specified in the `GenerateAnswerRequest` using `SemanticRetrieverConfig`.",
+      "id": "SemanticRetrieverChunk",
+      "properties": {
+        "chunk": {
           "readOnly": true,
-          "description": "Output only. Citation information for model-generated `content` in this `Message`. If this `Message` was generated as output from the model, this field may be populated with attribution information for any text included in the `content`. This field is used only on output."
-        },
-        "content": {
           "type": "string",
-          "description": "Required. The text content of the structured `Message`."
+          "description": "Output only. Name of the `Chunk` containing the attributed text. Example: `corpora/123/documents/abc/chunks/xyz`"
         },
-        "author": {
+        "source": {
+          "readOnly": true,
           "type": "string",
-          "description": "Optional. The author of this Message. This serves as a key for tagging the content of this Message when it is fed to the model as text. The author can be any alphanumeric string."
+          "description": "Output only. Name of the source matching the request's `SemanticRetrieverConfig.source`. Example: `corpora/123` or `corpora/123/documents/abc`"
         }
       }
     },
-    "GenerationConfig": {
-      "type": "object",
-      "description": "Configuration options for model generation and outputs. Not all parameters may be configurable for every model.",
+    "TuningSnapshot": {
+      "description": "Record for a single tuning step.",
       "properties": {
-        "responseMimeType": {
+        "meanLoss": {
+          "description": "Output only. The mean loss of the training examples for this step.",
+          "readOnly": true,
+          "type": "number",
+          "format": "float"
+        },
+        "epoch": {
+          "readOnly": true,
+          "type": "integer",
+          "format": "int32",
+          "description": "Output only. The epoch this step was part of."
+        },
+        "computeTime": {
+          "description": "Output only. The timestamp when this metric was computed.",
+          "readOnly": true,
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "step": {
+          "format": "int32",
+          "type": "integer",
+          "readOnly": true,
+          "description": "Output only. The tuning step."
+        }
+      },
+      "id": "TuningSnapshot",
+      "type": "object"
+    },
+    "ToolConfig": {
+      "type": "object",
+      "id": "ToolConfig",
+      "properties": {
+        "functionCallingConfig": {
+          "$ref": "FunctionCallingConfig",
+          "description": "Optional. Function calling config."
+        }
+      },
+      "description": "The Tool configuration containing parameters for specifying `Tool` use in the request."
+    },
+    "CountTextTokensRequest": {
+      "properties": {
+        "prompt": {
+          "description": "Required. The free-form input text given to the model as a prompt.",
+          "$ref": "TextPrompt"
+        }
+      },
+      "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`.",
+      "type": "object",
+      "id": "CountTextTokensRequest"
+    },
+    "Model": {
+      "properties": {
+        "displayName": {
+          "description": "The human-readable name of the model. E.g. \"Chat Bison\". The name can be up to 128 characters long and can consist of any UTF-8 characters.",
+          "type": "string"
+        },
+        "name": {
           "type": "string",
-          "description": "Optional. Output response mimetype of the generated candidate text. Supported mimetype: `text/plain`: (default) Text output. `application/json`: JSON response in the candidates."
+          "description": "Required. The resource name of the `Model`. Format: `models/{model}` with a `{model}` naming convention of: * \"{base_model_id}-{version}\" Examples: * `models/chat-bison-001`"
+        },
+        "outputTokenLimit": {
+          "format": "int32",
+          "description": "Maximum number of output tokens available for this model.",
+          "type": "integer"
         },
         "topP": {
-          "format": "float",
           "type": "number",
-          "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Tokens are sorted based on their assigned probabilities so that only the most likely tokens are considered. Top-k sampling directly limits the maximum number of tokens to consider, while Nucleus sampling limits number of tokens based on the cumulative probability. Note: The default value varies by model, see the `Model.top_p` attribute of the `Model` returned from the `getModel` function."
+          "description": "For Nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`. This value specifies default to be used by the backend while making the call to the model.",
+          "format": "float"
         },
-        "stopSequences": {
-          "type": "array",
+        "baseModelId": {
+          "type": "string",
+          "description": "Required. The name of the base model, pass this to the generation request. Examples: * `chat-bison`"
+        },
+        "inputTokenLimit": {
+          "format": "int32",
+          "description": "Maximum number of input tokens allowed for this model.",
+          "type": "integer"
+        },
+        "version": {
+          "type": "string",
+          "description": "Required. The version number of the model. This represents the major version"
+        },
+        "supportedGenerationMethods": {
           "items": {
             "type": "string"
           },
-          "description": "Optional. The set of character sequences (up to 5) that will stop output generation. If specified, the API will stop at the first appearance of a stop sequence. The stop sequence will not be included as part of the response."
+          "type": "array",
+          "description": "The model's supported generation methods. The method names are defined as Pascal case strings, such as `generateMessage` which correspond to API methods."
         },
         "topK": {
+          "description": "For Top-k sampling. Top-k sampling considers the set of `top_k` most probable tokens. This value specifies default to be used by the backend while making the call to the model. If empty, indicates the model doesn't use top-k sampling, and `top_k` isn't allowed as a generation parameter.",
           "format": "int32",
-          "description": "Optional. The maximum number of tokens to consider when sampling. Models use nucleus sampling or combined Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens. Models running with nucleus sampling don't allow top_k setting. Note: The default value varies by model, see the `Model.top_k` attribute of the `Model` returned from the `getModel` function. Empty `top_k` field in `Model` indicates the model doesn't apply top-k sampling and doesn't allow setting `top_k` on requests.",
           "type": "integer"
         },
-        "maxOutputTokens": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Optional. The maximum number of tokens to include in a candidate. Note: The default value varies by model, see the `Model.output_token_limit` attribute of the `Model` returned from the `getModel` function."
-        },
-        "candidateCount": {
-          "description": "Optional. Number of generated responses to return. Currently, this value can only be set to 1. If unset, this will default to 1.",
-          "type": "integer",
-          "format": "int32"
+        "description": {
+          "type": "string",
+          "description": "A short description of the model."
         },
         "temperature": {
+          "description": "Controls the randomness of the output. Values can range over `[0.0,1.0]`, inclusive. A value closer to `1.0` will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model. This value specifies default to be used by the backend while making the call to the model.",
           "format": "float",
-          "description": "Optional. Controls the randomness of the output. Note: The default value varies by model, see the `Model.temperature` attribute of the `Model` returned from the `getModel` function. Values can range from [0.0, 2.0].",
           "type": "number"
         }
       },
-      "id": "GenerationConfig"
+      "type": "object",
+      "id": "Model",
+      "description": "Information about a Generative Language Model."
+    },
+    "MetadataFilter": {
+      "properties": {
+        "conditions": {
+          "items": {
+            "$ref": "Condition"
+          },
+          "description": "Required. The `Condition`s for the given key that will trigger this filter. Multiple `Condition`s are joined by logical ORs.",
+          "type": "array"
+        },
+        "key": {
+          "description": "Required. The key of the metadata to filter on.",
+          "type": "string"
+        }
+      },
+      "id": "MetadataFilter",
+      "description": "User provided filter to limit retrieval based on `Chunk` or `Document` level metadata values. Example (genre = drama OR genre = action): key = \"document.custom_metadata.genre\" conditions = [{string_value = \"drama\", operation = EQUAL}, {string_value = \"action\", operation = EQUAL}]",
+      "type": "object"
+    },
+    "GroundingPassageId": {
+      "properties": {
+        "passageId": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Output only. ID of the passage matching the `GenerateAnswerRequest`'s `GroundingPassage.id`."
+        },
+        "partIndex": {
+          "description": "Output only. Index of the part within the `GenerateAnswerRequest`'s `GroundingPassage.content`.",
+          "type": "integer",
+          "format": "int32",
+          "readOnly": true
+        }
+      },
+      "description": "Identifier for a part within a `GroundingPassage`.",
+      "id": "GroundingPassageId",
+      "type": "object"
     }
   },
-  "ownerName": "Google",
+  "parameters": {
+    "quotaUser": {
+      "type": "string",
+      "location": "query",
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters."
+    },
+    "$.xgafv": {
+      "type": "string",
+      "enum": [
+        "1",
+        "2"
+      ],
+      "enumDescriptions": [
+        "v1 error format",
+        "v2 error format"
+      ],
+      "description": "V1 error format.",
+      "location": "query"
+    },
+    "fields": {
+      "type": "string",
+      "location": "query",
+      "description": "Selector specifying which fields to include in a partial response."
+    },
+    "upload_protocol": {
+      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
+      "type": "string",
+      "location": "query"
+    },
+    "oauth_token": {
+      "type": "string",
+      "description": "OAuth 2.0 token for the current user.",
+      "location": "query"
+    },
+    "prettyPrint": {
+      "location": "query",
+      "default": "true",
+      "type": "boolean",
+      "description": "Returns response with indentations and line breaks."
+    },
+    "callback": {
+      "description": "JSONP",
+      "location": "query",
+      "type": "string"
+    },
+    "access_token": {
+      "location": "query",
+      "type": "string",
+      "description": "OAuth access token."
+    },
+    "key": {
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "location": "query",
+      "type": "string"
+    },
+    "uploadType": {
+      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+      "location": "query",
+      "type": "string"
+    },
+    "alt": {
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json",
+        "Media download with context-dependent Content-Type",
+        "Responses with Content-Type of application/x-protobuf"
+      ],
+      "default": "json",
+      "description": "Data format for response.",
+      "location": "query",
+      "enum": [
+        "json",
+        "media",
+        "proto"
+      ],
+      "type": "string"
+    }
+  },
+  "servicePath": "",
+  "id": "generativelanguage:v1beta",
+  "revision": "20240524",
   "documentationLink": "https://developers.generativeai.google/api",
+  "fullyEncodeReservedExpansion": true,
+  "rootUrl": "https://generativelanguage.googleapis.com/",
   "batchPath": "batch",
   "canonicalName": "Generative Language",
-  "protocol": "rest",
-  "rootUrl": "https://generativelanguage.googleapis.com/",
-  "servicePath": "",
-  "version": "v1beta",
   "ownerDomain": "google.com",
-  "revision": "20240508",
-  "discoveryVersion": "v1",
-  "id": "generativelanguage:v1beta",
-  "kind": "discovery#restDescription",
-  "title": "Generative Language API",
-  "name": "generativelanguage",
-  "icons": {
-    "x32": "http://www.google.com/images/icons/product/search-32.gif",
-    "x16": "http://www.google.com/images/icons/product/search-16.gif"
-  }
+  "baseUrl": "https://generativelanguage.googleapis.com/",
+  "mtlsRootUrl": "https://generativelanguage.mtls.googleapis.com/",
+  "resources": {
+    "tunedModels": {
+      "methods": {
+        "get": {
+          "id": "generativelanguage.tunedModels.get",
+          "parameterOrder": [
+            "name"
+          ],
+          "description": "Gets information about a specific TunedModel.",
+          "parameters": {
+            "name": {
+              "required": true,
+              "description": "Required. The resource name of the model. Format: `tunedModels/my-model-id`",
+              "pattern": "^tunedModels/[^/]+$",
+              "type": "string",
+              "location": "path"
+            }
+          },
+          "flatPath": "v1beta/tunedModels/{tunedModelsId}",
+          "response": {
+            "$ref": "TunedModel"
+          },
+          "path": "v1beta/{+name}",
+          "httpMethod": "GET"
+        },
+        "transferOwnership": {
+          "path": "v1beta/{+name}:transferOwnership",
+          "flatPath": "v1beta/tunedModels/{tunedModelsId}:transferOwnership",
+          "request": {
+            "$ref": "TransferOwnershipRequest"
+          },
+          "response": {
+            "$ref": "TransferOwnershipResponse"
+          },
+          "parameterOrder": [
+            "name"
+          ],
+          "description": "Transfers ownership of the tuned model. This is the only way to change ownership of the tuned model. The current owner will be downgraded to writer role.",
+          "id": "generativelanguage.tunedModels.transferOwnership",
+          "parameters": {
+            "name": {
+              "description": "Required. The resource name of the tuned model to transfer ownership. Format: `tunedModels/my-model-id`",
+              "location": "path",
+              "required": true,
+              "type": "string",
+              "pattern": "^tunedModels/[^/]+$"
+            }
+          },
+          "httpMethod": "POST"
+        },
+        "create": {
+          "flatPath": "v1beta/tunedModels",
+          "response": {
+            "$ref": "Operation"
+          },
+          "parameterOrder": [],
+          "id": "generativelanguage.tunedModels.create",
+          "request": {
+            "$ref": "TunedModel"
+          },
+          "parameters": {
+            "tunedModelId": {
+              "type": "string",
+              "location": "query",
+              "description": "Optional. The unique id for the tuned model if specified. This value should be up to 40 characters, the first character must be a letter, the last could be a letter or a number. The id must match the regular expression: [a-z]([a-z0-9-]{0,38}[a-z0-9])?."
+            }
+          },
+          "path": "v1beta/tunedModels",
+          "description": "Creates a tuned model. Intermediate tuning progress (if any) is accessed through the [google.longrunning.Operations] service. Status and results can be accessed through the Operations service. Example: GET /v1/tunedModels/az2mb0bpw6i/operations/000-111-222",
+          "httpMethod": "POST"
+        },
+        "list": {
+          "id": "generativelanguage.tunedModels.list",
+          "description": "Lists tuned models owned by the user.",
+          "response": {
+            "$ref": "ListTunedModelsResponse"
+          },
+          "httpMethod": "GET",
+          "parameters": {
+            "pageToken": {
+              "type": "string",
+              "description": "Optional. A page token, received from a previous `ListTunedModels` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListTunedModels` must match the call that provided the page token.",
+              "location": "query"
+            },
+            "pageSize": {
+              "format": "int32",
+              "description": "Optional. The maximum number of `TunedModels` to return (per page). The service may return fewer tuned models. If unspecified, at most 10 tuned models will be returned. This method returns at most 1000 models per page, even if you pass a larger page_size.",
+              "type": "integer",
+              "location": "query"
+            },
+            "filter": {
+              "type": "string",
+              "location": "query",
+              "description": "Optional. A filter is a full text search over the tuned model's description and display name. By default, results will not include tuned models shared with everyone. Additional operators: - owner:me - writers:me - readers:me - readers:everyone Examples: \"owner:me\" returns all tuned models to which caller has owner role \"readers:me\" returns all tuned models to which caller has reader role \"readers:everyone\" returns all tuned models that are shared with everyone"
+            }
+          },
+          "flatPath": "v1beta/tunedModels",
+          "parameterOrder": [],
+          "path": "v1beta/tunedModels"
+        },
+        "patch": {
+          "httpMethod": "PATCH",
+          "response": {
+            "$ref": "TunedModel"
+          },
+          "path": "v1beta/{+name}",
+          "parameters": {
+            "updateMask": {
+              "description": "Required. The list of fields to update.",
+              "location": "query",
+              "format": "google-fieldmask",
+              "type": "string"
+            },
+            "name": {
+              "description": "Output only. The tuned model name. A unique name will be generated on create. Example: `tunedModels/az2mb0bpw6i` If display_name is set on create, the id portion of the name will be set by concatenating the words of the display_name with hyphens and adding a random portion for uniqueness. Example: display_name = \"Sentence Translator\" name = \"tunedModels/sentence-translator-u3b7m\"",
+              "required": true,
+              "location": "path",
+              "type": "string",
+              "pattern": "^tunedModels/[^/]+$"
+            }
+          },
+          "description": "Updates a tuned model.",
+          "flatPath": "v1beta/tunedModels/{tunedModelsId}",
+          "parameterOrder": [
+            "name"
+          ],
+          "id": "generativelanguage.tunedModels.patch",
+          "request": {
+            "$ref": "TunedModel"
+          }
+        },
+        "generateContent": {
+          "httpMethod": "POST",
+          "response": {
+            "$ref": "GenerateContentResponse"
+          },
+          "request": {
+            "$ref": "GenerateContentRequest"
+          },
+          "parameters": {
+            "model": {
+              "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`.",
+              "location": "path",
+              "required": true,
+              "pattern": "^tunedModels/[^/]+$",
+              "type": "string"
+            }
+          },
+          "flatPath": "v1beta/tunedModels/{tunedModelsId}:generateContent",
+          "description": "Generates a response from the model given an input `GenerateContentRequest`. Input capabilities differ between models, including tuned models. See the [model guide](https://ai.google.dev/models/gemini) and [tuning guide](https://ai.google.dev/docs/model_tuning_guidance) for details.",
+          "parameterOrder": [
+            "model"
+          ],
+          "path": "v1beta/{+model}:generateContent",
+          "id": "generativelanguage.tunedModels.generateContent"
+        },
+        "delete": {
+          "flatPath": "v1beta/tunedModels/{tunedModelsId}",
+          "id": "generativelanguage.tunedModels.delete",
+          "response": {
+            "$ref": "Empty"
+          },
+          "description": "Deletes a tuned model.",
+          "httpMethod": "DELETE",
+          "path": "v1beta/{+name}",
+          "parameters": {
+            "name": {
+              "pattern": "^tunedModels/[^/]+$",
+              "type": "string",
+              "description": "Required. The resource name of the model. Format: `tunedModels/my-model-id`",
+              "location": "path",
+              "required": true
+            }
+          },
+          "parameterOrder": [
+            "name"
+          ]
+        },
+        "generateText": {
+          "path": "v1beta/{+model}:generateText",
+          "parameters": {
+            "model": {
+              "type": "string",
+              "location": "path",
+              "pattern": "^tunedModels/[^/]+$",
+              "required": true,
+              "description": "Required. The name of the `Model` or `TunedModel` to use for generating the completion. Examples: models/text-bison-001 tunedModels/sentence-translator-u3b7m"
+            }
+          },
+          "httpMethod": "POST",
+          "response": {
+            "$ref": "GenerateTextResponse"
+          },
+          "request": {
+            "$ref": "GenerateTextRequest"
+          },
+          "id": "generativelanguage.tunedModels.generateText",
+          "parameterOrder": [
+            "model"
+          ],
+          "description": "Generates a response from the model given an input message.",
+          "flatPath": "v1beta/tunedModels/{tunedModelsId}:generateText"
+        }
+      },
+      "resources": {
+        "permissions": {
+          "methods": {
+            "patch": {
+              "description": "Updates the permission.",
+              "httpMethod": "PATCH",
+              "id": "generativelanguage.tunedModels.permissions.patch",
+              "parameterOrder": [
+                "name"
+              ],
+              "parameters": {
+                "updateMask": {
+                  "format": "google-fieldmask",
+                  "description": "Required. The list of fields to update. Accepted ones: - role (`Permission.role` field)",
+                  "location": "query",
+                  "type": "string"
+                },
+                "name": {
+                  "location": "path",
+                  "description": "Output only. Identifier. The permission name. A unique name will be generated on create. Examples: tunedModels/{tuned_model}/permissions/{permission} corpora/{corpus}/permissions/{permission} Output only.",
+                  "required": true,
+                  "pattern": "^tunedModels/[^/]+/permissions/[^/]+$",
+                  "type": "string"
+                }
+              },
+              "request": {
+                "$ref": "Permission"
+              },
+              "response": {
+                "$ref": "Permission"
+              },
+              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions/{permissionsId}",
+              "path": "v1beta/{+name}"
+            },
+            "delete": {
+              "parameterOrder": [
+                "name"
+              ],
+              "description": "Deletes the permission.",
+              "response": {
+                "$ref": "Empty"
+              },
+              "parameters": {
+                "name": {
+                  "required": true,
+                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
+                  "type": "string",
+                  "pattern": "^tunedModels/[^/]+/permissions/[^/]+$",
+                  "location": "path"
+                }
+              },
+              "path": "v1beta/{+name}",
+              "id": "generativelanguage.tunedModels.permissions.delete",
+              "httpMethod": "DELETE",
+              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions/{permissionsId}"
+            },
+            "list": {
+              "description": "Lists permissions for the specific resource.",
+              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions",
+              "parameters": {
+                "pageSize": {
+                  "type": "integer",
+                  "description": "Optional. The maximum number of `Permission`s to return (per page). The service may return fewer permissions. If unspecified, at most 10 permissions will be returned. This method returns at most 1000 permissions per page, even if you pass larger page_size.",
+                  "format": "int32",
+                  "location": "query"
+                },
+                "pageToken": {
+                  "type": "string",
+                  "location": "query",
+                  "description": "Optional. A page token, received from a previous `ListPermissions` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListPermissions` must match the call that provided the page token."
+                },
+                "parent": {
+                  "pattern": "^tunedModels/[^/]+$",
+                  "required": true,
+                  "type": "string",
+                  "location": "path",
+                  "description": "Required. The parent resource of the permissions. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`"
+                }
+              },
+              "parameterOrder": [
+                "parent"
+              ],
+              "response": {
+                "$ref": "ListPermissionsResponse"
+              },
+              "path": "v1beta/{+parent}/permissions",
+              "id": "generativelanguage.tunedModels.permissions.list",
+              "httpMethod": "GET"
+            },
+            "get": {
+              "response": {
+                "$ref": "Permission"
+              },
+              "parameters": {
+                "name": {
+                  "pattern": "^tunedModels/[^/]+/permissions/[^/]+$",
+                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
+                  "type": "string",
+                  "required": true,
+                  "location": "path"
+                }
+              },
+              "path": "v1beta/{+name}",
+              "httpMethod": "GET",
+              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions/{permissionsId}",
+              "parameterOrder": [
+                "name"
+              ],
+              "id": "generativelanguage.tunedModels.permissions.get",
+              "description": "Gets information about a specific Permission."
+            },
+            "create": {
+              "request": {
+                "$ref": "Permission"
+              },
+              "response": {
+                "$ref": "Permission"
+              },
+              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions",
+              "description": "Create a permission to a specific resource.",
+              "id": "generativelanguage.tunedModels.permissions.create",
+              "path": "v1beta/{+parent}/permissions",
+              "httpMethod": "POST",
+              "parameters": {
+                "parent": {
+                  "required": true,
+                  "description": "Required. The parent resource of the `Permission`. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`",
+                  "type": "string",
+                  "location": "path",
+                  "pattern": "^tunedModels/[^/]+$"
+                }
+              },
+              "parameterOrder": [
+                "parent"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "corpora": {
+      "resources": {
+        "documents": {
+          "resources": {
+            "chunks": {
+              "methods": {
+                "batchCreate": {
+                  "id": "generativelanguage.corpora.documents.chunks.batchCreate",
+                  "request": {
+                    "$ref": "BatchCreateChunksRequest"
+                  },
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks:batchCreate",
+                  "httpMethod": "POST",
+                  "response": {
+                    "$ref": "BatchCreateChunksResponse"
+                  },
+                  "parameters": {
+                    "parent": {
+                      "required": true,
+                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                      "location": "path",
+                      "type": "string",
+                      "description": "Optional. The name of the `Document` where this batch of `Chunk`s will be created. The parent field in every `CreateChunkRequest` must match this value. Example: `corpora/my-corpus-123/documents/the-doc-abc`"
+                    }
+                  },
+                  "path": "v1beta/{+parent}/chunks:batchCreate",
+                  "description": "Batch create `Chunk`s.",
+                  "parameterOrder": [
+                    "parent"
+                  ]
+                },
+                "delete": {
+                  "description": "Deletes a `Chunk`.",
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks/{chunksId}",
+                  "httpMethod": "DELETE",
+                  "id": "generativelanguage.corpora.documents.chunks.delete",
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "parameters": {
+                    "name": {
+                      "pattern": "^corpora/[^/]+/documents/[^/]+/chunks/[^/]+$",
+                      "required": true,
+                      "type": "string",
+                      "description": "Required. The resource name of the `Chunk` to delete. Example: `corpora/my-corpus-123/documents/the-doc-abc/chunks/some-chunk`",
+                      "location": "path"
+                    }
+                  },
+                  "path": "v1beta/{+name}"
+                },
+                "patch": {
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "description": "Updates a `Chunk`.",
+                  "parameters": {
+                    "name": {
+                      "required": true,
+                      "pattern": "^corpora/[^/]+/documents/[^/]+/chunks/[^/]+$",
+                      "description": "Immutable. Identifier. The `Chunk` resource name. The ID (name excluding the \"corpora/*/documents/*/chunks/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a random 12-character unique ID will be generated. Example: `corpora/{corpus_id}/documents/{document_id}/chunks/123a456b789c`",
+                      "location": "path",
+                      "type": "string"
+                    },
+                    "updateMask": {
+                      "description": "Required. The list of fields to update. Currently, this only supports updating `custom_metadata` and `data`.",
+                      "format": "google-fieldmask",
+                      "type": "string",
+                      "location": "query"
+                    }
+                  },
+                  "response": {
+                    "$ref": "Chunk"
+                  },
+                  "id": "generativelanguage.corpora.documents.chunks.patch",
+                  "path": "v1beta/{+name}",
+                  "httpMethod": "PATCH",
+                  "request": {
+                    "$ref": "Chunk"
+                  },
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks/{chunksId}"
+                },
+                "create": {
+                  "description": "Creates a `Chunk`.",
+                  "httpMethod": "POST",
+                  "path": "v1beta/{+parent}/chunks",
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "response": {
+                    "$ref": "Chunk"
+                  },
+                  "parameters": {
+                    "parent": {
+                      "required": true,
+                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                      "location": "path",
+                      "type": "string",
+                      "description": "Required. The name of the `Document` where this `Chunk` will be created. Example: `corpora/my-corpus-123/documents/the-doc-abc`"
+                    }
+                  },
+                  "id": "generativelanguage.corpora.documents.chunks.create",
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks",
+                  "request": {
+                    "$ref": "Chunk"
+                  }
+                },
+                "list": {
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks",
+                  "description": "Lists all `Chunk`s in a `Document`.",
+                  "parameters": {
+                    "pageToken": {
+                      "location": "query",
+                      "type": "string",
+                      "description": "Optional. A page token, received from a previous `ListChunks` call. Provide the `next_page_token` returned in the response as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListChunks` must match the call that provided the page token."
+                    },
+                    "parent": {
+                      "location": "path",
+                      "description": "Required. The name of the `Document` containing `Chunk`s. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
+                      "type": "string",
+                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                      "required": true
+                    },
+                    "pageSize": {
+                      "type": "integer",
+                      "format": "int32",
+                      "location": "query",
+                      "description": "Optional. The maximum number of `Chunk`s to return (per page). The service may return fewer `Chunk`s. If unspecified, at most 10 `Chunk`s will be returned. The maximum size limit is 100 `Chunk`s per page."
+                    }
+                  },
+                  "httpMethod": "GET",
+                  "path": "v1beta/{+parent}/chunks",
+                  "id": "generativelanguage.corpora.documents.chunks.list",
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "response": {
+                    "$ref": "ListChunksResponse"
+                  }
+                },
+                "batchUpdate": {
+                  "id": "generativelanguage.corpora.documents.chunks.batchUpdate",
+                  "path": "v1beta/{+parent}/chunks:batchUpdate",
+                  "description": "Batch update `Chunk`s.",
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks:batchUpdate",
+                  "request": {
+                    "$ref": "BatchUpdateChunksRequest"
+                  },
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "response": {
+                    "$ref": "BatchUpdateChunksResponse"
+                  },
+                  "httpMethod": "POST",
+                  "parameters": {
+                    "parent": {
+                      "description": "Optional. The name of the `Document` containing the `Chunk`s to update. The parent field in every `UpdateChunkRequest` must match this value. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
+                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                      "location": "path",
+                      "required": true,
+                      "type": "string"
+                    }
+                  }
+                },
+                "get": {
+                  "description": "Gets information about a specific `Chunk`.",
+                  "parameters": {
+                    "name": {
+                      "pattern": "^corpora/[^/]+/documents/[^/]+/chunks/[^/]+$",
+                      "required": true,
+                      "type": "string",
+                      "location": "path",
+                      "description": "Required. The name of the `Chunk` to retrieve. Example: `corpora/my-corpus-123/documents/the-doc-abc/chunks/some-chunk`"
+                    }
+                  },
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks/{chunksId}",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "response": {
+                    "$ref": "Chunk"
+                  },
+                  "id": "generativelanguage.corpora.documents.chunks.get",
+                  "httpMethod": "GET",
+                  "path": "v1beta/{+name}"
+                },
+                "batchDelete": {
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "description": "Batch delete `Chunk`s.",
+                  "httpMethod": "POST",
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks:batchDelete",
+                  "parameters": {
+                    "parent": {
+                      "location": "path",
+                      "description": "Optional. The name of the `Document` containing the `Chunk`s to delete. The parent field in every `DeleteChunkRequest` must match this value. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
+                      "required": true,
+                      "type": "string",
+                      "pattern": "^corpora/[^/]+/documents/[^/]+$"
+                    }
+                  },
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "id": "generativelanguage.corpora.documents.chunks.batchDelete",
+                  "request": {
+                    "$ref": "BatchDeleteChunksRequest"
+                  },
+                  "path": "v1beta/{+parent}/chunks:batchDelete"
+                }
+              }
+            }
+          },
+          "methods": {
+            "delete": {
+              "description": "Deletes a `Document`.",
+              "path": "v1beta/{+name}",
+              "response": {
+                "$ref": "Empty"
+              },
+              "id": "generativelanguage.corpora.documents.delete",
+              "parameters": {
+                "force": {
+                  "location": "query",
+                  "description": "Optional. If set to true, any `Chunk`s and objects related to this `Document` will also be deleted. If false (the default), a `FAILED_PRECONDITION` error will be returned if `Document` contains any `Chunk`s.",
+                  "type": "boolean"
+                },
+                "name": {
+                  "description": "Required. The resource name of the `Document` to delete. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
+                  "location": "path",
+                  "required": true,
+                  "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                  "type": "string"
+                }
+              },
+              "parameterOrder": [
+                "name"
+              ],
+              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}",
+              "httpMethod": "DELETE"
+            },
+            "create": {
+              "flatPath": "v1beta/corpora/{corporaId}/documents",
+              "parameters": {
+                "parent": {
+                  "pattern": "^corpora/[^/]+$",
+                  "type": "string",
+                  "location": "path",
+                  "description": "Required. The name of the `Corpus` where this `Document` will be created. Example: `corpora/my-corpus-123`",
+                  "required": true
+                }
+              },
+              "response": {
+                "$ref": "Document"
+              },
+              "id": "generativelanguage.corpora.documents.create",
+              "path": "v1beta/{+parent}/documents",
+              "parameterOrder": [
+                "parent"
+              ],
+              "description": "Creates an empty `Document`.",
+              "request": {
+                "$ref": "Document"
+              },
+              "httpMethod": "POST"
+            },
+            "query": {
+              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}:query",
+              "response": {
+                "$ref": "QueryDocumentResponse"
+              },
+              "parameterOrder": [
+                "name"
+              ],
+              "request": {
+                "$ref": "QueryDocumentRequest"
+              },
+              "path": "v1beta/{+name}:query",
+              "description": "Performs semantic search over a `Document`.",
+              "id": "generativelanguage.corpora.documents.query",
+              "httpMethod": "POST",
+              "parameters": {
+                "name": {
+                  "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                  "type": "string",
+                  "description": "Required. The name of the `Document` to query. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
+                  "required": true,
+                  "location": "path"
+                }
+              }
+            },
+            "patch": {
+              "description": "Updates a `Document`.",
+              "response": {
+                "$ref": "Document"
+              },
+              "httpMethod": "PATCH",
+              "path": "v1beta/{+name}",
+              "parameters": {
+                "name": {
+                  "required": true,
+                  "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                  "description": "Immutable. Identifier. The `Document` resource name. The ID (name excluding the \"corpora/*/documents/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/{corpus_id}/documents/my-awesome-doc-123a456b789c`",
+                  "type": "string",
+                  "location": "path"
+                },
+                "updateMask": {
+                  "type": "string",
+                  "location": "query",
+                  "format": "google-fieldmask",
+                  "description": "Required. The list of fields to update. Currently, this only supports updating `display_name` and `custom_metadata`."
+                }
+              },
+              "parameterOrder": [
+                "name"
+              ],
+              "id": "generativelanguage.corpora.documents.patch",
+              "request": {
+                "$ref": "Document"
+              },
+              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}"
+            },
+            "list": {
+              "id": "generativelanguage.corpora.documents.list",
+              "parameters": {
+                "pageSize": {
+                  "location": "query",
+                  "type": "integer",
+                  "format": "int32",
+                  "description": "Optional. The maximum number of `Document`s to return (per page). The service may return fewer `Document`s. If unspecified, at most 10 `Document`s will be returned. The maximum size limit is 20 `Document`s per page."
+                },
+                "parent": {
+                  "type": "string",
+                  "location": "path",
+                  "required": true,
+                  "pattern": "^corpora/[^/]+$",
+                  "description": "Required. The name of the `Corpus` containing `Document`s. Example: `corpora/my-corpus-123`"
+                },
+                "pageToken": {
+                  "type": "string",
+                  "description": "Optional. A page token, received from a previous `ListDocuments` call. Provide the `next_page_token` returned in the response as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListDocuments` must match the call that provided the page token.",
+                  "location": "query"
+                }
+              },
+              "description": "Lists all `Document`s in a `Corpus`.",
+              "response": {
+                "$ref": "ListDocumentsResponse"
+              },
+              "path": "v1beta/{+parent}/documents",
+              "httpMethod": "GET",
+              "parameterOrder": [
+                "parent"
+              ],
+              "flatPath": "v1beta/corpora/{corporaId}/documents"
+            },
+            "get": {
+              "parameterOrder": [
+                "name"
+              ],
+              "response": {
+                "$ref": "Document"
+              },
+              "description": "Gets information about a specific `Document`.",
+              "parameters": {
+                "name": {
+                  "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                  "type": "string",
+                  "required": true,
+                  "description": "Required. The name of the `Document` to retrieve. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
+                  "location": "path"
+                }
+              },
+              "id": "generativelanguage.corpora.documents.get",
+              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}",
+              "path": "v1beta/{+name}",
+              "httpMethod": "GET"
+            }
+          }
+        },
+        "permissions": {
+          "methods": {
+            "list": {
+              "httpMethod": "GET",
+              "path": "v1beta/{+parent}/permissions",
+              "flatPath": "v1beta/corpora/{corporaId}/permissions",
+              "response": {
+                "$ref": "ListPermissionsResponse"
+              },
+              "id": "generativelanguage.corpora.permissions.list",
+              "parameterOrder": [
+                "parent"
+              ],
+              "description": "Lists permissions for the specific resource.",
+              "parameters": {
+                "pageToken": {
+                  "location": "query",
+                  "description": "Optional. A page token, received from a previous `ListPermissions` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListPermissions` must match the call that provided the page token.",
+                  "type": "string"
+                },
+                "pageSize": {
+                  "description": "Optional. The maximum number of `Permission`s to return (per page). The service may return fewer permissions. If unspecified, at most 10 permissions will be returned. This method returns at most 1000 permissions per page, even if you pass larger page_size.",
+                  "format": "int32",
+                  "location": "query",
+                  "type": "integer"
+                },
+                "parent": {
+                  "description": "Required. The parent resource of the permissions. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`",
+                  "required": true,
+                  "location": "path",
+                  "pattern": "^corpora/[^/]+$",
+                  "type": "string"
+                }
+              }
+            },
+            "delete": {
+              "path": "v1beta/{+name}",
+              "parameterOrder": [
+                "name"
+              ],
+              "httpMethod": "DELETE",
+              "description": "Deletes the permission.",
+              "response": {
+                "$ref": "Empty"
+              },
+              "flatPath": "v1beta/corpora/{corporaId}/permissions/{permissionsId}",
+              "id": "generativelanguage.corpora.permissions.delete",
+              "parameters": {
+                "name": {
+                  "type": "string",
+                  "location": "path",
+                  "required": true,
+                  "pattern": "^corpora/[^/]+/permissions/[^/]+$",
+                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`"
+                }
+              }
+            },
+            "get": {
+              "response": {
+                "$ref": "Permission"
+              },
+              "id": "generativelanguage.corpora.permissions.get",
+              "parameters": {
+                "name": {
+                  "type": "string",
+                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
+                  "required": true,
+                  "location": "path",
+                  "pattern": "^corpora/[^/]+/permissions/[^/]+$"
+                }
+              },
+              "httpMethod": "GET",
+              "description": "Gets information about a specific Permission.",
+              "flatPath": "v1beta/corpora/{corporaId}/permissions/{permissionsId}",
+              "parameterOrder": [
+                "name"
+              ],
+              "path": "v1beta/{+name}"
+            },
+            "patch": {
+              "request": {
+                "$ref": "Permission"
+              },
+              "parameterOrder": [
+                "name"
+              ],
+              "id": "generativelanguage.corpora.permissions.patch",
+              "flatPath": "v1beta/corpora/{corporaId}/permissions/{permissionsId}",
+              "path": "v1beta/{+name}",
+              "description": "Updates the permission.",
+              "httpMethod": "PATCH",
+              "response": {
+                "$ref": "Permission"
+              },
+              "parameters": {
+                "name": {
+                  "description": "Output only. Identifier. The permission name. A unique name will be generated on create. Examples: tunedModels/{tuned_model}/permissions/{permission} corpora/{corpus}/permissions/{permission} Output only.",
+                  "type": "string",
+                  "pattern": "^corpora/[^/]+/permissions/[^/]+$",
+                  "location": "path",
+                  "required": true
+                },
+                "updateMask": {
+                  "type": "string",
+                  "format": "google-fieldmask",
+                  "location": "query",
+                  "description": "Required. The list of fields to update. Accepted ones: - role (`Permission.role` field)"
+                }
+              }
+            },
+            "create": {
+              "httpMethod": "POST",
+              "path": "v1beta/{+parent}/permissions",
+              "flatPath": "v1beta/corpora/{corporaId}/permissions",
+              "parameters": {
+                "parent": {
+                  "pattern": "^corpora/[^/]+$",
+                  "type": "string",
+                  "description": "Required. The parent resource of the `Permission`. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`",
+                  "required": true,
+                  "location": "path"
+                }
+              },
+              "id": "generativelanguage.corpora.permissions.create",
+              "request": {
+                "$ref": "Permission"
+              },
+              "response": {
+                "$ref": "Permission"
+              },
+              "description": "Create a permission to a specific resource.",
+              "parameterOrder": [
+                "parent"
+              ]
+            }
+          }
+        }
+      },
+      "methods": {
+        "create": {
+          "parameterOrder": [],
+          "description": "Creates an empty `Corpus`.",
+          "request": {
+            "$ref": "Corpus"
+          },
+          "httpMethod": "POST",
+          "response": {
+            "$ref": "Corpus"
+          },
+          "id": "generativelanguage.corpora.create",
+          "flatPath": "v1beta/corpora",
+          "path": "v1beta/corpora",
+          "parameters": {}
+        },
+        "query": {
+          "parameterOrder": [
+            "name"
+          ],
+          "request": {
+            "$ref": "QueryCorpusRequest"
+          },
+          "parameters": {
+            "name": {
+              "location": "path",
+              "pattern": "^corpora/[^/]+$",
+              "required": true,
+              "type": "string",
+              "description": "Required. The name of the `Corpus` to query. Example: `corpora/my-corpus-123`"
+            }
+          },
+          "httpMethod": "POST",
+          "response": {
+            "$ref": "QueryCorpusResponse"
+          },
+          "flatPath": "v1beta/corpora/{corporaId}:query",
+          "id": "generativelanguage.corpora.query",
+          "description": "Performs semantic search over a `Corpus`.",
+          "path": "v1beta/{+name}:query"
+        },
+        "get": {
+          "flatPath": "v1beta/corpora/{corporaId}",
+          "description": "Gets information about a specific `Corpus`.",
+          "parameters": {
+            "name": {
+              "pattern": "^corpora/[^/]+$",
+              "location": "path",
+              "description": "Required. The name of the `Corpus`. Example: `corpora/my-corpus-123`",
+              "type": "string",
+              "required": true
+            }
+          },
+          "response": {
+            "$ref": "Corpus"
+          },
+          "id": "generativelanguage.corpora.get",
+          "path": "v1beta/{+name}",
+          "parameterOrder": [
+            "name"
+          ],
+          "httpMethod": "GET"
+        },
+        "delete": {
+          "description": "Deletes a `Corpus`.",
+          "flatPath": "v1beta/corpora/{corporaId}",
+          "id": "generativelanguage.corpora.delete",
+          "parameterOrder": [
+            "name"
+          ],
+          "parameters": {
+            "force": {
+              "location": "query",
+              "description": "Optional. If set to true, any `Document`s and objects related to this `Corpus` will also be deleted. If false (the default), a `FAILED_PRECONDITION` error will be returned if `Corpus` contains any `Document`s.",
+              "type": "boolean"
+            },
+            "name": {
+              "required": true,
+              "type": "string",
+              "pattern": "^corpora/[^/]+$",
+              "location": "path",
+              "description": "Required. The resource name of the `Corpus`. Example: `corpora/my-corpus-123`"
+            }
+          },
+          "response": {
+            "$ref": "Empty"
+          },
+          "httpMethod": "DELETE",
+          "path": "v1beta/{+name}"
+        },
+        "patch": {
+          "id": "generativelanguage.corpora.patch",
+          "parameterOrder": [
+            "name"
+          ],
+          "description": "Updates a `Corpus`.",
+          "flatPath": "v1beta/corpora/{corporaId}",
+          "parameters": {
+            "updateMask": {
+              "format": "google-fieldmask",
+              "type": "string",
+              "location": "query",
+              "description": "Required. The list of fields to update. Currently, this only supports updating `display_name`."
+            },
+            "name": {
+              "location": "path",
+              "required": true,
+              "type": "string",
+              "pattern": "^corpora/[^/]+$",
+              "description": "Immutable. Identifier. The `Corpus` resource name. The ID (name excluding the \"corpora/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/my-awesome-corpora-123a456b789c`"
+            }
+          },
+          "response": {
+            "$ref": "Corpus"
+          },
+          "httpMethod": "PATCH",
+          "path": "v1beta/{+name}",
+          "request": {
+            "$ref": "Corpus"
+          }
+        },
+        "list": {
+          "id": "generativelanguage.corpora.list",
+          "path": "v1beta/corpora",
+          "flatPath": "v1beta/corpora",
+          "description": "Lists all `Corpora` owned by the user.",
+          "parameterOrder": [],
+          "httpMethod": "GET",
+          "response": {
+            "$ref": "ListCorporaResponse"
+          },
+          "parameters": {
+            "pageSize": {
+              "type": "integer",
+              "format": "int32",
+              "description": "Optional. The maximum number of `Corpora` to return (per page). The service may return fewer `Corpora`. If unspecified, at most 10 `Corpora` will be returned. The maximum size limit is 20 `Corpora` per page.",
+              "location": "query"
+            },
+            "pageToken": {
+              "location": "query",
+              "type": "string",
+              "description": "Optional. A page token, received from a previous `ListCorpora` call. Provide the `next_page_token` returned in the response as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListCorpora` must match the call that provided the page token."
+            }
+          }
+        }
+      }
+    },
+    "media": {
+      "methods": {
+        "upload": {
+          "mediaUpload": {
+            "maxSize": "2147483648",
+            "accept": [
+              "*/*"
+            ],
+            "protocols": {
+              "resumable": {
+                "path": "/resumable/upload/v1beta/files",
+                "multipart": true
+              },
+              "simple": {
+                "path": "/upload/v1beta/files",
+                "multipart": true
+              }
+            }
+          },
+          "response": {
+            "$ref": "CreateFileResponse"
+          },
+          "flatPath": "v1beta/files",
+          "id": "generativelanguage.media.upload",
+          "description": "Creates a `File`.",
+          "request": {
+            "$ref": "CreateFileRequest"
+          },
+          "httpMethod": "POST",
+          "supportsMediaUpload": true,
+          "path": "v1beta/files",
+          "parameters": {},
+          "parameterOrder": []
+        }
+      }
+    },
+    "files": {
+      "methods": {
+        "list": {
+          "flatPath": "v1beta/files",
+          "parameterOrder": [],
+          "httpMethod": "GET",
+          "id": "generativelanguage.files.list",
+          "description": "Lists the metadata for `File`s owned by the requesting project.",
+          "path": "v1beta/files",
+          "parameters": {
+            "pageSize": {
+              "format": "int32",
+              "type": "integer",
+              "location": "query",
+              "description": "Optional. Maximum number of `File`s to return per page. If unspecified, defaults to 10. Maximum `page_size` is 100."
+            },
+            "pageToken": {
+              "description": "Optional. A page token from a previous `ListFiles` call.",
+              "type": "string",
+              "location": "query"
+            }
+          },
+          "response": {
+            "$ref": "ListFilesResponse"
+          }
+        },
+        "get": {
+          "parameterOrder": [
+            "name"
+          ],
+          "path": "v1beta/{+name}",
+          "description": "Gets the metadata for the given `File`.",
+          "id": "generativelanguage.files.get",
+          "response": {
+            "$ref": "File"
+          },
+          "parameters": {
+            "name": {
+              "required": true,
+              "pattern": "^files/[^/]+$",
+              "location": "path",
+              "description": "Required. The name of the `File` to get. Example: `files/abc-123`",
+              "type": "string"
+            }
+          },
+          "flatPath": "v1beta/files/{filesId}",
+          "httpMethod": "GET"
+        },
+        "delete": {
+          "httpMethod": "DELETE",
+          "parameterOrder": [
+            "name"
+          ],
+          "response": {
+            "$ref": "Empty"
+          },
+          "description": "Deletes the `File`.",
+          "id": "generativelanguage.files.delete",
+          "flatPath": "v1beta/files/{filesId}",
+          "parameters": {
+            "name": {
+              "description": "Required. The name of the `File` to delete. Example: `files/abc-123`",
+              "location": "path",
+              "required": true,
+              "pattern": "^files/[^/]+$",
+              "type": "string"
+            }
+          },
+          "path": "v1beta/{+name}"
+        }
+      }
+    },
+    "models": {
+      "methods": {
+        "generateMessage": {
+          "description": "Generates a response from the model given an input `MessagePrompt`.",
+          "request": {
+            "$ref": "GenerateMessageRequest"
+          },
+          "parameterOrder": [
+            "model"
+          ],
+          "path": "v1beta/{+model}:generateMessage",
+          "response": {
+            "$ref": "GenerateMessageResponse"
+          },
+          "httpMethod": "POST",
+          "parameters": {
+            "model": {
+              "type": "string",
+              "pattern": "^models/[^/]+$",
+              "required": true,
+              "description": "Required. The name of the model to use. Format: `name=models/{model}`.",
+              "location": "path"
+            }
+          },
+          "flatPath": "v1beta/models/{modelsId}:generateMessage",
+          "id": "generativelanguage.models.generateMessage"
+        },
+        "generateContent": {
+          "id": "generativelanguage.models.generateContent",
+          "path": "v1beta/{+model}:generateContent",
+          "request": {
+            "$ref": "GenerateContentRequest"
+          },
+          "flatPath": "v1beta/models/{modelsId}:generateContent",
+          "description": "Generates a response from the model given an input `GenerateContentRequest`. Input capabilities differ between models, including tuned models. See the [model guide](https://ai.google.dev/models/gemini) and [tuning guide](https://ai.google.dev/docs/model_tuning_guidance) for details.",
+          "parameterOrder": [
+            "model"
+          ],
+          "response": {
+            "$ref": "GenerateContentResponse"
+          },
+          "httpMethod": "POST",
+          "parameters": {
+            "model": {
+              "pattern": "^models/[^/]+$",
+              "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`.",
+              "type": "string",
+              "location": "path",
+              "required": true
+            }
+          }
+        },
+        "batchEmbedText": {
+          "httpMethod": "POST",
+          "description": "Generates multiple embeddings from the model given input text in a synchronous call.",
+          "response": {
+            "$ref": "BatchEmbedTextResponse"
+          },
+          "flatPath": "v1beta/models/{modelsId}:batchEmbedText",
+          "parameterOrder": [
+            "model"
+          ],
+          "request": {
+            "$ref": "BatchEmbedTextRequest"
+          },
+          "path": "v1beta/{+model}:batchEmbedText",
+          "id": "generativelanguage.models.batchEmbedText",
+          "parameters": {
+            "model": {
+              "type": "string",
+              "location": "path",
+              "pattern": "^models/[^/]+$",
+              "description": "Required. The name of the `Model` to use for generating the embedding. Examples: models/embedding-gecko-001",
+              "required": true
+            }
+          }
+        },
+        "get": {
+          "description": "Gets information about a specific Model.",
+          "parameterOrder": [
+            "name"
+          ],
+          "path": "v1beta/{+name}",
+          "flatPath": "v1beta/models/{modelsId}",
+          "id": "generativelanguage.models.get",
+          "response": {
+            "$ref": "Model"
+          },
+          "httpMethod": "GET",
+          "parameters": {
+            "name": {
+              "description": "Required. The resource name of the model. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
+              "required": true,
+              "pattern": "^models/[^/]+$",
+              "type": "string",
+              "location": "path"
+            }
+          }
+        },
+        "embedContent": {
+          "request": {
+            "$ref": "EmbedContentRequest"
+          },
+          "description": "Generates an embedding from the model given an input `Content`.",
+          "response": {
+            "$ref": "EmbedContentResponse"
+          },
+          "httpMethod": "POST",
+          "parameterOrder": [
+            "model"
+          ],
+          "id": "generativelanguage.models.embedContent",
+          "flatPath": "v1beta/models/{modelsId}:embedContent",
+          "parameters": {
+            "model": {
+              "pattern": "^models/[^/]+$",
+              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
+              "location": "path",
+              "type": "string",
+              "required": true
+            }
+          },
+          "path": "v1beta/{+model}:embedContent"
+        },
+        "streamGenerateContent": {
+          "description": "Generates a streamed response from the model given an input `GenerateContentRequest`.",
+          "parameters": {
+            "model": {
+              "pattern": "^models/[^/]+$",
+              "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`.",
+              "type": "string",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "httpMethod": "POST",
+          "id": "generativelanguage.models.streamGenerateContent",
+          "response": {
+            "$ref": "GenerateContentResponse"
+          },
+          "path": "v1beta/{+model}:streamGenerateContent",
+          "request": {
+            "$ref": "GenerateContentRequest"
+          },
+          "parameterOrder": [
+            "model"
+          ],
+          "flatPath": "v1beta/models/{modelsId}:streamGenerateContent"
+        },
+        "embedText": {
+          "response": {
+            "$ref": "EmbedTextResponse"
+          },
+          "httpMethod": "POST",
+          "parameters": {
+            "model": {
+              "type": "string",
+              "required": true,
+              "pattern": "^models/[^/]+$",
+              "description": "Required. The model name to use with the format model=models/{model}.",
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "model"
+          ],
+          "flatPath": "v1beta/models/{modelsId}:embedText",
+          "request": {
+            "$ref": "EmbedTextRequest"
+          },
+          "description": "Generates an embedding from the model given an input message.",
+          "path": "v1beta/{+model}:embedText",
+          "id": "generativelanguage.models.embedText"
+        },
+        "list": {
+          "parameterOrder": [],
+          "id": "generativelanguage.models.list",
+          "flatPath": "v1beta/models",
+          "response": {
+            "$ref": "ListModelsResponse"
+          },
+          "httpMethod": "GET",
+          "description": "Lists models available through the API.",
+          "parameters": {
+            "pageSize": {
+              "location": "query",
+              "format": "int32",
+              "description": "The maximum number of `Models` to return (per page). The service may return fewer models. If unspecified, at most 50 models will be returned per page. This method returns at most 1000 models per page, even if you pass a larger page_size.",
+              "type": "integer"
+            },
+            "pageToken": {
+              "type": "string",
+              "description": "A page token, received from a previous `ListModels` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListModels` must match the call that provided the page token.",
+              "location": "query"
+            }
+          },
+          "path": "v1beta/models"
+        },
+        "generateText": {
+          "flatPath": "v1beta/models/{modelsId}:generateText",
+          "request": {
+            "$ref": "GenerateTextRequest"
+          },
+          "description": "Generates a response from the model given an input message.",
+          "parameters": {
+            "model": {
+              "description": "Required. The name of the `Model` or `TunedModel` to use for generating the completion. Examples: models/text-bison-001 tunedModels/sentence-translator-u3b7m",
+              "location": "path",
+              "type": "string",
+              "pattern": "^models/[^/]+$",
+              "required": true
+            }
+          },
+          "httpMethod": "POST",
+          "response": {
+            "$ref": "GenerateTextResponse"
+          },
+          "path": "v1beta/{+model}:generateText",
+          "parameterOrder": [
+            "model"
+          ],
+          "id": "generativelanguage.models.generateText"
+        },
+        "batchEmbedContents": {
+          "id": "generativelanguage.models.batchEmbedContents",
+          "parameterOrder": [
+            "model"
+          ],
+          "path": "v1beta/{+model}:batchEmbedContents",
+          "httpMethod": "POST",
+          "response": {
+            "$ref": "BatchEmbedContentsResponse"
+          },
+          "description": "Generates multiple embeddings from the model given input text in a synchronous call.",
+          "flatPath": "v1beta/models/{modelsId}:batchEmbedContents",
+          "parameters": {
+            "model": {
+              "type": "string",
+              "location": "path",
+              "pattern": "^models/[^/]+$",
+              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
+              "required": true
+            }
+          },
+          "request": {
+            "$ref": "BatchEmbedContentsRequest"
+          }
+        },
+        "countTokens": {
+          "description": "Runs a model's tokenizer on input content and returns the token count.",
+          "httpMethod": "POST",
+          "request": {
+            "$ref": "CountTokensRequest"
+          },
+          "id": "generativelanguage.models.countTokens",
+          "parameterOrder": [
+            "model"
+          ],
+          "response": {
+            "$ref": "CountTokensResponse"
+          },
+          "flatPath": "v1beta/models/{modelsId}:countTokens",
+          "parameters": {
+            "model": {
+              "location": "path",
+              "type": "string",
+              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
+              "pattern": "^models/[^/]+$",
+              "required": true
+            }
+          },
+          "path": "v1beta/{+model}:countTokens"
+        },
+        "countMessageTokens": {
+          "id": "generativelanguage.models.countMessageTokens",
+          "httpMethod": "POST",
+          "parameterOrder": [
+            "model"
+          ],
+          "request": {
+            "$ref": "CountMessageTokensRequest"
+          },
+          "description": "Runs a model's tokenizer on a string and returns the token count.",
+          "path": "v1beta/{+model}:countMessageTokens",
+          "response": {
+            "$ref": "CountMessageTokensResponse"
+          },
+          "parameters": {
+            "model": {
+              "location": "path",
+              "type": "string",
+              "pattern": "^models/[^/]+$",
+              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
+              "required": true
+            }
+          },
+          "flatPath": "v1beta/models/{modelsId}:countMessageTokens"
+        },
+        "countTextTokens": {
+          "flatPath": "v1beta/models/{modelsId}:countTextTokens",
+          "description": "Runs a model's tokenizer on a text and returns the token count.",
+          "request": {
+            "$ref": "CountTextTokensRequest"
+          },
+          "parameters": {
+            "model": {
+              "type": "string",
+              "pattern": "^models/[^/]+$",
+              "required": true,
+              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "model"
+          ],
+          "path": "v1beta/{+model}:countTextTokens",
+          "httpMethod": "POST",
+          "response": {
+            "$ref": "CountTextTokensResponse"
+          },
+          "id": "generativelanguage.models.countTextTokens"
+        },
+        "generateAnswer": {
+          "response": {
+            "$ref": "GenerateAnswerResponse"
+          },
+          "id": "generativelanguage.models.generateAnswer",
+          "request": {
+            "$ref": "GenerateAnswerRequest"
+          },
+          "parameterOrder": [
+            "model"
+          ],
+          "description": "Generates a grounded answer from the model given an input `GenerateAnswerRequest`.",
+          "httpMethod": "POST",
+          "flatPath": "v1beta/models/{modelsId}:generateAnswer",
+          "path": "v1beta/{+model}:generateAnswer",
+          "parameters": {
+            "model": {
+              "location": "path",
+              "pattern": "^models/[^/]+$",
+              "type": "string",
+              "description": "Required. The name of the `Model` to use for generating the grounded response. Format: `model=models/{model}`.",
+              "required": true
+            }
+          }
+        }
+      }
+    }
+  },
+  "basePath": ""
 }

--- a/genai/internal/generativelanguage/v1beta/generativelanguage-gen.go
+++ b/genai/internal/generativelanguage/v1beta/generativelanguage-gen.go
@@ -1003,7 +1003,8 @@ func (s *CountTextTokensResponse) MarshalJSON() ([]byte, error) {
 // model. Models may tokenize text differently, so each model may return a
 // different `token_count`.
 type CountTokensRequest struct {
-	// Contents: Optional. The input given to the model as a prompt.
+	// Contents: Optional. The input given to the model as a prompt. This field is
+	// ignored when `generate_content_request` is set.
 	Contents []*Content `json:"contents,omitempty"`
 	// GenerateContentRequest: Optional. The overall input given to the model.
 	// CountTokens will count prompt, function calling, etc.
@@ -1468,6 +1469,8 @@ type File struct {
 	// display name must be no more than 512 characters in length, including
 	// spaces. Example: "Welcome Image"
 	DisplayName string `json:"displayName,omitempty"`
+	// Error: Output only. Error status if File processing failed.
+	Error *Status `json:"error,omitempty"`
 	// ExpirationTime: Output only. The timestamp of when the `File` will be
 	// deleted. Only set if the `File` is scheduled to expire.
 	ExpirationTime string `json:"expirationTime,omitempty"`
@@ -1497,6 +1500,8 @@ type File struct {
 	UpdateTime string `json:"updateTime,omitempty"`
 	// Uri: Output only. The uri of the `File`.
 	Uri string `json:"uri,omitempty"`
+	// VideoMetadata: Output only. Metadata for a video.
+	VideoMetadata *VideoMetadata `json:"videoMetadata,omitempty"`
 
 	// ServerResponse contains the HTTP response code and headers from the server.
 	googleapi.ServerResponse `json:"-"`
@@ -2135,6 +2140,13 @@ type GenerationConfig struct {
 	// candidate text. Supported mimetype: `text/plain`: (default) Text output.
 	// `application/json`: JSON response in the candidates.
 	ResponseMimeType string `json:"responseMimeType,omitempty"`
+	// ResponseSchema: Optional. Output response schema of the generated candidate
+	// text when response mime type can have schema. Schema can be objects,
+	// primitives or arrays and is a subset of OpenAPI schema
+	// (https://spec.openapis.org/oas/v3.0.3#schema). If set, a compatible
+	// response_mime_type must also be set. Compatible mimetypes:
+	// `application/json`: Schema for JSON response.
+	ResponseSchema *Schema `json:"responseSchema,omitempty"`
 	// StopSequences: Optional. The set of character sequences (up to 5) that will
 	// stop output generation. If specified, the API will stop at the first
 	// appearance of a stop sequence. The stop sequence will not be included as
@@ -3215,7 +3227,7 @@ func (s *SafetyRating) MarshalJSON() ([]byte, error) {
 }
 
 // SafetySetting: Safety setting, affecting the safety-blocking behavior.
-// Passing a safety setting for a category changes the allowed proability that
+// Passing a safety setting for a category changes the allowed probability that
 // content is blocked.
 type SafetySetting struct {
 	// Category: Required. The category for this setting.
@@ -3875,6 +3887,28 @@ type UsageMetadata struct {
 
 func (s *UsageMetadata) MarshalJSON() ([]byte, error) {
 	type NoMethod UsageMetadata
+	return gensupport.MarshalJSON(NoMethod(*s), s.ForceSendFields, s.NullFields)
+}
+
+// VideoMetadata: Metadata for a video `File`.
+type VideoMetadata struct {
+	// VideoDuration: Duration of the video.
+	VideoDuration string `json:"videoDuration,omitempty"`
+	// ForceSendFields is a list of field names (e.g. "VideoDuration") to
+	// unconditionally include in API requests. By default, fields with empty or
+	// default values are omitted from API requests. See
+	// https://pkg.go.dev/google.golang.org/api#hdr-ForceSendFields for more
+	// details.
+	ForceSendFields []string `json:"-"`
+	// NullFields is a list of field names (e.g. "VideoDuration") to include in API
+	// requests with the JSON null value. By default, fields with empty values are
+	// omitted from API requests. See
+	// https://pkg.go.dev/google.golang.org/api#hdr-NullFields for more details.
+	NullFields []string `json:"-"`
+}
+
+func (s *VideoMetadata) MarshalJSON() ([]byte, error) {
+	type NoMethod VideoMetadata
 	return gensupport.MarshalJSON(NoMethod(*s), s.ForceSendFields, s.NullFields)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,17 +3,18 @@ module github.com/google/generative-ai-go
 go 1.21
 
 require (
+	cloud.google.com/go v0.113.0
 	cloud.google.com/go/ai v0.5.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.12.4
 	google.golang.org/api v0.178.0
+	google.golang.org/genproto v0.0.0-20240401170217-c3f982113cda
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240506185236-b8a5c65736ae
 	google.golang.org/protobuf v1.34.1
 )
 
 require (
-	cloud.google.com/go v0.113.0 // indirect
 	cloud.google.com/go/auth v0.4.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.2 // indirect
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
+google.golang.org/genproto v0.0.0-20240401170217-c3f982113cda h1:wu/KJm9KJwpfHWhkkZGohVC6KRrc1oJNr4jwtQMOQXw=
+google.golang.org/genproto v0.0.0-20240401170217-c3f982113cda/go.mod h1:g2LLCvCeCSir/JJSWosk19BR4NVxGqHUC6rxIRsd7Aw=
 google.golang.org/genproto/googleapis/api v0.0.0-20240506185236-b8a5c65736ae h1:AH34z6WAGVNkllnKs5raNq3yRq93VnjBG6rpfub/jYk=
 google.golang.org/genproto/googleapis/api v0.0.0-20240506185236-b8a5c65736ae/go.mod h1:FfiGhwUm6CJviekPrc0oJ+7h29e+DmWU6UtjX0ZvI7Y=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240506185236-b8a5c65736ae h1:c55+MER4zkBS14uJhSZMGGmya0yJx5iHV4x/fpOSNRk=

--- a/internal/support/support.go
+++ b/internal/support/support.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,8 +17,12 @@ package support
 
 import (
 	"fmt"
+	"time"
 
+	"cloud.google.com/go/civil"
+	"google.golang.org/genproto/googleapis/type/date"
 	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // TransformSlice applies f to each element of from and returns
@@ -67,6 +71,27 @@ func DerefOrZero[T any](x *T) T {
 	return *x
 }
 
+// CivilDateToProto converts a civil.Date to a date.Date.
+func CivilDateToProto(d civil.Date) *date.Date {
+	return &date.Date{
+		Year:  int32(d.Year),
+		Month: int32(d.Month),
+		Day:   int32(d.Day),
+	}
+}
+
+// CivilDateFromProto converts a date.Date to a civil.Date.
+func CivilDateFromProto(p *date.Date) civil.Date {
+	if p == nil {
+		return civil.Date{}
+	}
+	return civil.Date{
+		Year:  int(p.Year),
+		Month: time.Month(p.Month),
+		Day:   int(p.Day),
+	}
+}
+
 // MapToStructPB converts a map into a structpb.Struct.
 func MapToStructPB(m map[string]any) *structpb.Struct {
 	if m == nil {
@@ -85,4 +110,12 @@ func MapFromStructPB(p *structpb.Struct) map[string]any {
 		return nil
 	}
 	return p.AsMap()
+}
+
+// TimeFromProto converts a Timestamp into a time.Time.
+func TimeFromProto(ts *timestamppb.Timestamp) time.Time {
+	if ts == nil {
+		return time.Time{}
+	}
+	return ts.AsTime()
 }


### PR DESCRIPTION
Add three fields to `File` that are of type time.Time.

This requires the changes to protoveneer in
https://github.com/googleapis/google-cloud-go/pull/10266,
which also includes changes to the support packages.

Running `go generate` also introduced two additional `File` fields,
Error and Metadata, that we will deal with later.

There are also additions to the discovery client which don't concern
us.
