### PR TITLE
genai: spell name of HTTP client option correctly

### DIFF
--- a/genai/client.go
+++ b/genai/client.go
@@ -101,7 +101,7 @@ func hasAuthOption(opts []option.ClientOption) bool {
 		case "option.withAPIKey":
 			return v.String() != ""
 
-		case "option.withHttpClient",
+		case "option.withHTTPClient",
 			"option.withTokenSource",
 			"option.withCredentialsFile",
 			"option.withCredentialsJSON":


### PR DESCRIPTION
Result: NewClient no longer returns an error if the user
passes option.WithHTTPClient.
