### PR TITLE
genai: turn conversion panics to errors

### DIFF
--- a/genai/chat.go
+++ b/genai/chat.go
@@ -33,7 +33,10 @@ func (m *GenerativeModel) StartChat() *ChatSession {
 func (cs *ChatSession) SendMessage(ctx context.Context, parts ...Part) (*GenerateContentResponse, error) {
 	// Call the underlying client with the entire history plus the argument Content.
 	cs.History = append(cs.History, newUserContent(parts))
-	req := cs.m.newGenerateContentRequest(cs.History...)
+	req, err := cs.m.newGenerateContentRequest(cs.History...)
+	if err != nil {
+		return nil, err
+	}
 	req.GenerationConfig.CandidateCount = Ptr[int32](1)
 	resp, err := cs.m.generateContent(ctx, req)
 	if err != nil {
@@ -46,7 +49,10 @@ func (cs *ChatSession) SendMessage(ctx context.Context, parts ...Part) (*Generat
 // SendMessageStream is like SendMessage, but with a streaming request.
 func (cs *ChatSession) SendMessageStream(ctx context.Context, parts ...Part) *GenerateContentResponseIterator {
 	cs.History = append(cs.History, newUserContent(parts))
-	req := cs.m.newGenerateContentRequest(cs.History...)
+	req, err := cs.m.newGenerateContentRequest(cs.History...)
+	if err != nil {
+		return &GenerateContentResponseIterator{err: err}
+	}
 	req.GenerationConfig.CandidateCount = Ptr[int32](1)
 	streamClient, err := cs.m.c.c.StreamGenerateContent(ctx, req)
 	return &GenerateContentResponseIterator{

--- a/genai/client.go
+++ b/genai/client.go
@@ -199,7 +199,7 @@ func (m *GenerativeModel) generateContent(ctx context.Context, req *pb.GenerateC
 }
 
 func (m *GenerativeModel) newGenerateContentRequest(contents ...*Content) (*pb.GenerateContentRequest, error) {
-	return catchPVPanic(func() *pb.GenerateContentRequest {
+	return pvCatchPanic(func() *pb.GenerateContentRequest {
 		return &pb.GenerateContentRequest{
 			Model:             m.fullName,
 			Contents:          transformSlice(contents, (*Content).toProto),
@@ -444,20 +444,5 @@ func transformSlice[From, To any](from []From, f func(From) To) []To {
 
 func fromProto[V interface{ fromProto(P) *V }, P any](p P) (*V, error) {
 	var v V
-	return catchPVPanic(func() *V { return v.fromProto(p) })
-}
-
-// catchPVPanic recovers from panics of type pvPanic and
-// returns an error instead.
-func catchPVPanic[T any](f func() T) (_ T, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			if _, ok := r.(pvPanic); ok {
-				err = r.(error)
-			} else {
-				panic(r)
-			}
-		}
-	}()
-	return f(), nil
+	return pvCatchPanic(func() *V { return v.fromProto(p) })
 }

--- a/genai/client.go
+++ b/genai/client.go
@@ -158,7 +158,10 @@ func fullModelName(name string) string {
 // GenerateContent produces a single request and response.
 func (m *GenerativeModel) GenerateContent(ctx context.Context, parts ...Part) (*GenerateContentResponse, error) {
 	content := newUserContent(parts)
-	req := m.newGenerateContentRequest(content)
+	req, err := m.newGenerateContentRequest(content)
+	if err != nil {
+		return nil, err
+	}
 	res, err := m.c.c.GenerateContent(ctx, req)
 	if err != nil {
 		return nil, err
@@ -168,11 +171,14 @@ func (m *GenerativeModel) GenerateContent(ctx context.Context, parts ...Part) (*
 
 // GenerateContentStream returns an iterator that enumerates responses.
 func (m *GenerativeModel) GenerateContentStream(ctx context.Context, parts ...Part) *GenerateContentResponseIterator {
-	streamClient, err := m.c.c.StreamGenerateContent(ctx, m.newGenerateContentRequest(newUserContent(parts)))
-	return &GenerateContentResponseIterator{
-		sc:  streamClient,
-		err: err,
+	iter := &GenerateContentResponseIterator{}
+	req, err := m.newGenerateContentRequest(newUserContent(parts))
+	if err != nil {
+		iter.err = err
+	} else {
+		iter.sc, iter.err = m.c.c.StreamGenerateContent(ctx, req)
 	}
+	return iter
 }
 
 func (m *GenerativeModel) generateContent(ctx context.Context, req *pb.GenerateContentRequest) (*GenerateContentResponse, error) {
@@ -192,16 +198,18 @@ func (m *GenerativeModel) generateContent(ctx context.Context, req *pb.GenerateC
 	}
 }
 
-func (m *GenerativeModel) newGenerateContentRequest(contents ...*Content) *pb.GenerateContentRequest {
-	return &pb.GenerateContentRequest{
-		Model:             m.fullName,
-		Contents:          transformSlice(contents, (*Content).toProto),
-		SafetySettings:    transformSlice(m.SafetySettings, (*SafetySetting).toProto),
-		Tools:             transformSlice(m.Tools, (*Tool).toProto),
-		ToolConfig:        m.ToolConfig.toProto(),
-		GenerationConfig:  m.GenerationConfig.toProto(),
-		SystemInstruction: m.SystemInstruction.toProto(),
-	}
+func (m *GenerativeModel) newGenerateContentRequest(contents ...*Content) (*pb.GenerateContentRequest, error) {
+	return catchPVPanic(func() *pb.GenerateContentRequest {
+		return &pb.GenerateContentRequest{
+			Model:             m.fullName,
+			Contents:          transformSlice(contents, (*Content).toProto),
+			SafetySettings:    transformSlice(m.SafetySettings, (*SafetySetting).toProto),
+			Tools:             transformSlice(m.Tools, (*Tool).toProto),
+			ToolConfig:        m.ToolConfig.toProto(),
+			GenerationConfig:  m.GenerationConfig.toProto(),
+			SystemInstruction: m.SystemInstruction.toProto(),
+		}
+	})
 }
 
 func newUserContent(parts []Part) *Content {
@@ -244,7 +252,10 @@ func (iter *GenerateContentResponseIterator) Next() (*GenerateContentResponse, e
 }
 
 func protoToResponse(resp *pb.GenerateContentResponse) (*GenerateContentResponse, error) {
-	gcp := (GenerateContentResponse{}).fromProto(resp)
+	gcp, err := fromProto[GenerateContentResponse](resp)
+	if err != nil {
+		return nil, err
+	}
 	if gcp == nil {
 		return nil, errors.New("empty response from model")
 	}
@@ -273,20 +284,26 @@ func (iter *GenerateContentResponseIterator) MergedResponse() *GenerateContentRe
 
 // CountTokens counts the number of tokens in the content.
 func (m *GenerativeModel) CountTokens(ctx context.Context, parts ...Part) (*CountTokensResponse, error) {
-	req := m.newCountTokensRequest(newUserContent(parts))
+	req, err := m.newCountTokensRequest(newUserContent(parts))
+	if err != nil {
+		return nil, err
+	}
 	res, err := m.c.c.CountTokens(ctx, req)
 	if err != nil {
 		return nil, err
 	}
-
-	return (CountTokensResponse{}).fromProto(res), nil
+	return fromProto[CountTokensResponse](res)
 }
 
-func (m *GenerativeModel) newCountTokensRequest(contents ...*Content) *pb.CountTokensRequest {
+func (m *GenerativeModel) newCountTokensRequest(contents ...*Content) (*pb.CountTokensRequest, error) {
+	gcr, err := m.newGenerateContentRequest(contents...)
+	if err != nil {
+		return nil, err
+	}
 	return &pb.CountTokensRequest{
 		Model:                  m.fullName,
-		GenerateContentRequest: m.newGenerateContentRequest(contents...),
-	}
+		GenerateContentRequest: gcr,
+	}, nil
 }
 
 // Info returns information about the model.
@@ -300,7 +317,7 @@ func (c *Client) modelInfo(ctx context.Context, fullName string) (*ModelInfo, er
 	if err != nil {
 		return nil, err
 	}
-	return (ModelInfo{}).fromProto(res), nil
+	return fromProto[ModelInfo](res)
 }
 
 // A BlockedError indicates that the model's response was blocked.
@@ -423,4 +440,24 @@ func transformSlice[From, To any](from []From, f func(From) To) []To {
 		to[i] = f(e)
 	}
 	return to
+}
+
+func fromProto[V interface{ fromProto(P) *V }, P any](p P) (*V, error) {
+	var v V
+	return catchPVPanic(func() *V { return v.fromProto(p) })
+}
+
+// catchPVPanic recovers from panics of type pvPanic and
+// returns an error instead.
+func catchPVPanic[T any](f func() T) (_ T, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if _, ok := r.(pvPanic); ok {
+				err = r.(error)
+			} else {
+				panic(r)
+			}
+		}
+	}()
+	return f(), nil
 }

--- a/genai/client_test.go
+++ b/genai/client_test.go
@@ -766,3 +766,16 @@ func TestNoAPIKey(t *testing.T) {
 		t.Fatal("got nil, want error")
 	}
 }
+
+func TestRecoverPanic(t *testing.T) {
+	// Verify that conversions that used to cause a panic now result in an error.
+	fr := &FunctionResponse{
+		Name:     "r",
+		Response: map[string]any{"x": 1 + 2i}, // complex values are invalid
+	}
+	var m GenerativeModel
+	_, err := m.newGenerateContentRequest(newUserContent([]Part{fr}))
+	if err == nil {
+		t.Fatal("got nil, want error")
+	}
+}

--- a/genai/generativelanguagepb_veneer.gen.go
+++ b/genai/generativelanguagepb_veneer.gen.go
@@ -41,7 +41,7 @@ func (v *BatchEmbedContentsResponse) toProto() *pb.BatchEmbedContentsResponse {
 		return nil
 	}
 	return &pb.BatchEmbedContentsResponse{
-		Embeddings: transformSlice(v.Embeddings, (*ContentEmbedding).toProto),
+		Embeddings: pvTransformSlice(v.Embeddings, (*ContentEmbedding).toProto),
 	}
 }
 
@@ -50,7 +50,7 @@ func (BatchEmbedContentsResponse) fromProto(p *pb.BatchEmbedContentsResponse) *B
 		return nil
 	}
 	return &BatchEmbedContentsResponse{
-		Embeddings: transformSlice(p.Embeddings, (ContentEmbedding{}).fromProto),
+		Embeddings: pvTransformSlice(p.Embeddings, (ContentEmbedding{}).fromProto),
 	}
 }
 
@@ -149,7 +149,7 @@ func (v *Candidate) toProto() *pb.Candidate {
 		Index:            pvAddrOrNil(v.Index),
 		Content:          v.Content.toProto(),
 		FinishReason:     pb.Candidate_FinishReason(v.FinishReason),
-		SafetyRatings:    transformSlice(v.SafetyRatings, (*SafetyRating).toProto),
+		SafetyRatings:    pvTransformSlice(v.SafetyRatings, (*SafetyRating).toProto),
 		CitationMetadata: v.CitationMetadata.toProto(),
 		TokenCount:       v.TokenCount,
 	}
@@ -163,7 +163,7 @@ func (Candidate) fromProto(p *pb.Candidate) *Candidate {
 		Index:            pvDerefOrZero(p.Index),
 		Content:          (Content{}).fromProto(p.Content),
 		FinishReason:     FinishReason(p.FinishReason),
-		SafetyRatings:    transformSlice(p.SafetyRatings, (SafetyRating{}).fromProto),
+		SafetyRatings:    pvTransformSlice(p.SafetyRatings, (SafetyRating{}).fromProto),
 		CitationMetadata: (CitationMetadata{}).fromProto(p.CitationMetadata),
 		TokenCount:       p.TokenCount,
 	}
@@ -180,7 +180,7 @@ func (v *CitationMetadata) toProto() *pb.CitationMetadata {
 		return nil
 	}
 	return &pb.CitationMetadata{
-		CitationSources: transformSlice(v.CitationSources, (*CitationSource).toProto),
+		CitationSources: pvTransformSlice(v.CitationSources, (*CitationSource).toProto),
 	}
 }
 
@@ -189,7 +189,7 @@ func (CitationMetadata) fromProto(p *pb.CitationMetadata) *CitationMetadata {
 		return nil
 	}
 	return &CitationMetadata{
-		CitationSources: transformSlice(p.CitationSources, (CitationSource{}).fromProto),
+		CitationSources: pvTransformSlice(p.CitationSources, (CitationSource{}).fromProto),
 	}
 }
 
@@ -256,7 +256,7 @@ func (v *Content) toProto() *pb.Content {
 		return nil
 	}
 	return &pb.Content{
-		Parts: transformSlice(v.Parts, partToProto),
+		Parts: pvTransformSlice(v.Parts, partToProto),
 		Role:  v.Role,
 	}
 }
@@ -266,7 +266,7 @@ func (Content) fromProto(p *pb.Content) *Content {
 		return nil
 	}
 	return &Content{
-		Parts: transformSlice(p.Parts, partFromProto),
+		Parts: pvTransformSlice(p.Parts, partFromProto),
 		Role:  p.Role,
 	}
 }
@@ -713,7 +713,7 @@ func (v *GenerateContentResponse) toProto() *pb.GenerateContentResponse {
 		return nil
 	}
 	return &pb.GenerateContentResponse{
-		Candidates:     transformSlice(v.Candidates, (*Candidate).toProto),
+		Candidates:     pvTransformSlice(v.Candidates, (*Candidate).toProto),
 		PromptFeedback: v.PromptFeedback.toProto(),
 		UsageMetadata:  v.UsageMetadata.toProto(),
 	}
@@ -724,7 +724,7 @@ func (GenerateContentResponse) fromProto(p *pb.GenerateContentResponse) *Generat
 		return nil
 	}
 	return &GenerateContentResponse{
-		Candidates:     transformSlice(p.Candidates, (Candidate{}).fromProto),
+		Candidates:     pvTransformSlice(p.Candidates, (Candidate{}).fromProto),
 		PromptFeedback: (PromptFeedback{}).fromProto(p.PromptFeedback),
 		UsageMetadata:  (UsageMetadata{}).fromProto(p.UsageMetadata),
 	}
@@ -1063,7 +1063,7 @@ func (v *PromptFeedback) toProto() *pb.GenerateContentResponse_PromptFeedback {
 	}
 	return &pb.GenerateContentResponse_PromptFeedback{
 		BlockReason:   pb.GenerateContentResponse_PromptFeedback_BlockReason(v.BlockReason),
-		SafetyRatings: transformSlice(v.SafetyRatings, (*SafetyRating).toProto),
+		SafetyRatings: pvTransformSlice(v.SafetyRatings, (*SafetyRating).toProto),
 	}
 }
 
@@ -1073,7 +1073,7 @@ func (PromptFeedback) fromProto(p *pb.GenerateContentResponse_PromptFeedback) *P
 	}
 	return &PromptFeedback{
 		BlockReason:   BlockReason(p.BlockReason),
-		SafetyRatings: transformSlice(p.SafetyRatings, (SafetyRating{}).fromProto),
+		SafetyRatings: pvTransformSlice(p.SafetyRatings, (SafetyRating{}).fromProto),
 	}
 }
 
@@ -1268,7 +1268,7 @@ func (v *Tool) toProto() *pb.Tool {
 		return nil
 	}
 	return &pb.Tool{
-		FunctionDeclarations: transformSlice(v.FunctionDeclarations, (*FunctionDeclaration).toProto),
+		FunctionDeclarations: pvTransformSlice(v.FunctionDeclarations, (*FunctionDeclaration).toProto),
 	}
 }
 
@@ -1277,7 +1277,7 @@ func (Tool) fromProto(p *pb.Tool) *Tool {
 		return nil
 	}
 	return &Tool{
-		FunctionDeclarations: transformSlice(p.FunctionDeclarations, (FunctionDeclaration{}).fromProto),
+		FunctionDeclarations: pvTransformSlice(p.FunctionDeclarations, (FunctionDeclaration{}).fromProto),
 	}
 }
 
@@ -1444,7 +1444,7 @@ func pvMapToStructPB(m map[string]any) *structpb.Struct {
 	}
 	s, err := structpb.NewStruct(m)
 	if err != nil {
-		panic(fmt.Errorf("support.MapToProto: %w", err))
+		panic(pvPanic(fmt.Errorf("pvMapToStructPB: %w", err)))
 	}
 	return s
 }
@@ -1493,3 +1493,5 @@ func pvDurationFromProto(d *durationpb.Duration) time.Duration {
 	}
 	return d.AsDuration()
 }
+
+type pvPanic error

--- a/genai/generativelanguagepb_veneer.gen.go
+++ b/genai/generativelanguagepb_veneer.gen.go
@@ -1494,4 +1494,22 @@ func pvDurationFromProto(d *durationpb.Duration) time.Duration {
 	return d.AsDuration()
 }
 
+// pvPanic wraps panics from support functions.
+// User-provided functions in the same package can also use it.
+// It allows callers to distinguish conversion function panics from other panics.
 type pvPanic error
+
+// pvCatchPanic recovers from panics of type pvPanic and
+// returns an error instead.
+func pvCatchPanic[T any](f func() T) (_ T, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if _, ok := r.(pvPanic); ok {
+				err = r.(error)
+			} else {
+				panic(r)
+			}
+		}
+	}()
+	return f(), nil
+}

--- a/genai/internal/generativelanguage/v1beta/generativelanguage-api.json
+++ b/genai/internal/generativelanguage/v1beta/generativelanguage-api.json
@@ -1,1825 +1,697 @@
 {
-  "protocol": "rest",
-  "mtlsRootUrl": "https://generativelanguage.mtls.googleapis.com/",
-  "icons": {
-    "x16": "http://www.google.com/images/icons/product/search-16.gif",
-    "x32": "http://www.google.com/images/icons/product/search-32.gif"
-  },
-  "batchPath": "batch",
-  "description": "The Gemini API allows developers to build generative AI applications using Gemini models. Gemini is our most capable model, built from the ground up to be multimodal. It can generalize and seamlessly understand, operate across, and combine different types of information including language, images, audio, video, and code. You can use the Gemini API for use cases like reasoning across text and images, content generation, dialogue agents, summarization and classification systems, and more.",
   "servicePath": "",
-  "rootUrl": "https://generativelanguage.googleapis.com/",
   "name": "generativelanguage",
-  "documentationLink": "https://developers.generativeai.google/api",
-  "baseUrl": "https://generativelanguage.googleapis.com/",
-  "kind": "discovery#restDescription",
-  "version_module": true,
-  "parameters": {
-    "callback": {
-      "type": "string",
-      "description": "JSONP",
-      "location": "query"
-    },
-    "uploadType": {
-      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
-      "location": "query",
-      "type": "string"
-    },
-    "fields": {
-      "description": "Selector specifying which fields to include in a partial response.",
-      "type": "string",
-      "location": "query"
-    },
-    "alt": {
-      "enum": [
-        "json",
-        "media",
-        "proto"
-      ],
-      "enumDescriptions": [
-        "Responses with Content-Type of application/json",
-        "Media download with context-dependent Content-Type",
-        "Responses with Content-Type of application/x-protobuf"
-      ],
-      "location": "query",
-      "type": "string",
-      "default": "json",
-      "description": "Data format for response."
-    },
-    "upload_protocol": {
-      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
-      "location": "query",
-      "type": "string"
-    },
-    "$.xgafv": {
-      "location": "query",
-      "description": "V1 error format.",
-      "type": "string",
-      "enumDescriptions": [
-        "v1 error format",
-        "v2 error format"
-      ],
-      "enum": [
-        "1",
-        "2"
-      ]
-    },
-    "prettyPrint": {
-      "default": "true",
-      "type": "boolean",
-      "location": "query",
-      "description": "Returns response with indentations and line breaks."
-    },
-    "oauth_token": {
-      "description": "OAuth 2.0 token for the current user.",
-      "type": "string",
-      "location": "query"
-    },
-    "access_token": {
-      "location": "query",
-      "type": "string",
-      "description": "OAuth access token."
-    },
-    "quotaUser": {
-      "location": "query",
-      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
-      "type": "string"
-    },
-    "key": {
-      "type": "string",
-      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
-      "location": "query"
-    }
-  },
   "discoveryVersion": "v1",
-  "fullyEncodeReservedExpansion": true,
-  "resources": {
-    "models": {
-      "methods": {
-        "batchEmbedContents": {
-          "path": "v1beta/{+model}:batchEmbedContents",
-          "parameters": {
-            "model": {
-              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
-              "location": "path",
-              "required": true,
-              "pattern": "^models/[^/]+$",
-              "type": "string"
-            }
-          },
-          "description": "Generates multiple embeddings from the model given input text in a synchronous call.",
-          "flatPath": "v1beta/models/{modelsId}:batchEmbedContents",
-          "id": "generativelanguage.models.batchEmbedContents",
-          "parameterOrder": [
-            "model"
-          ],
-          "httpMethod": "POST",
-          "response": {
-            "$ref": "BatchEmbedContentsResponse"
-          },
-          "request": {
-            "$ref": "BatchEmbedContentsRequest"
-          }
-        },
-        "embedText": {
-          "path": "v1beta/{+model}:embedText",
-          "description": "Generates an embedding from the model given an input message.",
-          "flatPath": "v1beta/models/{modelsId}:embedText",
-          "httpMethod": "POST",
-          "response": {
-            "$ref": "EmbedTextResponse"
-          },
-          "request": {
-            "$ref": "EmbedTextRequest"
-          },
-          "parameters": {
-            "model": {
-              "type": "string",
-              "required": true,
-              "description": "Required. The model name to use with the format model=models/{model}.",
-              "pattern": "^models/[^/]+$",
-              "location": "path"
-            }
-          },
-          "parameterOrder": [
-            "model"
-          ],
-          "id": "generativelanguage.models.embedText"
-        },
-        "list": {
-          "flatPath": "v1beta/models",
-          "response": {
-            "$ref": "ListModelsResponse"
-          },
-          "description": "Lists models available through the API.",
-          "parameterOrder": [],
-          "path": "v1beta/models",
-          "httpMethod": "GET",
-          "parameters": {
-            "pageToken": {
-              "description": "A page token, received from a previous `ListModels` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListModels` must match the call that provided the page token.",
-              "location": "query",
-              "type": "string"
-            },
-            "pageSize": {
-              "description": "The maximum number of `Models` to return (per page). The service may return fewer models. If unspecified, at most 50 models will be returned per page. This method returns at most 1000 models per page, even if you pass a larger page_size.",
-              "location": "query",
-              "format": "int32",
-              "type": "integer"
-            }
-          },
-          "id": "generativelanguage.models.list"
-        },
-        "embedContent": {
-          "parameters": {
-            "model": {
-              "location": "path",
-              "required": true,
-              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
-              "pattern": "^models/[^/]+$",
-              "type": "string"
-            }
-          },
-          "parameterOrder": [
-            "model"
-          ],
-          "description": "Generates an embedding from the model given an input `Content`.",
-          "request": {
-            "$ref": "EmbedContentRequest"
-          },
-          "path": "v1beta/{+model}:embedContent",
-          "httpMethod": "POST",
-          "response": {
-            "$ref": "EmbedContentResponse"
-          },
-          "flatPath": "v1beta/models/{modelsId}:embedContent",
-          "id": "generativelanguage.models.embedContent"
-        },
-        "streamGenerateContent": {
-          "flatPath": "v1beta/models/{modelsId}:streamGenerateContent",
-          "description": "Generates a streamed response from the model given an input `GenerateContentRequest`.",
-          "path": "v1beta/{+model}:streamGenerateContent",
-          "httpMethod": "POST",
-          "request": {
-            "$ref": "GenerateContentRequest"
-          },
-          "response": {
-            "$ref": "GenerateContentResponse"
-          },
-          "id": "generativelanguage.models.streamGenerateContent",
-          "parameterOrder": [
-            "model"
-          ],
-          "parameters": {
-            "model": {
-              "type": "string",
-              "pattern": "^models/[^/]+$",
-              "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`.",
-              "required": true,
-              "location": "path"
-            }
-          }
-        },
-        "countMessageTokens": {
-          "response": {
-            "$ref": "CountMessageTokensResponse"
-          },
-          "parameterOrder": [
-            "model"
-          ],
-          "flatPath": "v1beta/models/{modelsId}:countMessageTokens",
-          "path": "v1beta/{+model}:countMessageTokens",
-          "request": {
-            "$ref": "CountMessageTokensRequest"
-          },
-          "description": "Runs a model's tokenizer on a string and returns the token count.",
-          "httpMethod": "POST",
-          "id": "generativelanguage.models.countMessageTokens",
-          "parameters": {
-            "model": {
-              "location": "path",
-              "required": true,
-              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
-              "pattern": "^models/[^/]+$",
-              "type": "string"
-            }
-          }
-        },
-        "get": {
-          "parameterOrder": [
-            "name"
-          ],
-          "path": "v1beta/{+name}",
-          "httpMethod": "GET",
-          "flatPath": "v1beta/models/{modelsId}",
-          "parameters": {
-            "name": {
-              "description": "Required. The resource name of the model. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
-              "required": true,
-              "type": "string",
-              "pattern": "^models/[^/]+$",
-              "location": "path"
-            }
-          },
-          "description": "Gets information about a specific Model.",
-          "response": {
-            "$ref": "Model"
-          },
-          "id": "generativelanguage.models.get"
-        },
-        "generateMessage": {
-          "response": {
-            "$ref": "GenerateMessageResponse"
-          },
-          "flatPath": "v1beta/models/{modelsId}:generateMessage",
-          "id": "generativelanguage.models.generateMessage",
-          "request": {
-            "$ref": "GenerateMessageRequest"
-          },
-          "parameters": {
-            "model": {
-              "location": "path",
-              "pattern": "^models/[^/]+$",
-              "description": "Required. The name of the model to use. Format: `name=models/{model}`.",
-              "type": "string",
-              "required": true
-            }
-          },
-          "description": "Generates a response from the model given an input `MessagePrompt`.",
-          "path": "v1beta/{+model}:generateMessage",
-          "httpMethod": "POST",
-          "parameterOrder": [
-            "model"
-          ]
-        },
-        "generateContent": {
-          "description": "Generates a response from the model given an input `GenerateContentRequest`. Input capabilities differ between models, including tuned models. See the [model guide](https://ai.google.dev/models/gemini) and [tuning guide](https://ai.google.dev/docs/model_tuning_guidance) for details.",
-          "parameters": {
-            "model": {
-              "pattern": "^models/[^/]+$",
-              "required": true,
-              "type": "string",
-              "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`.",
-              "location": "path"
-            }
-          },
-          "path": "v1beta/{+model}:generateContent",
-          "id": "generativelanguage.models.generateContent",
-          "parameterOrder": [
-            "model"
-          ],
-          "flatPath": "v1beta/models/{modelsId}:generateContent",
-          "response": {
-            "$ref": "GenerateContentResponse"
-          },
-          "request": {
-            "$ref": "GenerateContentRequest"
-          },
-          "httpMethod": "POST"
-        },
-        "generateAnswer": {
-          "response": {
-            "$ref": "GenerateAnswerResponse"
-          },
-          "httpMethod": "POST",
-          "flatPath": "v1beta/models/{modelsId}:generateAnswer",
-          "description": "Generates a grounded answer from the model given an input `GenerateAnswerRequest`.",
-          "request": {
-            "$ref": "GenerateAnswerRequest"
-          },
-          "parameterOrder": [
-            "model"
-          ],
-          "path": "v1beta/{+model}:generateAnswer",
-          "id": "generativelanguage.models.generateAnswer",
-          "parameters": {
-            "model": {
-              "type": "string",
-              "pattern": "^models/[^/]+$",
-              "required": true,
-              "location": "path",
-              "description": "Required. The name of the `Model` to use for generating the grounded response. Format: `model=models/{model}`."
-            }
-          }
-        },
-        "batchEmbedText": {
-          "response": {
-            "$ref": "BatchEmbedTextResponse"
-          },
-          "path": "v1beta/{+model}:batchEmbedText",
-          "flatPath": "v1beta/models/{modelsId}:batchEmbedText",
-          "parameterOrder": [
-            "model"
-          ],
-          "id": "generativelanguage.models.batchEmbedText",
-          "description": "Generates multiple embeddings from the model given input text in a synchronous call.",
-          "request": {
-            "$ref": "BatchEmbedTextRequest"
-          },
-          "httpMethod": "POST",
-          "parameters": {
-            "model": {
-              "description": "Required. The name of the `Model` to use for generating the embedding. Examples: models/embedding-gecko-001",
-              "location": "path",
-              "required": true,
-              "pattern": "^models/[^/]+$",
-              "type": "string"
-            }
-          }
-        },
-        "generateText": {
-          "path": "v1beta/{+model}:generateText",
-          "response": {
-            "$ref": "GenerateTextResponse"
-          },
-          "flatPath": "v1beta/models/{modelsId}:generateText",
-          "id": "generativelanguage.models.generateText",
-          "request": {
-            "$ref": "GenerateTextRequest"
-          },
-          "parameterOrder": [
-            "model"
-          ],
-          "parameters": {
-            "model": {
-              "location": "path",
-              "type": "string",
-              "required": true,
-              "pattern": "^models/[^/]+$",
-              "description": "Required. The name of the `Model` or `TunedModel` to use for generating the completion. Examples: models/text-bison-001 tunedModels/sentence-translator-u3b7m"
-            }
-          },
-          "description": "Generates a response from the model given an input message.",
-          "httpMethod": "POST"
-        },
-        "countTokens": {
-          "description": "Runs a model's tokenizer on input content and returns the token count.",
-          "path": "v1beta/{+model}:countTokens",
-          "flatPath": "v1beta/models/{modelsId}:countTokens",
-          "parameterOrder": [
-            "model"
-          ],
-          "httpMethod": "POST",
-          "response": {
-            "$ref": "CountTokensResponse"
-          },
-          "id": "generativelanguage.models.countTokens",
-          "parameters": {
-            "model": {
-              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
-              "location": "path",
-              "pattern": "^models/[^/]+$",
-              "required": true,
-              "type": "string"
-            }
-          },
-          "request": {
-            "$ref": "CountTokensRequest"
-          }
-        },
-        "countTextTokens": {
-          "parameterOrder": [
-            "model"
-          ],
-          "flatPath": "v1beta/models/{modelsId}:countTextTokens",
-          "path": "v1beta/{+model}:countTextTokens",
-          "id": "generativelanguage.models.countTextTokens",
-          "parameters": {
-            "model": {
-              "required": true,
-              "type": "string",
-              "location": "path",
-              "pattern": "^models/[^/]+$",
-              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`"
-            }
-          },
-          "request": {
-            "$ref": "CountTextTokensRequest"
-          },
-          "description": "Runs a model's tokenizer on a text and returns the token count.",
-          "response": {
-            "$ref": "CountTextTokensResponse"
-          },
-          "httpMethod": "POST"
-        }
-      }
-    },
-    "corpora": {
-      "methods": {
-        "list": {
-          "response": {
-            "$ref": "ListCorporaResponse"
-          },
-          "description": "Lists all `Corpora` owned by the user.",
-          "id": "generativelanguage.corpora.list",
-          "parameterOrder": [],
-          "path": "v1beta/corpora",
-          "httpMethod": "GET",
-          "flatPath": "v1beta/corpora",
-          "parameters": {
-            "pageSize": {
-              "description": "Optional. The maximum number of `Corpora` to return (per page). The service may return fewer `Corpora`. If unspecified, at most 10 `Corpora` will be returned. The maximum size limit is 20 `Corpora` per page.",
-              "type": "integer",
-              "format": "int32",
-              "location": "query"
-            },
-            "pageToken": {
-              "description": "Optional. A page token, received from a previous `ListCorpora` call. Provide the `next_page_token` returned in the response as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListCorpora` must match the call that provided the page token.",
-              "location": "query",
-              "type": "string"
-            }
-          }
-        },
-        "query": {
-          "httpMethod": "POST",
-          "path": "v1beta/{+name}:query",
-          "id": "generativelanguage.corpora.query",
-          "response": {
-            "$ref": "QueryCorpusResponse"
-          },
-          "parameterOrder": [
-            "name"
-          ],
-          "flatPath": "v1beta/corpora/{corporaId}:query",
-          "request": {
-            "$ref": "QueryCorpusRequest"
-          },
-          "parameters": {
-            "name": {
-              "required": true,
-              "description": "Required. The name of the `Corpus` to query. Example: `corpora/my-corpus-123`",
-              "pattern": "^corpora/[^/]+$",
-              "location": "path",
-              "type": "string"
-            }
-          },
-          "description": "Performs semantic search over a `Corpus`."
-        },
-        "create": {
-          "request": {
-            "$ref": "Corpus"
-          },
-          "response": {
-            "$ref": "Corpus"
-          },
-          "parameterOrder": [],
-          "flatPath": "v1beta/corpora",
-          "httpMethod": "POST",
-          "parameters": {},
-          "description": "Creates an empty `Corpus`.",
-          "path": "v1beta/corpora",
-          "id": "generativelanguage.corpora.create"
-        },
-        "patch": {
-          "parameterOrder": [
-            "name"
-          ],
-          "id": "generativelanguage.corpora.patch",
-          "response": {
-            "$ref": "Corpus"
-          },
-          "request": {
-            "$ref": "Corpus"
-          },
-          "httpMethod": "PATCH",
-          "flatPath": "v1beta/corpora/{corporaId}",
-          "parameters": {
-            "name": {
-              "location": "path",
-              "description": "Immutable. Identifier. The `Corpus` resource name. The ID (name excluding the \"corpora/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/my-awesome-corpora-123a456b789c`",
-              "pattern": "^corpora/[^/]+$",
-              "type": "string",
-              "required": true
-            },
-            "updateMask": {
-              "description": "Required. The list of fields to update. Currently, this only supports updating `display_name`.",
-              "format": "google-fieldmask",
-              "location": "query",
-              "type": "string"
-            }
-          },
-          "description": "Updates a `Corpus`.",
-          "path": "v1beta/{+name}"
-        },
-        "delete": {
-          "path": "v1beta/{+name}",
-          "parameters": {
-            "name": {
-              "location": "path",
-              "type": "string",
-              "required": true,
-              "description": "Required. The resource name of the `Corpus`. Example: `corpora/my-corpus-123`",
-              "pattern": "^corpora/[^/]+$"
-            },
-            "force": {
-              "location": "query",
-              "type": "boolean",
-              "description": "Optional. If set to true, any `Document`s and objects related to this `Corpus` will also be deleted. If false (the default), a `FAILED_PRECONDITION` error will be returned if `Corpus` contains any `Document`s."
-            }
-          },
-          "response": {
-            "$ref": "Empty"
-          },
-          "id": "generativelanguage.corpora.delete",
-          "parameterOrder": [
-            "name"
-          ],
-          "flatPath": "v1beta/corpora/{corporaId}",
-          "description": "Deletes a `Corpus`.",
-          "httpMethod": "DELETE"
-        },
-        "get": {
-          "flatPath": "v1beta/corpora/{corporaId}",
-          "parameters": {
-            "name": {
-              "required": true,
-              "type": "string",
-              "description": "Required. The name of the `Corpus`. Example: `corpora/my-corpus-123`",
-              "location": "path",
-              "pattern": "^corpora/[^/]+$"
-            }
-          },
-          "httpMethod": "GET",
-          "description": "Gets information about a specific `Corpus`.",
-          "parameterOrder": [
-            "name"
-          ],
-          "path": "v1beta/{+name}",
-          "id": "generativelanguage.corpora.get",
-          "response": {
-            "$ref": "Corpus"
-          }
-        }
-      },
-      "resources": {
-        "permissions": {
-          "methods": {
-            "create": {
-              "parameterOrder": [
-                "parent"
-              ],
-              "description": "Create a permission to a specific resource.",
-              "response": {
-                "$ref": "Permission"
-              },
-              "id": "generativelanguage.corpora.permissions.create",
-              "flatPath": "v1beta/corpora/{corporaId}/permissions",
-              "parameters": {
-                "parent": {
-                  "location": "path",
-                  "required": true,
-                  "pattern": "^corpora/[^/]+$",
-                  "type": "string",
-                  "description": "Required. The parent resource of the `Permission`. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`"
-                }
-              },
-              "httpMethod": "POST",
-              "path": "v1beta/{+parent}/permissions",
-              "request": {
-                "$ref": "Permission"
-              }
-            },
-            "patch": {
-              "parameterOrder": [
-                "name"
-              ],
-              "id": "generativelanguage.corpora.permissions.patch",
-              "httpMethod": "PATCH",
-              "description": "Updates the permission.",
-              "parameters": {
-                "updateMask": {
-                  "description": "Required. The list of fields to update. Accepted ones: - role (`Permission.role` field)",
-                  "format": "google-fieldmask",
-                  "location": "query",
-                  "type": "string"
-                },
-                "name": {
-                  "location": "path",
-                  "description": "Output only. Identifier. The permission name. A unique name will be generated on create. Examples: tunedModels/{tuned_model}/permissions/{permission} corpora/{corpus}/permissions/{permission} Output only.",
-                  "required": true,
-                  "pattern": "^corpora/[^/]+/permissions/[^/]+$",
-                  "type": "string"
-                }
-              },
-              "response": {
-                "$ref": "Permission"
-              },
-              "path": "v1beta/{+name}",
-              "request": {
-                "$ref": "Permission"
-              },
-              "flatPath": "v1beta/corpora/{corporaId}/permissions/{permissionsId}"
-            },
-            "list": {
-              "response": {
-                "$ref": "ListPermissionsResponse"
-              },
-              "id": "generativelanguage.corpora.permissions.list",
-              "flatPath": "v1beta/corpora/{corporaId}/permissions",
-              "path": "v1beta/{+parent}/permissions",
-              "parameters": {
-                "parent": {
-                  "required": true,
-                  "description": "Required. The parent resource of the permissions. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`",
-                  "location": "path",
-                  "type": "string",
-                  "pattern": "^corpora/[^/]+$"
-                },
-                "pageToken": {
-                  "description": "Optional. A page token, received from a previous `ListPermissions` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListPermissions` must match the call that provided the page token.",
-                  "location": "query",
-                  "type": "string"
-                },
-                "pageSize": {
-                  "format": "int32",
-                  "description": "Optional. The maximum number of `Permission`s to return (per page). The service may return fewer permissions. If unspecified, at most 10 permissions will be returned. This method returns at most 1000 permissions per page, even if you pass larger page_size.",
-                  "type": "integer",
-                  "location": "query"
-                }
-              },
-              "httpMethod": "GET",
-              "parameterOrder": [
-                "parent"
-              ],
-              "description": "Lists permissions for the specific resource."
-            },
-            "delete": {
-              "parameterOrder": [
-                "name"
-              ],
-              "response": {
-                "$ref": "Empty"
-              },
-              "description": "Deletes the permission.",
-              "flatPath": "v1beta/corpora/{corporaId}/permissions/{permissionsId}",
-              "httpMethod": "DELETE",
-              "parameters": {
-                "name": {
-                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
-                  "required": true,
-                  "location": "path",
-                  "type": "string",
-                  "pattern": "^corpora/[^/]+/permissions/[^/]+$"
-                }
-              },
-              "id": "generativelanguage.corpora.permissions.delete",
-              "path": "v1beta/{+name}"
-            },
-            "get": {
-              "response": {
-                "$ref": "Permission"
-              },
-              "httpMethod": "GET",
-              "parameterOrder": [
-                "name"
-              ],
-              "description": "Gets information about a specific Permission.",
-              "path": "v1beta/{+name}",
-              "parameters": {
-                "name": {
-                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
-                  "required": true,
-                  "location": "path",
-                  "type": "string",
-                  "pattern": "^corpora/[^/]+/permissions/[^/]+$"
-                }
-              },
-              "id": "generativelanguage.corpora.permissions.get",
-              "flatPath": "v1beta/corpora/{corporaId}/permissions/{permissionsId}"
-            }
-          }
-        },
-        "documents": {
-          "methods": {
-            "create": {
-              "flatPath": "v1beta/corpora/{corporaId}/documents",
-              "request": {
-                "$ref": "Document"
-              },
-              "parameterOrder": [
-                "parent"
-              ],
-              "httpMethod": "POST",
-              "parameters": {
-                "parent": {
-                  "type": "string",
-                  "pattern": "^corpora/[^/]+$",
-                  "description": "Required. The name of the `Corpus` where this `Document` will be created. Example: `corpora/my-corpus-123`",
-                  "location": "path",
-                  "required": true
-                }
-              },
-              "path": "v1beta/{+parent}/documents",
-              "response": {
-                "$ref": "Document"
-              },
-              "id": "generativelanguage.corpora.documents.create",
-              "description": "Creates an empty `Document`."
-            },
-            "list": {
-              "id": "generativelanguage.corpora.documents.list",
-              "path": "v1beta/{+parent}/documents",
-              "parameterOrder": [
-                "parent"
-              ],
-              "flatPath": "v1beta/corpora/{corporaId}/documents",
-              "response": {
-                "$ref": "ListDocumentsResponse"
-              },
-              "httpMethod": "GET",
-              "parameters": {
-                "pageToken": {
-                  "location": "query",
-                  "type": "string",
-                  "description": "Optional. A page token, received from a previous `ListDocuments` call. Provide the `next_page_token` returned in the response as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListDocuments` must match the call that provided the page token."
-                },
-                "parent": {
-                  "pattern": "^corpora/[^/]+$",
-                  "location": "path",
-                  "required": true,
-                  "type": "string",
-                  "description": "Required. The name of the `Corpus` containing `Document`s. Example: `corpora/my-corpus-123`"
-                },
-                "pageSize": {
-                  "description": "Optional. The maximum number of `Document`s to return (per page). The service may return fewer `Document`s. If unspecified, at most 10 `Document`s will be returned. The maximum size limit is 20 `Document`s per page.",
-                  "format": "int32",
-                  "type": "integer",
-                  "location": "query"
-                }
-              },
-              "description": "Lists all `Document`s in a `Corpus`."
-            },
-            "get": {
-              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}",
-              "description": "Gets information about a specific `Document`.",
-              "response": {
-                "$ref": "Document"
-              },
-              "id": "generativelanguage.corpora.documents.get",
-              "parameters": {
-                "name": {
-                  "description": "Required. The name of the `Document` to retrieve. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
-                  "type": "string",
-                  "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                  "required": true,
-                  "location": "path"
-                }
-              },
-              "path": "v1beta/{+name}",
-              "httpMethod": "GET",
-              "parameterOrder": [
-                "name"
-              ]
-            },
-            "query": {
-              "path": "v1beta/{+name}:query",
-              "id": "generativelanguage.corpora.documents.query",
-              "httpMethod": "POST",
-              "parameterOrder": [
-                "name"
-              ],
-              "parameters": {
-                "name": {
-                  "location": "path",
-                  "description": "Required. The name of the `Document` to query. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
-                  "type": "string",
-                  "required": true,
-                  "pattern": "^corpora/[^/]+/documents/[^/]+$"
-                }
-              },
-              "request": {
-                "$ref": "QueryDocumentRequest"
-              },
-              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}:query",
-              "response": {
-                "$ref": "QueryDocumentResponse"
-              },
-              "description": "Performs semantic search over a `Document`."
-            },
-            "patch": {
-              "httpMethod": "PATCH",
-              "description": "Updates a `Document`.",
-              "parameterOrder": [
-                "name"
-              ],
-              "parameters": {
-                "name": {
-                  "description": "Immutable. Identifier. The `Document` resource name. The ID (name excluding the \"corpora/*/documents/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/{corpus_id}/documents/my-awesome-doc-123a456b789c`",
-                  "type": "string",
-                  "required": true,
-                  "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                  "location": "path"
-                },
-                "updateMask": {
-                  "type": "string",
-                  "description": "Required. The list of fields to update. Currently, this only supports updating `display_name` and `custom_metadata`.",
-                  "location": "query",
-                  "format": "google-fieldmask"
-                }
-              },
-              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}",
-              "response": {
-                "$ref": "Document"
-              },
-              "id": "generativelanguage.corpora.documents.patch",
-              "path": "v1beta/{+name}",
-              "request": {
-                "$ref": "Document"
-              }
-            },
-            "delete": {
-              "id": "generativelanguage.corpora.documents.delete",
-              "parameters": {
-                "name": {
-                  "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                  "type": "string",
-                  "required": true,
-                  "location": "path",
-                  "description": "Required. The resource name of the `Document` to delete. Example: `corpora/my-corpus-123/documents/the-doc-abc`"
-                },
-                "force": {
-                  "description": "Optional. If set to true, any `Chunk`s and objects related to this `Document` will also be deleted. If false (the default), a `FAILED_PRECONDITION` error will be returned if `Document` contains any `Chunk`s.",
-                  "type": "boolean",
-                  "location": "query"
-                }
-              },
-              "description": "Deletes a `Document`.",
-              "response": {
-                "$ref": "Empty"
-              },
-              "httpMethod": "DELETE",
-              "path": "v1beta/{+name}",
-              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}",
-              "parameterOrder": [
-                "name"
-              ]
-            }
-          },
-          "resources": {
-            "chunks": {
-              "methods": {
-                "create": {
-                  "request": {
-                    "$ref": "Chunk"
-                  },
-                  "parameters": {
-                    "parent": {
-                      "type": "string",
-                      "location": "path",
-                      "required": true,
-                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                      "description": "Required. The name of the `Document` where this `Chunk` will be created. Example: `corpora/my-corpus-123/documents/the-doc-abc`"
-                    }
-                  },
-                  "description": "Creates a `Chunk`.",
-                  "path": "v1beta/{+parent}/chunks",
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks",
-                  "httpMethod": "POST",
-                  "id": "generativelanguage.corpora.documents.chunks.create",
-                  "response": {
-                    "$ref": "Chunk"
-                  },
-                  "parameterOrder": [
-                    "parent"
-                  ]
-                },
-                "patch": {
-                  "httpMethod": "PATCH",
-                  "path": "v1beta/{+name}",
-                  "parameters": {
-                    "updateMask": {
-                      "location": "query",
-                      "type": "string",
-                      "format": "google-fieldmask",
-                      "description": "Required. The list of fields to update. Currently, this only supports updating `custom_metadata` and `data`."
-                    },
-                    "name": {
-                      "required": true,
-                      "pattern": "^corpora/[^/]+/documents/[^/]+/chunks/[^/]+$",
-                      "location": "path",
-                      "type": "string",
-                      "description": "Immutable. Identifier. The `Chunk` resource name. The ID (name excluding the \"corpora/*/documents/*/chunks/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a random 12-character unique ID will be generated. Example: `corpora/{corpus_id}/documents/{document_id}/chunks/123a456b789c`"
-                    }
-                  },
-                  "request": {
-                    "$ref": "Chunk"
-                  },
-                  "id": "generativelanguage.corpora.documents.chunks.patch",
-                  "description": "Updates a `Chunk`.",
-                  "parameterOrder": [
-                    "name"
-                  ],
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks/{chunksId}",
-                  "response": {
-                    "$ref": "Chunk"
-                  }
-                },
-                "batchDelete": {
-                  "id": "generativelanguage.corpora.documents.chunks.batchDelete",
-                  "request": {
-                    "$ref": "BatchDeleteChunksRequest"
-                  },
-                  "parameters": {
-                    "parent": {
-                      "type": "string",
-                      "location": "path",
-                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                      "required": true,
-                      "description": "Optional. The name of the `Document` containing the `Chunk`s to delete. The parent field in every `DeleteChunkRequest` must match this value. Example: `corpora/my-corpus-123/documents/the-doc-abc`"
-                    }
-                  },
-                  "response": {
-                    "$ref": "Empty"
-                  },
-                  "path": "v1beta/{+parent}/chunks:batchDelete",
-                  "httpMethod": "POST",
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks:batchDelete",
-                  "parameterOrder": [
-                    "parent"
-                  ],
-                  "description": "Batch delete `Chunk`s."
-                },
-                "batchUpdate": {
-                  "path": "v1beta/{+parent}/chunks:batchUpdate",
-                  "id": "generativelanguage.corpora.documents.chunks.batchUpdate",
-                  "response": {
-                    "$ref": "BatchUpdateChunksResponse"
-                  },
-                  "parameterOrder": [
-                    "parent"
-                  ],
-                  "httpMethod": "POST",
-                  "description": "Batch update `Chunk`s.",
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks:batchUpdate",
-                  "request": {
-                    "$ref": "BatchUpdateChunksRequest"
-                  },
-                  "parameters": {
-                    "parent": {
-                      "description": "Optional. The name of the `Document` containing the `Chunk`s to update. The parent field in every `UpdateChunkRequest` must match this value. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
-                      "location": "path",
-                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                      "type": "string",
-                      "required": true
-                    }
-                  }
-                },
-                "batchCreate": {
-                  "request": {
-                    "$ref": "BatchCreateChunksRequest"
-                  },
-                  "path": "v1beta/{+parent}/chunks:batchCreate",
-                  "id": "generativelanguage.corpora.documents.chunks.batchCreate",
-                  "httpMethod": "POST",
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks:batchCreate",
-                  "parameterOrder": [
-                    "parent"
-                  ],
-                  "description": "Batch create `Chunk`s.",
-                  "response": {
-                    "$ref": "BatchCreateChunksResponse"
-                  },
-                  "parameters": {
-                    "parent": {
-                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                      "type": "string",
-                      "description": "Optional. The name of the `Document` where this batch of `Chunk`s will be created. The parent field in every `CreateChunkRequest` must match this value. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
-                      "location": "path",
-                      "required": true
-                    }
-                  }
-                },
-                "get": {
-                  "path": "v1beta/{+name}",
-                  "parameterOrder": [
-                    "name"
-                  ],
-                  "id": "generativelanguage.corpora.documents.chunks.get",
-                  "description": "Gets information about a specific `Chunk`.",
-                  "parameters": {
-                    "name": {
-                      "location": "path",
-                      "required": true,
-                      "type": "string",
-                      "pattern": "^corpora/[^/]+/documents/[^/]+/chunks/[^/]+$",
-                      "description": "Required. The name of the `Chunk` to retrieve. Example: `corpora/my-corpus-123/documents/the-doc-abc/chunks/some-chunk`"
-                    }
-                  },
-                  "httpMethod": "GET",
-                  "response": {
-                    "$ref": "Chunk"
-                  },
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks/{chunksId}"
-                },
-                "delete": {
-                  "path": "v1beta/{+name}",
-                  "parameterOrder": [
-                    "name"
-                  ],
-                  "httpMethod": "DELETE",
-                  "description": "Deletes a `Chunk`.",
-                  "id": "generativelanguage.corpora.documents.chunks.delete",
-                  "parameters": {
-                    "name": {
-                      "pattern": "^corpora/[^/]+/documents/[^/]+/chunks/[^/]+$",
-                      "type": "string",
-                      "required": true,
-                      "description": "Required. The resource name of the `Chunk` to delete. Example: `corpora/my-corpus-123/documents/the-doc-abc/chunks/some-chunk`",
-                      "location": "path"
-                    }
-                  },
-                  "response": {
-                    "$ref": "Empty"
-                  },
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks/{chunksId}"
-                },
-                "list": {
-                  "description": "Lists all `Chunk`s in a `Document`.",
-                  "parameters": {
-                    "pageSize": {
-                      "location": "query",
-                      "description": "Optional. The maximum number of `Chunk`s to return (per page). The service may return fewer `Chunk`s. If unspecified, at most 10 `Chunk`s will be returned. The maximum size limit is 100 `Chunk`s per page.",
-                      "format": "int32",
-                      "type": "integer"
-                    },
-                    "parent": {
-                      "required": true,
-                      "location": "path",
-                      "type": "string",
-                      "description": "Required. The name of the `Document` containing `Chunk`s. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
-                      "pattern": "^corpora/[^/]+/documents/[^/]+$"
-                    },
-                    "pageToken": {
-                      "type": "string",
-                      "location": "query",
-                      "description": "Optional. A page token, received from a previous `ListChunks` call. Provide the `next_page_token` returned in the response as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListChunks` must match the call that provided the page token."
-                    }
-                  },
-                  "response": {
-                    "$ref": "ListChunksResponse"
-                  },
-                  "id": "generativelanguage.corpora.documents.chunks.list",
-                  "httpMethod": "GET",
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks",
-                  "parameterOrder": [
-                    "parent"
-                  ],
-                  "path": "v1beta/{+parent}/chunks"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "files": {
-      "methods": {
-        "get": {
-          "id": "generativelanguage.files.get",
-          "httpMethod": "GET",
-          "response": {
-            "$ref": "File"
-          },
-          "description": "Gets the metadata for the given `File`.",
-          "path": "v1beta/{+name}",
-          "parameterOrder": [
-            "name"
-          ],
-          "flatPath": "v1beta/files/{filesId}",
-          "parameters": {
-            "name": {
-              "required": true,
-              "type": "string",
-              "description": "Required. The name of the `File` to get. Example: `files/abc-123`",
-              "pattern": "^files/[^/]+$",
-              "location": "path"
-            }
-          }
-        },
-        "list": {
-          "description": "Lists the metadata for `File`s owned by the requesting project.",
-          "parameterOrder": [],
-          "flatPath": "v1beta/files",
-          "httpMethod": "GET",
-          "response": {
-            "$ref": "ListFilesResponse"
-          },
-          "parameters": {
-            "pageSize": {
-              "description": "Optional. Maximum number of `File`s to return per page. If unspecified, defaults to 10. Maximum `page_size` is 100.",
-              "location": "query",
-              "type": "integer",
-              "format": "int32"
-            },
-            "pageToken": {
-              "description": "Optional. A page token from a previous `ListFiles` call.",
-              "type": "string",
-              "location": "query"
-            }
-          },
-          "path": "v1beta/files",
-          "id": "generativelanguage.files.list"
-        },
-        "delete": {
-          "parameterOrder": [
-            "name"
-          ],
-          "response": {
-            "$ref": "Empty"
-          },
-          "description": "Deletes the `File`.",
-          "path": "v1beta/{+name}",
-          "httpMethod": "DELETE",
-          "id": "generativelanguage.files.delete",
-          "flatPath": "v1beta/files/{filesId}",
-          "parameters": {
-            "name": {
-              "required": true,
-              "location": "path",
-              "pattern": "^files/[^/]+$",
-              "type": "string",
-              "description": "Required. The name of the `File` to delete. Example: `files/abc-123`"
-            }
-          }
-        }
-      }
-    },
-    "cachedContents": {
-      "methods": {
-        "get": {
-          "parameters": {
-            "name": {
-              "type": "string",
-              "pattern": "^cachedContents/[^/]+$",
-              "location": "path",
-              "description": "Required. The resource name referring to the content cache entry. Format: `cachedContents/{id}`",
-              "required": true
-            }
-          },
-          "flatPath": "v1beta/cachedContents/{cachedContentsId}",
-          "parameterOrder": [
-            "name"
-          ],
-          "id": "generativelanguage.cachedContents.get",
-          "httpMethod": "GET",
-          "path": "v1beta/{+name}",
-          "description": "Reads CachedContent resource.",
-          "response": {
-            "$ref": "CachedContent"
-          }
-        },
-        "patch": {
-          "description": "Updates CachedContent resource (only expiration is updatable).",
-          "httpMethod": "PATCH",
-          "id": "generativelanguage.cachedContents.patch",
-          "flatPath": "v1beta/cachedContents/{cachedContentsId}",
-          "response": {
-            "$ref": "CachedContent"
-          },
-          "parameterOrder": [
-            "name"
-          ],
-          "path": "v1beta/{+name}",
-          "parameters": {
-            "name": {
-              "description": "Optional. Identifier. The resource name referring to the cached content. Format: `cachedContents/{id}`",
-              "type": "string",
-              "location": "path",
-              "required": true,
-              "pattern": "^cachedContents/[^/]+$"
-            },
-            "updateMask": {
-              "type": "string",
-              "location": "query",
-              "format": "google-fieldmask",
-              "description": "The list of fields to update."
-            }
-          },
-          "request": {
-            "$ref": "CachedContent"
-          }
-        },
-        "create": {
-          "path": "v1beta/cachedContents",
-          "httpMethod": "POST",
-          "request": {
-            "$ref": "CachedContent"
-          },
-          "flatPath": "v1beta/cachedContents",
-          "description": "Creates CachedContent resource.",
-          "id": "generativelanguage.cachedContents.create",
-          "response": {
-            "$ref": "CachedContent"
-          },
-          "parameterOrder": [],
-          "parameters": {}
-        },
-        "list": {
-          "description": "Lists CachedContents.",
-          "parameterOrder": [],
-          "parameters": {
-            "pageSize": {
-              "type": "integer",
-              "location": "query",
-              "format": "int32",
-              "description": "Optional. The maximum number of cached contents to return. The service may return fewer than this value. If unspecified, some default (under maximum) number of items will be returned. The maximum value is 1000; values above 1000 will be coerced to 1000."
-            },
-            "pageToken": {
-              "location": "query",
-              "description": "Optional. A page token, received from a previous `ListCachedContents` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListCachedContents` must match the call that provided the page token.",
-              "type": "string"
-            }
-          },
-          "httpMethod": "GET",
-          "response": {
-            "$ref": "ListCachedContentsResponse"
-          },
-          "path": "v1beta/cachedContents",
-          "id": "generativelanguage.cachedContents.list",
-          "flatPath": "v1beta/cachedContents"
-        },
-        "delete": {
-          "id": "generativelanguage.cachedContents.delete",
-          "response": {
-            "$ref": "Empty"
-          },
-          "parameterOrder": [
-            "name"
-          ],
-          "flatPath": "v1beta/cachedContents/{cachedContentsId}",
-          "parameters": {
-            "name": {
-              "pattern": "^cachedContents/[^/]+$",
-              "required": true,
-              "type": "string",
-              "location": "path",
-              "description": "Required. The resource name referring to the content cache entry Format: `cachedContents/{id}`"
-            }
-          },
-          "description": "Deletes CachedContent resource.",
-          "httpMethod": "DELETE",
-          "path": "v1beta/{+name}"
-        }
-      }
-    },
-    "media": {
-      "methods": {
-        "upload": {
-          "request": {
-            "$ref": "CreateFileRequest"
-          },
-          "parameters": {},
-          "httpMethod": "POST",
-          "supportsMediaUpload": true,
-          "path": "v1beta/files",
-          "response": {
-            "$ref": "CreateFileResponse"
-          },
-          "id": "generativelanguage.media.upload",
-          "parameterOrder": [],
-          "mediaUpload": {
-            "accept": [
-              "*/*"
-            ],
-            "protocols": {
-              "simple": {
-                "multipart": true,
-                "path": "/upload/v1beta/files"
-              },
-              "resumable": {
-                "path": "/resumable/upload/v1beta/files",
-                "multipart": true
-              }
-            },
-            "maxSize": "2147483648"
-          },
-          "flatPath": "v1beta/files",
-          "description": "Creates a `File`."
-        }
-      }
-    },
-    "tunedModels": {
-      "resources": {
-        "permissions": {
-          "methods": {
-            "patch": {
-              "description": "Updates the permission.",
-              "parameters": {
-                "updateMask": {
-                  "location": "query",
-                  "format": "google-fieldmask",
-                  "type": "string",
-                  "description": "Required. The list of fields to update. Accepted ones: - role (`Permission.role` field)"
-                },
-                "name": {
-                  "pattern": "^tunedModels/[^/]+/permissions/[^/]+$",
-                  "type": "string",
-                  "required": true,
-                  "location": "path",
-                  "description": "Output only. Identifier. The permission name. A unique name will be generated on create. Examples: tunedModels/{tuned_model}/permissions/{permission} corpora/{corpus}/permissions/{permission} Output only."
-                }
-              },
-              "id": "generativelanguage.tunedModels.permissions.patch",
-              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions/{permissionsId}",
-              "path": "v1beta/{+name}",
-              "parameterOrder": [
-                "name"
-              ],
-              "request": {
-                "$ref": "Permission"
-              },
-              "response": {
-                "$ref": "Permission"
-              },
-              "httpMethod": "PATCH"
-            },
-            "list": {
-              "description": "Lists permissions for the specific resource.",
-              "httpMethod": "GET",
-              "response": {
-                "$ref": "ListPermissionsResponse"
-              },
-              "parameters": {
-                "pageSize": {
-                  "description": "Optional. The maximum number of `Permission`s to return (per page). The service may return fewer permissions. If unspecified, at most 10 permissions will be returned. This method returns at most 1000 permissions per page, even if you pass larger page_size.",
-                  "location": "query",
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "pageToken": {
-                  "description": "Optional. A page token, received from a previous `ListPermissions` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListPermissions` must match the call that provided the page token.",
-                  "type": "string",
-                  "location": "query"
-                },
-                "parent": {
-                  "pattern": "^tunedModels/[^/]+$",
-                  "description": "Required. The parent resource of the permissions. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`",
-                  "type": "string",
-                  "required": true,
-                  "location": "path"
-                }
-              },
-              "parameterOrder": [
-                "parent"
-              ],
-              "id": "generativelanguage.tunedModels.permissions.list",
-              "path": "v1beta/{+parent}/permissions",
-              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions"
-            },
-            "get": {
-              "path": "v1beta/{+name}",
-              "parameterOrder": [
-                "name"
-              ],
-              "description": "Gets information about a specific Permission.",
-              "response": {
-                "$ref": "Permission"
-              },
-              "id": "generativelanguage.tunedModels.permissions.get",
-              "parameters": {
-                "name": {
-                  "pattern": "^tunedModels/[^/]+/permissions/[^/]+$",
-                  "location": "path",
-                  "required": true,
-                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
-                  "type": "string"
-                }
-              },
-              "httpMethod": "GET",
-              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions/{permissionsId}"
-            },
-            "create": {
-              "parameters": {
-                "parent": {
-                  "required": true,
-                  "type": "string",
-                  "description": "Required. The parent resource of the `Permission`. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`",
-                  "location": "path",
-                  "pattern": "^tunedModels/[^/]+$"
-                }
-              },
-              "path": "v1beta/{+parent}/permissions",
-              "request": {
-                "$ref": "Permission"
-              },
-              "parameterOrder": [
-                "parent"
-              ],
-              "httpMethod": "POST",
-              "response": {
-                "$ref": "Permission"
-              },
-              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions",
-              "id": "generativelanguage.tunedModels.permissions.create",
-              "description": "Create a permission to a specific resource."
-            },
-            "delete": {
-              "parameters": {
-                "name": {
-                  "location": "path",
-                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
-                  "type": "string",
-                  "required": true,
-                  "pattern": "^tunedModels/[^/]+/permissions/[^/]+$"
-                }
-              },
-              "path": "v1beta/{+name}",
-              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions/{permissionsId}",
-              "description": "Deletes the permission.",
-              "httpMethod": "DELETE",
-              "parameterOrder": [
-                "name"
-              ],
-              "id": "generativelanguage.tunedModels.permissions.delete",
-              "response": {
-                "$ref": "Empty"
-              }
-            }
-          }
-        }
-      },
-      "methods": {
-        "generateContent": {
-          "request": {
-            "$ref": "GenerateContentRequest"
-          },
-          "response": {
-            "$ref": "GenerateContentResponse"
-          },
-          "parameters": {
-            "model": {
-              "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`.",
-              "type": "string",
-              "location": "path",
-              "required": true,
-              "pattern": "^tunedModels/[^/]+$"
-            }
-          },
-          "id": "generativelanguage.tunedModels.generateContent",
-          "parameterOrder": [
-            "model"
-          ],
-          "description": "Generates a response from the model given an input `GenerateContentRequest`. Input capabilities differ between models, including tuned models. See the [model guide](https://ai.google.dev/models/gemini) and [tuning guide](https://ai.google.dev/docs/model_tuning_guidance) for details.",
-          "flatPath": "v1beta/tunedModels/{tunedModelsId}:generateContent",
-          "httpMethod": "POST",
-          "path": "v1beta/{+model}:generateContent"
-        },
-        "generateText": {
-          "parameters": {
-            "model": {
-              "pattern": "^tunedModels/[^/]+$",
-              "type": "string",
-              "required": true,
-              "location": "path",
-              "description": "Required. The name of the `Model` or `TunedModel` to use for generating the completion. Examples: models/text-bison-001 tunedModels/sentence-translator-u3b7m"
-            }
-          },
-          "description": "Generates a response from the model given an input message.",
-          "id": "generativelanguage.tunedModels.generateText",
-          "path": "v1beta/{+model}:generateText",
-          "parameterOrder": [
-            "model"
-          ],
-          "response": {
-            "$ref": "GenerateTextResponse"
-          },
-          "httpMethod": "POST",
-          "flatPath": "v1beta/tunedModels/{tunedModelsId}:generateText",
-          "request": {
-            "$ref": "GenerateTextRequest"
-          }
-        },
-        "patch": {
-          "id": "generativelanguage.tunedModels.patch",
-          "request": {
-            "$ref": "TunedModel"
-          },
-          "description": "Updates a tuned model.",
-          "parameters": {
-            "name": {
-              "required": true,
-              "type": "string",
-              "description": "Output only. The tuned model name. A unique name will be generated on create. Example: `tunedModels/az2mb0bpw6i` If display_name is set on create, the id portion of the name will be set by concatenating the words of the display_name with hyphens and adding a random portion for uniqueness. Example: display_name = \"Sentence Translator\" name = \"tunedModels/sentence-translator-u3b7m\"",
-              "pattern": "^tunedModels/[^/]+$",
-              "location": "path"
-            },
-            "updateMask": {
-              "type": "string",
-              "description": "Required. The list of fields to update.",
-              "format": "google-fieldmask",
-              "location": "query"
-            }
-          },
-          "httpMethod": "PATCH",
-          "flatPath": "v1beta/tunedModels/{tunedModelsId}",
-          "path": "v1beta/{+name}",
-          "parameterOrder": [
-            "name"
-          ],
-          "response": {
-            "$ref": "TunedModel"
-          }
-        },
-        "get": {
-          "parameterOrder": [
-            "name"
-          ],
-          "id": "generativelanguage.tunedModels.get",
-          "description": "Gets information about a specific TunedModel.",
-          "flatPath": "v1beta/tunedModels/{tunedModelsId}",
-          "response": {
-            "$ref": "TunedModel"
-          },
-          "parameters": {
-            "name": {
-              "pattern": "^tunedModels/[^/]+$",
-              "location": "path",
-              "required": true,
-              "type": "string",
-              "description": "Required. The resource name of the model. Format: `tunedModels/my-model-id`"
-            }
-          },
-          "httpMethod": "GET",
-          "path": "v1beta/{+name}"
-        },
-        "delete": {
-          "path": "v1beta/{+name}",
-          "description": "Deletes a tuned model.",
-          "id": "generativelanguage.tunedModels.delete",
-          "response": {
-            "$ref": "Empty"
-          },
-          "flatPath": "v1beta/tunedModels/{tunedModelsId}",
-          "httpMethod": "DELETE",
-          "parameters": {
-            "name": {
-              "type": "string",
-              "description": "Required. The resource name of the model. Format: `tunedModels/my-model-id`",
-              "required": true,
-              "pattern": "^tunedModels/[^/]+$",
-              "location": "path"
-            }
-          },
-          "parameterOrder": [
-            "name"
-          ]
-        },
-        "transferOwnership": {
-          "parameters": {
-            "name": {
-              "description": "Required. The resource name of the tuned model to transfer ownership. Format: `tunedModels/my-model-id`",
-              "pattern": "^tunedModels/[^/]+$",
-              "type": "string",
-              "required": true,
-              "location": "path"
-            }
-          },
-          "path": "v1beta/{+name}:transferOwnership",
-          "httpMethod": "POST",
-          "flatPath": "v1beta/tunedModels/{tunedModelsId}:transferOwnership",
-          "request": {
-            "$ref": "TransferOwnershipRequest"
-          },
-          "description": "Transfers ownership of the tuned model. This is the only way to change ownership of the tuned model. The current owner will be downgraded to writer role.",
-          "response": {
-            "$ref": "TransferOwnershipResponse"
-          },
-          "id": "generativelanguage.tunedModels.transferOwnership",
-          "parameterOrder": [
-            "name"
-          ]
-        },
-        "create": {
-          "path": "v1beta/tunedModels",
-          "parameters": {
-            "tunedModelId": {
-              "type": "string",
-              "description": "Optional. The unique id for the tuned model if specified. This value should be up to 40 characters, the first character must be a letter, the last could be a letter or a number. The id must match the regular expression: [a-z]([a-z0-9-]{0,38}[a-z0-9])?.",
-              "location": "query"
-            }
-          },
-          "id": "generativelanguage.tunedModels.create",
-          "description": "Creates a tuned model. Intermediate tuning progress (if any) is accessed through the [google.longrunning.Operations] service. Status and results can be accessed through the Operations service. Example: GET /v1/tunedModels/az2mb0bpw6i/operations/000-111-222",
-          "httpMethod": "POST",
-          "request": {
-            "$ref": "TunedModel"
-          },
-          "response": {
-            "$ref": "Operation"
-          },
-          "parameterOrder": [],
-          "flatPath": "v1beta/tunedModels"
-        },
-        "list": {
-          "flatPath": "v1beta/tunedModels",
-          "parameters": {
-            "pageToken": {
-              "description": "Optional. A page token, received from a previous `ListTunedModels` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListTunedModels` must match the call that provided the page token.",
-              "type": "string",
-              "location": "query"
-            },
-            "pageSize": {
-              "type": "integer",
-              "location": "query",
-              "format": "int32",
-              "description": "Optional. The maximum number of `TunedModels` to return (per page). The service may return fewer tuned models. If unspecified, at most 10 tuned models will be returned. This method returns at most 1000 models per page, even if you pass a larger page_size."
-            },
-            "filter": {
-              "location": "query",
-              "type": "string",
-              "description": "Optional. A filter is a full text search over the tuned model's description and display name. By default, results will not include tuned models shared with everyone. Additional operators: - owner:me - writers:me - readers:me - readers:everyone Examples: \"owner:me\" returns all tuned models to which caller has owner role \"readers:me\" returns all tuned models to which caller has reader role \"readers:everyone\" returns all tuned models that are shared with everyone"
-            }
-          },
-          "parameterOrder": [],
-          "description": "Lists tuned models owned by the user.",
-          "httpMethod": "GET",
-          "response": {
-            "$ref": "ListTunedModelsResponse"
-          },
-          "id": "generativelanguage.tunedModels.list",
-          "path": "v1beta/tunedModels"
-        }
-      }
-    }
-  },
   "schemas": {
-    "CustomMetadata": {
-      "type": "object",
+    "ToolConfig": {
       "properties": {
-        "key": {
-          "type": "string",
-          "description": "Required. The key of the metadata to store."
-        },
-        "stringListValue": {
-          "$ref": "StringList",
-          "description": "The StringList value of the metadata to store."
-        },
-        "numericValue": {
-          "description": "The numeric value of the metadata to store.",
-          "type": "number",
-          "format": "float"
-        },
-        "stringValue": {
-          "description": "The string value of the metadata to store.",
-          "type": "string"
+        "functionCallingConfig": {
+          "description": "Optional. Function calling config.",
+          "$ref": "FunctionCallingConfig"
         }
       },
-      "description": "User provided metadata stored as key-value pairs.",
-      "id": "CustomMetadata"
-    },
-    "Content": {
-      "properties": {
-        "role": {
-          "type": "string",
-          "description": "Optional. The producer of the content. Must be either 'user' or 'model'. Useful to set for multi-turn conversations, otherwise can be left blank or unset."
-        },
-        "parts": {
-          "items": {
-            "$ref": "Part"
-          },
-          "type": "array",
-          "description": "Ordered `Parts` that constitute a single message. Parts may have different MIME types."
-        }
-      },
-      "description": "The base structured datatype containing multi-part content of a message. A `Content` includes a `role` field designating the producer of the `Content` and a `parts` field containing multi-part data that contains the content of the message turn.",
-      "id": "Content",
-      "type": "object"
-    },
-    "CreateChunkRequest": {
       "type": "object",
+      "id": "ToolConfig",
+      "description": "The Tool configuration containing parameters for specifying `Tool` use in the request."
+    },
+    "SemanticRetrieverChunk": {
+      "id": "SemanticRetrieverChunk",
       "properties": {
         "chunk": {
-          "description": "Required. The `Chunk` to create.",
-          "$ref": "Chunk"
-        },
-        "parent": {
+          "description": "Output only. Name of the `Chunk` containing the attributed text. Example: `corpora/123/documents/abc/chunks/xyz`",
           "type": "string",
-          "description": "Required. The name of the `Document` where this `Chunk` will be created. Example: `corpora/my-corpus-123/documents/the-doc-abc`"
+          "readOnly": true
+        },
+        "source": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Output only. Name of the source matching the request's `SemanticRetrieverConfig.source`. Example: `corpora/123` or `corpora/123/documents/abc`"
         }
       },
-      "id": "CreateChunkRequest",
-      "description": "Request to create a `Chunk`."
+      "type": "object",
+      "description": "Identifier for a `Chunk` retrieved via Semantic Retriever specified in the `GenerateAnswerRequest` using `SemanticRetrieverConfig`."
     },
-    "TunedModel": {
+    "InputFeedback": {
+      "description": "Feedback related to the input data used to answer the question, as opposed to model-generated response to the question.",
+      "id": "InputFeedback",
       "type": "object",
       "properties": {
-        "temperature": {
-          "type": "number",
-          "description": "Optional. Controls the randomness of the output. Values can range over `[0.0,1.0]`, inclusive. A value closer to `1.0` will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model. This value specifies default to be the one used by the base model while creating the model.",
-          "format": "float"
+        "safetyRatings": {
+          "items": {
+            "$ref": "SafetyRating"
+          },
+          "type": "array",
+          "description": "Ratings for safety of the input. There is at most one rating per category."
         },
-        "updateTime": {
-          "readOnly": true,
-          "description": "Output only. The timestamp when this model was updated.",
-          "format": "google-datetime",
-          "type": "string"
-        },
-        "name": {
-          "readOnly": true,
+        "blockReason": {
+          "enum": [
+            "BLOCK_REASON_UNSPECIFIED",
+            "SAFETY",
+            "OTHER"
+          ],
+          "enumDescriptions": [
+            "Default value. This value is unused.",
+            "Input was blocked due to safety reasons. You can inspect `safety_ratings` to understand which safety category blocked it.",
+            "Input was blocked due to other reasons."
+          ],
           "type": "string",
-          "description": "Output only. The tuned model name. A unique name will be generated on create. Example: `tunedModels/az2mb0bpw6i` If display_name is set on create, the id portion of the name will be set by concatenating the words of the display_name with hyphens and adding a random portion for uniqueness. Example: display_name = \"Sentence Translator\" name = \"tunedModels/sentence-translator-u3b7m\""
+          "description": "Optional. If set, the input was blocked and no candidates are returned. Rephrase your input."
+        }
+      }
+    },
+    "AttributionSourceId": {
+      "id": "AttributionSourceId",
+      "properties": {
+        "groundingPassage": {
+          "$ref": "GroundingPassageId",
+          "description": "Identifier for an inline passage."
         },
-        "displayName": {
-          "type": "string",
-          "description": "Optional. The name to display for this model in user interfaces. The display name must be up to 40 characters including spaces."
-        },
-        "baseModel": {
-          "description": "Immutable. The name of the `Model` to tune. Example: `models/text-bison-001`",
-          "type": "string"
-        },
-        "topK": {
+        "semanticRetrieverChunk": {
+          "$ref": "SemanticRetrieverChunk",
+          "description": "Identifier for a `Chunk` fetched via Semantic Retriever."
+        }
+      },
+      "type": "object",
+      "description": "Identifier for the source contributing to this attribution."
+    },
+    "QueryCorpusRequest": {
+      "id": "QueryCorpusRequest",
+      "properties": {
+        "resultsCount": {
           "format": "int32",
-          "description": "Optional. For Top-k sampling. Top-k sampling considers the set of `top_k` most probable tokens. This value specifies default to be used by the backend while making the call to the model. This value specifies default to be the one used by the base model while creating the model.",
+          "type": "integer",
+          "description": "Optional. The maximum number of `Chunk`s to return. The service may return fewer `Chunk`s. If unspecified, at most 10 `Chunk`s will be returned. The maximum specified result count is 100."
+        },
+        "metadataFilters": {
+          "items": {
+            "$ref": "MetadataFilter"
+          },
+          "type": "array",
+          "description": "Optional. Filter for `Chunk` and `Document` metadata. Each `MetadataFilter` object should correspond to a unique key. Multiple `MetadataFilter` objects are joined by logical \"AND\"s. Example query at document level: (year \u003e= 2020 OR year \u003c 2010) AND (genre = drama OR genre = action) `MetadataFilter` object list: metadata_filters = [ {key = \"document.custom_metadata.year\" conditions = [{int_value = 2020, operation = GREATER_EQUAL}, {int_value = 2010, operation = LESS}]}, {key = \"document.custom_metadata.year\" conditions = [{int_value = 2020, operation = GREATER_EQUAL}, {int_value = 2010, operation = LESS}]}, {key = \"document.custom_metadata.genre\" conditions = [{string_value = \"drama\", operation = EQUAL}, {string_value = \"action\", operation = EQUAL}]}] Example query at chunk level for a numeric range of values: (year \u003e 2015 AND year \u003c= 2020) `MetadataFilter` object list: metadata_filters = [ {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2015, operation = GREATER}]}, {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2020, operation = LESS_EQUAL}]}] Note: \"AND\"s for the same key are only supported for numeric values. String values only support \"OR\"s for the same key."
+        },
+        "query": {
+          "type": "string",
+          "description": "Required. Query string to perform semantic search."
+        }
+      },
+      "type": "object",
+      "description": "Request for querying a `Corpus`."
+    },
+    "Message": {
+      "id": "Message",
+      "properties": {
+        "citationMetadata": {
+          "readOnly": true,
+          "$ref": "CitationMetadata",
+          "description": "Output only. Citation information for model-generated `content` in this `Message`. If this `Message` was generated as output from the model, this field may be populated with attribution information for any text included in the `content`. This field is used only on output."
+        },
+        "content": {
+          "description": "Required. The text content of the structured `Message`.",
+          "type": "string"
+        },
+        "author": {
+          "type": "string",
+          "description": "Optional. The author of this Message. This serves as a key for tagging the content of this Message when it is fed to the model as text. The author can be any alphanumeric string."
+        }
+      },
+      "description": "The base unit of structured text. A `Message` includes an `author` and the `content` of the `Message`. The `author` is used to tag messages when they are fed to the model as text.",
+      "type": "object"
+    },
+    "Candidate": {
+      "id": "Candidate",
+      "type": "object",
+      "description": "A response candidate generated from the model.",
+      "properties": {
+        "tokenCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Output only. Token count for this candidate.",
+          "readOnly": true
+        },
+        "citationMetadata": {
+          "description": "Output only. Citation information for model-generated candidate. This field may be populated with recitation information for any text included in the `content`. These are passages that are \"recited\" from copyrighted material in the foundational LLM's training data.",
+          "$ref": "CitationMetadata",
+          "readOnly": true
+        },
+        "groundingAttributions": {
+          "readOnly": true,
+          "items": {
+            "$ref": "GroundingAttribution"
+          },
+          "description": "Output only. Attribution information for sources that contributed to a grounded answer. This field is populated for `GenerateAnswer` calls.",
+          "type": "array"
+        },
+        "content": {
+          "readOnly": true,
+          "$ref": "Content",
+          "description": "Output only. Generated content returned from the model."
+        },
+        "finishReason": {
+          "enum": [
+            "FINISH_REASON_UNSPECIFIED",
+            "STOP",
+            "MAX_TOKENS",
+            "SAFETY",
+            "RECITATION",
+            "OTHER"
+          ],
+          "type": "string",
+          "enumDescriptions": [
+            "Default value. This value is unused.",
+            "Natural stop point of the model or provided stop sequence.",
+            "The maximum number of tokens as specified in the request was reached.",
+            "The candidate content was flagged for safety reasons.",
+            "The candidate content was flagged for recitation reasons.",
+            "Unknown reason."
+          ],
+          "description": "Optional. Output only. The reason why the model stopped generating tokens. If empty, the model has not stopped generating the tokens.",
+          "readOnly": true
+        },
+        "index": {
+          "description": "Output only. Index of the candidate in the list of candidates.",
+          "format": "int32",
+          "readOnly": true,
           "type": "integer"
         },
-        "tunedModelSource": {
-          "$ref": "TunedModelSource",
-          "description": "Optional. TunedModel to use as the starting point for training the new model."
+        "safetyRatings": {
+          "description": "List of ratings for the safety of a response candidate. There is at most one rating per category.",
+          "items": {
+            "$ref": "SafetyRating"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "GenerateAnswerRequest": {
+      "id": "GenerateAnswerRequest",
+      "description": "Request to generate a grounded answer from the model.",
+      "type": "object",
+      "properties": {
+        "contents": {
+          "type": "array",
+          "items": {
+            "$ref": "Content"
+          },
+          "description": "Required. The content of the current conversation with the model. For single-turn queries, this is a single question to answer. For multi-turn queries, this is a repeated field that contains conversation history and the last `Content` in the list containing the question. Note: GenerateAnswer currently only supports queries in English."
+        },
+        "semanticRetriever": {
+          "$ref": "SemanticRetrieverConfig",
+          "description": "Content retrieved from resources created via the Semantic Retriever API."
+        },
+        "answerStyle": {
+          "enumDescriptions": [
+            "Unspecified answer style.",
+            "Succint but abstract style.",
+            "Very brief and extractive style.",
+            "Verbose style including extra details. The response may be formatted as a sentence, paragraph, multiple paragraphs, or bullet points, etc."
+          ],
+          "enum": [
+            "ANSWER_STYLE_UNSPECIFIED",
+            "ABSTRACTIVE",
+            "EXTRACTIVE",
+            "VERBOSE"
+          ],
+          "type": "string",
+          "description": "Required. Style in which answers should be returned."
+        },
+        "safetySettings": {
+          "items": {
+            "$ref": "SafetySetting"
+          },
+          "type": "array",
+          "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content. This will be enforced on the `GenerateAnswerRequest.contents` and `GenerateAnswerResponse.candidate`. There should not be more than one setting for each `SafetyCategory` type. The API will block any contents and responses that fail to meet the thresholds set by these settings. This list overrides the default settings for each `SafetyCategory` specified in the safety_settings. If there is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use the default safety setting for that category. Harm categories HARM_CATEGORY_HATE_SPEECH, HARM_CATEGORY_SEXUALLY_EXPLICIT, HARM_CATEGORY_DANGEROUS_CONTENT, HARM_CATEGORY_HARASSMENT are supported."
+        },
+        "inlinePassages": {
+          "description": "Passages provided inline with the request.",
+          "$ref": "GroundingPassages"
+        },
+        "temperature": {
+          "description": "Optional. Controls the randomness of the output. Values can range from [0.0,1.0], inclusive. A value closer to 1.0 will produce responses that are more varied and creative, while a value closer to 0.0 will typically result in more straightforward responses from the model. A low temperature (~0.2) is usually recommended for Attributed-Question-Answering use cases.",
+          "type": "number",
+          "format": "float"
+        }
+      }
+    },
+    "Blob": {
+      "properties": {
+        "data": {
+          "format": "byte",
+          "type": "string",
+          "description": "Raw bytes for media formats."
+        },
+        "mimeType": {
+          "description": "The IANA standard MIME type of the source data. Examples: - image/png - image/jpeg If an unsupported MIME type is provided, an error will be returned. For a complete list of supported types, see [Supported file formats](https://ai.google.dev/gemini-api/docs/prompting_with_media#supported_file_formats).",
+          "type": "string"
+        }
+      },
+      "id": "Blob",
+      "type": "object",
+      "description": "Raw media bytes. Text should not be sent as raw bytes, use the 'text' field."
+    },
+    "BatchDeleteChunksRequest": {
+      "properties": {
+        "requests": {
+          "items": {
+            "$ref": "DeleteChunkRequest"
+          },
+          "description": "Required. The request messages specifying the `Chunk`s to delete.",
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "id": "BatchDeleteChunksRequest",
+      "description": "Request to batch delete `Chunk`s."
+    },
+    "Schema": {
+      "properties": {
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional. Possible values of the element of Type.STRING with enum format. For example we can define an Enum Direction as : {type:STRING, format:enum, enum:[\"EAST\", NORTH\", \"SOUTH\", \"WEST\"]}"
+        },
+        "format": {
+          "description": "Optional. The format of the data. This is used only for primitive datatypes. Supported formats: for NUMBER type: float, double for INTEGER type: int32, int64",
+          "type": "string"
+        },
+        "type": {
+          "enumDescriptions": [
+            "Not specified, should not be used.",
+            "String type.",
+            "Number type.",
+            "Integer type.",
+            "Boolean type.",
+            "Array type.",
+            "Object type."
+          ],
+          "type": "string",
+          "enum": [
+            "TYPE_UNSPECIFIED",
+            "STRING",
+            "NUMBER",
+            "INTEGER",
+            "BOOLEAN",
+            "ARRAY",
+            "OBJECT"
+          ],
+          "description": "Required. Data type."
+        },
+        "properties": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "Schema"
+          },
+          "description": "Optional. Properties of Type.OBJECT."
+        },
+        "items": {
+          "description": "Optional. Schema of the elements of Type.ARRAY.",
+          "$ref": "Schema"
         },
         "description": {
           "type": "string",
-          "description": "Optional. A short description of this model."
+          "description": "Optional. A brief description of the parameter. This could contain examples of use. Parameter description may be formatted as Markdown."
         },
-        "tuningTask": {
-          "description": "Required. The tuning task that creates the tuned model.",
-          "$ref": "TuningTask"
+        "required": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Optional. Required properties of Type.OBJECT."
         },
-        "createTime": {
-          "format": "google-datetime",
+        "nullable": {
+          "type": "boolean",
+          "description": "Optional. Indicates if the value may be null."
+        }
+      },
+      "id": "Schema",
+      "description": "The `Schema` object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. Represents a select subset of an [OpenAPI 3.0 schema object](https://spec.openapis.org/oas/v3.0.3#schema).",
+      "type": "object"
+    },
+    "Condition": {
+      "description": "Filter condition applicable to a single key.",
+      "id": "Condition",
+      "type": "object",
+      "properties": {
+        "stringValue": {
           "type": "string",
-          "readOnly": true,
-          "description": "Output only. The timestamp when this model was created."
+          "description": "The string value to filter the metadata on."
         },
-        "topP": {
+        "numericValue": {
           "type": "number",
-          "description": "Optional. For Nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`. This value specifies default to be the one used by the base model while creating the model.",
+          "description": "The numeric value to filter the metadata on.",
           "format": "float"
         },
-        "state": {
+        "operation": {
+          "type": "string",
           "enumDescriptions": [
             "The default value. This value is unused.",
-            "The model is being created.",
-            "The model is ready to be used.",
-            "The model failed to be created."
+            "Supported by numeric.",
+            "Supported by numeric.",
+            "Supported by numeric & string.",
+            "Supported by numeric.",
+            "Supported by numeric.",
+            "Supported by numeric & string.",
+            "Supported by string only when `CustomMetadata` value type for the given key has a `string_list_value`.",
+            "Supported by string only when `CustomMetadata` value type for the given key has a `string_list_value`."
           ],
-          "description": "Output only. The state of the tuned model.",
           "enum": [
-            "STATE_UNSPECIFIED",
-            "CREATING",
-            "ACTIVE",
-            "FAILED"
+            "OPERATOR_UNSPECIFIED",
+            "LESS",
+            "LESS_EQUAL",
+            "EQUAL",
+            "GREATER_EQUAL",
+            "GREATER",
+            "NOT_EQUAL",
+            "INCLUDES",
+            "EXCLUDES"
           ],
+          "description": "Required. Operator applied to the given key-value pair to trigger the condition."
+        }
+      }
+    },
+    "UsageMetadata": {
+      "properties": {
+        "candidatesTokenCount": {
+          "description": "Total number of tokens across the generated candidates.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "cachedContentTokenCount": {
+          "format": "int32",
+          "type": "integer",
+          "description": "Number of tokens in the cached part of the prompt, i.e. in the cached content."
+        },
+        "totalTokenCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Total token count for the generation request (prompt + candidates)."
+        },
+        "promptTokenCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of tokens in the prompt. When cached_content is set, this is still the total effective prompt size. I.e. this includes the number of tokens in the cached content."
+        }
+      },
+      "id": "UsageMetadata",
+      "description": "Metadata on the generation request's token usage.",
+      "type": "object"
+    },
+    "GroundingPassageId": {
+      "properties": {
+        "partIndex": {
+          "description": "Output only. Index of the part within the `GenerateAnswerRequest`'s `GroundingPassage.content`.",
           "readOnly": true,
+          "format": "int32",
+          "type": "integer"
+        },
+        "passageId": {
+          "type": "string",
+          "description": "Output only. ID of the passage matching the `GenerateAnswerRequest`'s `GroundingPassage.id`.",
+          "readOnly": true
+        }
+      },
+      "id": "GroundingPassageId",
+      "description": "Identifier for a part within a `GroundingPassage`.",
+      "type": "object"
+    },
+    "BatchUpdateChunksResponse": {
+      "properties": {
+        "chunks": {
+          "items": {
+            "$ref": "Chunk"
+          },
+          "description": "`Chunk`s updated.",
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "id": "BatchUpdateChunksResponse",
+      "description": "Response from `BatchUpdateChunks` containing a list of updated `Chunk`s."
+    },
+    "TransferOwnershipRequest": {
+      "description": "Request to transfer the ownership of the tuned model.",
+      "properties": {
+        "emailAddress": {
+          "description": "Required. The email address of the user to whom the tuned model is being transferred to.",
           "type": "string"
         }
       },
-      "id": "TunedModel",
-      "description": "A fine-tuned model created using ModelService.CreateTunedModel."
+      "type": "object",
+      "id": "TransferOwnershipRequest"
+    },
+    "FileData": {
+      "description": "URI based data.",
+      "id": "FileData",
+      "type": "object",
+      "properties": {
+        "fileUri": {
+          "type": "string",
+          "description": "Required. URI."
+        },
+        "mimeType": {
+          "type": "string",
+          "description": "Optional. The IANA standard MIME type of the source data."
+        }
+      }
+    },
+    "ListCachedContentsResponse": {
+      "properties": {
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages."
+        },
+        "cachedContents": {
+          "type": "array",
+          "description": "List of cached contents.",
+          "items": {
+            "$ref": "CachedContent"
+          }
+        }
+      },
+      "type": "object",
+      "id": "ListCachedContentsResponse",
+      "description": "Response with CachedContents list."
+    },
+    "MetadataFilter": {
+      "type": "object",
+      "description": "User provided filter to limit retrieval based on `Chunk` or `Document` level metadata values. Example (genre = drama OR genre = action): key = \"document.custom_metadata.genre\" conditions = [{string_value = \"drama\", operation = EQUAL}, {string_value = \"action\", operation = EQUAL}]",
+      "id": "MetadataFilter",
+      "properties": {
+        "conditions": {
+          "type": "array",
+          "items": {
+            "$ref": "Condition"
+          },
+          "description": "Required. The `Condition`s for the given key that will trigger this filter. Multiple `Condition`s are joined by logical ORs."
+        },
+        "key": {
+          "description": "Required. The key of the metadata to filter on.",
+          "type": "string"
+        }
+      }
+    },
+    "GenerateContentRequest": {
+      "description": "Request to generate a completion from the model.",
+      "type": "object",
+      "properties": {
+        "systemInstruction": {
+          "$ref": "Content",
+          "description": "Optional. Developer set system instruction. Currently, text only."
+        },
+        "cachedContent": {
+          "description": "Optional. The name of the cached content used as context to serve the prediction. Note: only used in explicit caching, where users can have control over caching (e.g. what content to cache) and enjoy guaranteed cost savings. Format: `cachedContents/{cachedContent}`",
+          "type": "string"
+        },
+        "tools": {
+          "type": "array",
+          "description": "Optional. A list of `Tools` the model may use to generate the next response. A `Tool` is a piece of code that enables the system to interact with external systems to perform an action, or set of actions, outside of knowledge and scope of the model. The only supported tool is currently `Function`.",
+          "items": {
+            "$ref": "Tool"
+          }
+        },
+        "generationConfig": {
+          "description": "Optional. Configuration options for model generation and outputs.",
+          "$ref": "GenerationConfig"
+        },
+        "safetySettings": {
+          "items": {
+            "$ref": "SafetySetting"
+          },
+          "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content. This will be enforced on the `GenerateContentRequest.contents` and `GenerateContentResponse.candidates`. There should not be more than one setting for each `SafetyCategory` type. The API will block any contents and responses that fail to meet the thresholds set by these settings. This list overrides the default settings for each `SafetyCategory` specified in the safety_settings. If there is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use the default safety setting for that category. Harm categories HARM_CATEGORY_HATE_SPEECH, HARM_CATEGORY_SEXUALLY_EXPLICIT, HARM_CATEGORY_DANGEROUS_CONTENT, HARM_CATEGORY_HARASSMENT are supported.",
+          "type": "array"
+        },
+        "contents": {
+          "description": "Required. The content of the current conversation with the model. For single-turn queries, this is a single instance. For multi-turn queries, this is a repeated field that contains conversation history + latest request.",
+          "type": "array",
+          "items": {
+            "$ref": "Content"
+          }
+        },
+        "toolConfig": {
+          "$ref": "ToolConfig",
+          "description": "Optional. Tool configuration for any `Tool` specified in the request."
+        },
+        "model": {
+          "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`.",
+          "type": "string"
+        }
+      },
+      "id": "GenerateContentRequest"
+    },
+    "ListTunedModelsResponse": {
+      "type": "object",
+      "properties": {
+        "tunedModels": {
+          "description": "The returned Models.",
+          "type": "array",
+          "items": {
+            "$ref": "TunedModel"
+          }
+        },
+        "nextPageToken": {
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages.",
+          "type": "string"
+        }
+      },
+      "id": "ListTunedModelsResponse",
+      "description": "Response from `ListTunedModels` containing a paginated list of Models."
+    },
+    "QueryDocumentRequest": {
+      "id": "QueryDocumentRequest",
+      "type": "object",
+      "description": "Request for querying a `Document`.",
+      "properties": {
+        "metadataFilters": {
+          "description": "Optional. Filter for `Chunk` metadata. Each `MetadataFilter` object should correspond to a unique key. Multiple `MetadataFilter` objects are joined by logical \"AND\"s. Note: `Document`-level filtering is not supported for this request because a `Document` name is already specified. Example query: (year \u003e= 2020 OR year \u003c 2010) AND (genre = drama OR genre = action) `MetadataFilter` object list: metadata_filters = [ {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2020, operation = GREATER_EQUAL}, {int_value = 2010, operation = LESS}}, {key = \"chunk.custom_metadata.genre\" conditions = [{string_value = \"drama\", operation = EQUAL}, {string_value = \"action\", operation = EQUAL}}] Example query for a numeric range of values: (year \u003e 2015 AND year \u003c= 2020) `MetadataFilter` object list: metadata_filters = [ {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2015, operation = GREATER}]}, {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2020, operation = LESS_EQUAL}]}] Note: \"AND\"s for the same key are only supported for numeric values. String values only support \"OR\"s for the same key.",
+          "items": {
+            "$ref": "MetadataFilter"
+          },
+          "type": "array"
+        },
+        "resultsCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. The maximum number of `Chunk`s to return. The service may return fewer `Chunk`s. If unspecified, at most 10 `Chunk`s will be returned. The maximum specified result count is 100."
+        },
+        "query": {
+          "description": "Required. Query string to perform semantic search.",
+          "type": "string"
+        }
+      }
+    },
+    "CreateFileRequest": {
+      "id": "CreateFileRequest",
+      "properties": {
+        "file": {
+          "$ref": "File",
+          "description": "Optional. Metadata for the file to create."
+        }
+      },
+      "description": "Request for `CreateFile`.",
+      "type": "object"
+    },
+    "BatchCreateChunksRequest": {
+      "type": "object",
+      "properties": {
+        "requests": {
+          "description": "Required. The request messages specifying the `Chunk`s to create. A maximum of 100 `Chunk`s can be created in a batch.",
+          "items": {
+            "$ref": "CreateChunkRequest"
+          },
+          "type": "array"
+        }
+      },
+      "description": "Request to batch create `Chunk`s.",
+      "id": "BatchCreateChunksRequest"
+    },
+    "Dataset": {
+      "description": "Dataset for training or validation.",
+      "properties": {
+        "examples": {
+          "description": "Optional. Inline examples.",
+          "$ref": "TuningExamples"
+        }
+      },
+      "id": "Dataset",
+      "type": "object"
+    },
+    "BatchEmbedTextResponse": {
+      "properties": {
+        "embeddings": {
+          "description": "Output only. The embeddings generated from the input text.",
+          "type": "array",
+          "items": {
+            "$ref": "Embedding"
+          },
+          "readOnly": true
+        }
+      },
+      "description": "The response to a EmbedTextRequest.",
+      "id": "BatchEmbedTextResponse",
+      "type": "object"
+    },
+    "PromptFeedback": {
+      "properties": {
+        "blockReason": {
+          "type": "string",
+          "enumDescriptions": [
+            "Default value. This value is unused.",
+            "Prompt was blocked due to safety reasons. You can inspect `safety_ratings` to understand which safety category blocked it.",
+            "Prompt was blocked due to unknown reasons."
+          ],
+          "description": "Optional. If set, the prompt was blocked and no candidates are returned. Rephrase your prompt.",
+          "enum": [
+            "BLOCK_REASON_UNSPECIFIED",
+            "SAFETY",
+            "OTHER"
+          ]
+        },
+        "safetyRatings": {
+          "description": "Ratings for safety of the prompt. There is at most one rating per category.",
+          "items": {
+            "$ref": "SafetyRating"
+          },
+          "type": "array"
+        }
+      },
+      "id": "PromptFeedback",
+      "description": "A set of the feedback metadata the prompt specified in `GenerateContentRequest.content`.",
+      "type": "object"
+    },
+    "FunctionCallingConfig": {
+      "description": "Configuration for specifying function calling behavior.",
+      "id": "FunctionCallingConfig",
+      "properties": {
+        "allowedFunctionNames": {
+          "type": "array",
+          "description": "Optional. A set of function names that, when provided, limits the functions the model will call. This should only be set when the Mode is ANY. Function names should match [FunctionDeclaration.name]. With mode set to ANY, model will predict a function call from the set of function names provided.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "mode": {
+          "enumDescriptions": [
+            "Unspecified function calling mode. This value should not be used.",
+            "Default model behavior, model decides to predict either a function call or a natural language response.",
+            "Model is constrained to always predicting a function call only. If \"allowed_function_names\" are set, the predicted function call will be limited to any one of \"allowed_function_names\", else the predicted function call will be any one of the provided \"function_declarations\".",
+            "Model will not predict any function call. Model behavior is same as when not passing any function declarations."
+          ],
+          "enum": [
+            "MODE_UNSPECIFIED",
+            "AUTO",
+            "ANY",
+            "NONE"
+          ],
+          "type": "string",
+          "description": "Optional. Specifies the mode in which function calling should execute. If unspecified, the default value will be set to AUTO."
+        }
+      },
+      "type": "object"
     },
     "ListFilesResponse": {
-      "type": "object",
-      "id": "ListFilesResponse",
       "description": "Response for `ListFiles`.",
+      "id": "ListFilesResponse",
       "properties": {
         "nextPageToken": {
           "type": "string",
@@ -1832,498 +704,111 @@
             "$ref": "File"
           }
         }
-      }
-    },
-    "Empty": {
-      "description": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); }",
-      "id": "Empty",
-      "properties": {},
-      "type": "object"
-    },
-    "BatchEmbedTextResponse": {
-      "id": "BatchEmbedTextResponse",
-      "type": "object",
-      "description": "The response to a EmbedTextRequest.",
-      "properties": {
-        "embeddings": {
-          "items": {
-            "$ref": "Embedding"
-          },
-          "readOnly": true,
-          "description": "Output only. The embeddings generated from the input text.",
-          "type": "array"
-        }
-      }
-    },
-    "Model": {
-      "type": "object",
-      "description": "Information about a Generative Language Model.",
-      "id": "Model",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Required. The resource name of the `Model`. Format: `models/{model}` with a `{model}` naming convention of: * \"{base_model_id}-{version}\" Examples: * `models/chat-bison-001`"
-        },
-        "displayName": {
-          "type": "string",
-          "description": "The human-readable name of the model. E.g. \"Chat Bison\". The name can be up to 128 characters long and can consist of any UTF-8 characters."
-        },
-        "description": {
-          "description": "A short description of the model.",
-          "type": "string"
-        },
-        "topP": {
-          "type": "number",
-          "format": "float",
-          "description": "For Nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`. This value specifies default to be used by the backend while making the call to the model."
-        },
-        "version": {
-          "description": "Required. The version number of the model. This represents the major version",
-          "type": "string"
-        },
-        "outputTokenLimit": {
-          "format": "int32",
-          "description": "Maximum number of output tokens available for this model.",
-          "type": "integer"
-        },
-        "maxTemperature": {
-          "format": "float",
-          "type": "number",
-          "description": "The maximum temperature this model can use."
-        },
-        "inputTokenLimit": {
-          "format": "int32",
-          "description": "Maximum number of input tokens allowed for this model.",
-          "type": "integer"
-        },
-        "baseModelId": {
-          "description": "Required. The name of the base model, pass this to the generation request. Examples: * `chat-bison`",
-          "type": "string"
-        },
-        "temperature": {
-          "format": "float",
-          "description": "Controls the randomness of the output. Values can range over `[0.0,max_temperature]`, inclusive. A higher value will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model. This value specifies default to be used by the backend while making the call to the model.",
-          "type": "number"
-        },
-        "supportedGenerationMethods": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "The model's supported generation methods. The method names are defined as Pascal case strings, such as `generateMessage` which correspond to API methods."
-        },
-        "topK": {
-          "description": "For Top-k sampling. Top-k sampling considers the set of `top_k` most probable tokens. This value specifies default to be used by the backend while making the call to the model. If empty, indicates the model doesn't use top-k sampling, and `top_k` isn't allowed as a generation parameter.",
-          "format": "int32",
-          "type": "integer"
-        }
-      }
-    },
-    "CreateFileRequest": {
-      "properties": {
-        "file": {
-          "$ref": "File",
-          "description": "Optional. Metadata for the file to create."
-        }
       },
-      "description": "Request for `CreateFile`.",
-      "id": "CreateFileRequest",
       "type": "object"
     },
-    "ContentEmbedding": {
-      "description": "A list of floats representing an embedding.",
+    "Embedding": {
+      "type": "object",
+      "description": "A list of floats representing the embedding.",
       "properties": {
-        "values": {
-          "type": "array",
+        "value": {
           "items": {
             "format": "float",
             "type": "number"
           },
+          "type": "array",
           "description": "The embedding values."
         }
       },
-      "type": "object",
-      "id": "ContentEmbedding"
+      "id": "Embedding"
     },
-    "ListCorporaResponse": {
-      "description": "Response from `ListCorpora` containing a paginated list of `Corpora`. The results are sorted by ascending `corpus.create_time`.",
-      "id": "ListCorporaResponse",
+    "Corpus": {
+      "description": "A `Corpus` is a collection of `Document`s. A project can create up to 5 corpora.",
+      "id": "Corpus",
       "properties": {
-        "corpora": {
-          "description": "The returned corpora.",
-          "type": "array",
-          "items": {
-            "$ref": "Corpus"
-          }
-        },
-        "nextPageToken": {
-          "type": "string",
-          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
-        }
-      },
-      "type": "object"
-    },
-    "RelevantChunk": {
-      "type": "object",
-      "properties": {
-        "chunkRelevanceScore": {
-          "description": "`Chunk` relevance to the query.",
-          "type": "number",
-          "format": "float"
-        },
-        "chunk": {
-          "$ref": "Chunk",
-          "description": "`Chunk` associated with the query."
-        }
-      },
-      "id": "RelevantChunk",
-      "description": "The information for a chunk relevant to a query."
-    },
-    "GroundingPassage": {
-      "type": "object",
-      "id": "GroundingPassage",
-      "properties": {
-        "content": {
-          "description": "Content of the passage.",
-          "$ref": "Content"
-        },
-        "id": {
-          "description": "Identifier for the passage for attributing this passage in grounded answers.",
-          "type": "string"
-        }
-      },
-      "description": "Passage included inline with a grounding configuration."
-    },
-    "EmbedContentResponse": {
-      "properties": {
-        "embedding": {
-          "readOnly": true,
-          "description": "Output only. The embedding generated from the input content.",
-          "$ref": "ContentEmbedding"
-        }
-      },
-      "id": "EmbedContentResponse",
-      "type": "object",
-      "description": "The response to an `EmbedContentRequest`."
-    },
-    "Tool": {
-      "type": "object",
-      "description": "Tool details that the model may use to generate response. A `Tool` is a piece of code that enables the system to interact with external systems to perform an action, or set of actions, outside of knowledge and scope of the model.",
-      "id": "Tool",
-      "properties": {
-        "functionDeclarations": {
-          "type": "array",
-          "description": "Optional. A list of `FunctionDeclarations` available to the model that can be used for function calling. The model or system does not execute the function. Instead the defined function may be returned as a FunctionCall with arguments to the client side for execution. The model may decide to call a subset of these functions by populating FunctionCall in the response. The next conversation turn may contain a FunctionResponse with the [content.role] \"function\" generation context for the next model turn.",
-          "items": {
-            "$ref": "FunctionDeclaration"
-          }
-        }
-      }
-    },
-    "BatchEmbedContentsResponse": {
-      "type": "object",
-      "description": "The response to a `BatchEmbedContentsRequest`.",
-      "id": "BatchEmbedContentsResponse",
-      "properties": {
-        "embeddings": {
-          "description": "Output only. The embeddings for each request, in the same order as provided in the batch request.",
-          "type": "array",
-          "readOnly": true,
-          "items": {
-            "$ref": "ContentEmbedding"
-          }
-        }
-      }
-    },
-    "GenerateMessageRequest": {
-      "type": "object",
-      "properties": {
-        "topP": {
-          "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`.",
-          "format": "float",
-          "type": "number"
-        },
-        "temperature": {
-          "type": "number",
-          "format": "float",
-          "description": "Optional. Controls the randomness of the output. Values can range over `[0.0,1.0]`, inclusive. A value closer to `1.0` will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model."
-        },
-        "topK": {
-          "type": "integer",
-          "description": "Optional. The maximum number of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens.",
-          "format": "int32"
-        },
-        "prompt": {
-          "description": "Required. The structured textual input given to the model as a prompt. Given a prompt, the model will return what it predicts is the next message in the discussion.",
-          "$ref": "MessagePrompt"
-        },
-        "candidateCount": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Optional. The number of generated response messages to return. This value must be between `[1, 8]`, inclusive. If unset, this will default to `1`."
-        }
-      },
-      "id": "GenerateMessageRequest",
-      "description": "Request to generate a message response from the model."
-    },
-    "BatchEmbedContentsRequest": {
-      "id": "BatchEmbedContentsRequest",
-      "properties": {
-        "requests": {
-          "description": "Required. Embed requests for the batch. The model in each of these requests must match the model specified `BatchEmbedContentsRequest.model`.",
-          "items": {
-            "$ref": "EmbedContentRequest"
-          },
-          "type": "array"
-        }
-      },
-      "type": "object",
-      "description": "Batch request to get embeddings from the model for a list of prompts."
-    },
-    "GroundingPassages": {
-      "type": "object",
-      "description": "A repeated list of passages.",
-      "id": "GroundingPassages",
-      "properties": {
-        "passages": {
-          "description": "List of passages.",
-          "type": "array",
-          "items": {
-            "$ref": "GroundingPassage"
-          }
-        }
-      }
-    },
-    "GenerateMessageResponse": {
-      "description": "The response from the model. This includes candidate messages and conversation history in the form of chronologically-ordered messages.",
-      "id": "GenerateMessageResponse",
-      "type": "object",
-      "properties": {
-        "candidates": {
-          "type": "array",
-          "items": {
-            "$ref": "Message"
-          },
-          "description": "Candidate response messages from the model."
-        },
-        "messages": {
-          "type": "array",
-          "description": "The conversation history used by the model.",
-          "items": {
-            "$ref": "Message"
-          }
-        },
-        "filters": {
-          "description": "A set of content filtering metadata for the prompt and response text. This indicates which `SafetyCategory`(s) blocked a candidate from this response, the lowest `HarmProbability` that triggered a block, and the HarmThreshold setting for that category.",
-          "type": "array",
-          "items": {
-            "$ref": "ContentFilter"
-          }
-        }
-      }
-    },
-    "TransferOwnershipRequest": {
-      "type": "object",
-      "description": "Request to transfer the ownership of the tuned model.",
-      "id": "TransferOwnershipRequest",
-      "properties": {
-        "emailAddress": {
-          "type": "string",
-          "description": "Required. The email address of the user to whom the tuned model is being transferred to."
-        }
-      }
-    },
-    "ListPermissionsResponse": {
-      "properties": {
-        "nextPageToken": {
-          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages.",
-          "type": "string"
-        },
-        "permissions": {
-          "type": "array",
-          "items": {
-            "$ref": "Permission"
-          },
-          "description": "Returned permissions."
-        }
-      },
-      "description": "Response from `ListPermissions` containing a paginated list of permissions.",
-      "type": "object",
-      "id": "ListPermissionsResponse"
-    },
-    "ToolConfig": {
-      "type": "object",
-      "properties": {
-        "functionCallingConfig": {
-          "description": "Optional. Function calling config.",
-          "$ref": "FunctionCallingConfig"
-        }
-      },
-      "id": "ToolConfig",
-      "description": "The Tool configuration containing parameters for specifying `Tool` use in the request."
-    },
-    "CitationSource": {
-      "type": "object",
-      "id": "CitationSource",
-      "properties": {
-        "uri": {
-          "type": "string",
-          "description": "Optional. URI that is attributed as a source for a portion of the text."
-        },
-        "endIndex": {
-          "description": "Optional. End of the attributed segment, exclusive.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "startIndex": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Optional. Start of segment of the response that is attributed to this source. Index indicates the start of the segment, measured in bytes."
-        },
-        "license": {
-          "type": "string",
-          "description": "Optional. License for the GitHub project that is attributed as a source for segment. License info is required for code citations."
-        }
-      },
-      "description": "A citation to a source for a portion of a specific response."
-    },
-    "CountMessageTokensResponse": {
-      "id": "CountMessageTokensResponse",
-      "description": "A response from `CountMessageTokens`. It returns the model's `token_count` for the `prompt`.",
-      "properties": {
-        "tokenCount": {
-          "description": "The number of tokens that the `model` tokenizes the `prompt` into. Always non-negative.",
-          "format": "int32",
-          "type": "integer"
-        }
-      },
-      "type": "object"
-    },
-    "BatchUpdateChunksRequest": {
-      "description": "Request to batch update `Chunk`s.",
-      "id": "BatchUpdateChunksRequest",
-      "properties": {
-        "requests": {
-          "description": "Required. The request messages specifying the `Chunk`s to update. A maximum of 100 `Chunk`s can be updated in a batch.",
-          "items": {
-            "$ref": "UpdateChunkRequest"
-          },
-          "type": "array"
-        }
-      },
-      "type": "object"
-    },
-    "File": {
-      "properties": {
-        "state": {
-          "enumDescriptions": [
-            "The default value. This value is used if the state is omitted.",
-            "File is being processed and cannot be used for inference yet.",
-            "File is processed and available for inference.",
-            "File failed processing."
-          ],
-          "enum": [
-            "STATE_UNSPECIFIED",
-            "PROCESSING",
-            "ACTIVE",
-            "FAILED"
-          ],
-          "description": "Output only. Processing state of the File.",
-          "type": "string",
-          "readOnly": true
-        },
-        "mimeType": {
-          "type": "string",
-          "readOnly": true,
-          "description": "Output only. MIME type of the file."
-        },
-        "videoMetadata": {
-          "description": "Output only. Metadata for a video.",
-          "readOnly": true,
-          "$ref": "VideoMetadata"
-        },
-        "uri": {
-          "readOnly": true,
-          "description": "Output only. The uri of the `File`.",
-          "type": "string"
-        },
-        "sha256Hash": {
-          "readOnly": true,
-          "format": "byte",
-          "type": "string",
-          "description": "Output only. SHA-256 hash of the uploaded bytes."
-        },
         "updateTime": {
+          "readOnly": true,
           "format": "google-datetime",
           "type": "string",
-          "description": "Output only. The timestamp of when the `File` was last updated.",
-          "readOnly": true
-        },
-        "sizeBytes": {
-          "readOnly": true,
-          "format": "int64",
-          "type": "string",
-          "description": "Output only. Size of the file in bytes."
-        },
-        "createTime": {
-          "format": "google-datetime",
-          "description": "Output only. The timestamp of when the `File` was created.",
-          "type": "string",
-          "readOnly": true
-        },
-        "error": {
-          "$ref": "Status",
-          "readOnly": true,
-          "description": "Output only. Error status if File processing failed."
+          "description": "Output only. The Timestamp of when the `Corpus` was last updated."
         },
         "displayName": {
           "type": "string",
-          "description": "Optional. The human-readable display name for the `File`. The display name must be no more than 512 characters in length, including spaces. Example: \"Welcome Image\""
-        },
-        "expirationTime": {
-          "description": "Output only. The timestamp of when the `File` will be deleted. Only set if the `File` is scheduled to expire.",
-          "type": "string",
-          "format": "google-datetime",
-          "readOnly": true
+          "description": "Optional. The human-readable display name for the `Corpus`. The display name must be no more than 512 characters in length, including spaces. Example: \"Docs on Semantic Retriever\""
         },
         "name": {
-          "description": "Immutable. Identifier. The `File` resource name. The ID (name excluding the \"files/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be generated. Example: `files/123-456`",
+          "description": "Immutable. Identifier. The `Corpus` resource name. The ID (name excluding the \"corpora/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/my-awesome-corpora-123a456b789c`",
           "type": "string"
-        }
-      },
-      "type": "object",
-      "id": "File",
-      "description": "A file uploaded to the API."
-    },
-    "BatchCreateChunksRequest": {
-      "properties": {
-        "requests": {
-          "items": {
-            "$ref": "CreateChunkRequest"
-          },
-          "description": "Required. The request messages specifying the `Chunk`s to create. A maximum of 100 `Chunk`s can be created in a batch.",
-          "type": "array"
-        }
-      },
-      "description": "Request to batch create `Chunk`s.",
-      "type": "object",
-      "id": "BatchCreateChunksRequest"
-    },
-    "UpdateChunkRequest": {
-      "type": "object",
-      "properties": {
-        "updateMask": {
-          "type": "string",
-          "format": "google-fieldmask",
-          "description": "Required. The list of fields to update. Currently, this only supports updating `custom_metadata` and `data`."
         },
-        "chunk": {
-          "description": "Required. The `Chunk` to update.",
-          "$ref": "Chunk"
+        "createTime": {
+          "type": "string",
+          "format": "google-datetime",
+          "readOnly": true,
+          "description": "Output only. The Timestamp of when the `Corpus` was created."
         }
       },
-      "description": "Request to update a `Chunk`.",
-      "id": "UpdateChunkRequest"
+      "type": "object"
+    },
+    "CountTextTokensResponse": {
+      "description": "A response from `CountTextTokens`. It returns the model's `token_count` for the `prompt`.",
+      "properties": {
+        "tokenCount": {
+          "format": "int32",
+          "type": "integer",
+          "description": "The number of tokens that the `model` tokenizes the `prompt` into. Always non-negative."
+        }
+      },
+      "type": "object",
+      "id": "CountTextTokensResponse"
+    },
+    "BatchCreateChunksResponse": {
+      "id": "BatchCreateChunksResponse",
+      "type": "object",
+      "description": "Response from `BatchCreateChunks` containing a list of created `Chunk`s.",
+      "properties": {
+        "chunks": {
+          "type": "array",
+          "items": {
+            "$ref": "Chunk"
+          },
+          "description": "`Chunk`s created."
+        }
+      }
+    },
+    "TransferOwnershipResponse": {
+      "id": "TransferOwnershipResponse",
+      "description": "Response from `TransferOwnership`.",
+      "type": "object",
+      "properties": {}
+    },
+    "TuningExamples": {
+      "id": "TuningExamples",
+      "properties": {
+        "examples": {
+          "type": "array",
+          "items": {
+            "$ref": "TuningExample"
+          },
+          "description": "Required. The examples. Example input can be for text or discuss, but all examples in a set must be of the same type."
+        }
+      },
+      "description": "A set of tuning examples. Can be training or validation data.",
+      "type": "object"
+    },
+    "BatchEmbedContentsResponse": {
+      "description": "The response to a `BatchEmbedContentsRequest`.",
+      "properties": {
+        "embeddings": {
+          "items": {
+            "$ref": "ContentEmbedding"
+          },
+          "description": "Output only. The embeddings for each request, in the same order as provided in the batch request.",
+          "type": "array",
+          "readOnly": true
+        }
+      },
+      "id": "BatchEmbedContentsResponse",
+      "type": "object"
     },
     "QueryDocumentResponse": {
       "type": "object",
@@ -2339,9 +824,109 @@
       },
       "id": "QueryDocumentResponse"
     },
+    "CustomMetadata": {
+      "properties": {
+        "stringListValue": {
+          "$ref": "StringList",
+          "description": "The StringList value of the metadata to store."
+        },
+        "key": {
+          "type": "string",
+          "description": "Required. The key of the metadata to store."
+        },
+        "numericValue": {
+          "format": "float",
+          "type": "number",
+          "description": "The numeric value of the metadata to store."
+        },
+        "stringValue": {
+          "type": "string",
+          "description": "The string value of the metadata to store."
+        }
+      },
+      "description": "User provided metadata stored as key-value pairs.",
+      "type": "object",
+      "id": "CustomMetadata"
+    },
+    "ListModelsResponse": {
+      "type": "object",
+      "id": "ListModelsResponse",
+      "description": "Response from `ListModel` containing a paginated list of Models.",
+      "properties": {
+        "models": {
+          "type": "array",
+          "description": "The returned Models.",
+          "items": {
+            "$ref": "Model"
+          }
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
+        }
+      }
+    },
+    "CachedContentUsageMetadata": {
+      "properties": {
+        "totalTokenCount": {
+          "description": "Total number of tokens that the cached content consumes.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "description": "Metadata on the usage of the cached content.",
+      "type": "object",
+      "id": "CachedContentUsageMetadata"
+    },
+    "FunctionCall": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Required. The name of the function to call. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
+        },
+        "args": {
+          "type": "object",
+          "description": "Optional. The function parameters and values in JSON object format.",
+          "additionalProperties": {
+            "type": "any",
+            "description": "Properties of the object."
+          }
+        }
+      },
+      "description": "A predicted `FunctionCall` returned from the model that contains a string representing the `FunctionDeclaration.name` with the arguments and their values.",
+      "type": "object",
+      "id": "FunctionCall"
+    },
+    "TextCompletion": {
+      "description": "Output text returned from a model.",
+      "id": "TextCompletion",
+      "type": "object",
+      "properties": {
+        "safetyRatings": {
+          "description": "Ratings for the safety of a response. There is at most one rating per category.",
+          "items": {
+            "$ref": "SafetyRating"
+          },
+          "type": "array"
+        },
+        "citationMetadata": {
+          "$ref": "CitationMetadata",
+          "description": "Output only. Citation information for model-generated `output` in this `TextCompletion`. This field may be populated with attribution information for any text included in the `output`.",
+          "readOnly": true
+        },
+        "output": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Output only. The generated text returned from the model."
+        }
+      }
+    },
     "SafetySetting": {
+      "type": "object",
+      "description": "Safety setting, affecting the safety-blocking behavior. Passing a safety setting for a category changes the allowed probability that content is blocked.",
       "properties": {
         "category": {
+          "description": "Required. The category for this setting.",
           "enumDescriptions": [
             "Category is unspecified.",
             "Negative or harmful comments targeting identity and/or protected attribute.",
@@ -2355,7 +940,6 @@
             "Sexually explicit content.",
             "Dangerous content."
           ],
-          "description": "Required. The category for this setting.",
           "type": "string",
           "enum": [
             "HARM_CATEGORY_UNSPECIFIED",
@@ -2372,7 +956,13 @@
           ]
         },
         "threshold": {
-          "description": "Required. Controls the probability threshold at which harm is blocked.",
+          "enumDescriptions": [
+            "Threshold is unspecified.",
+            "Content with NEGLIGIBLE will be allowed.",
+            "Content with NEGLIGIBLE and LOW will be allowed.",
+            "Content with NEGLIGIBLE, LOW, and MEDIUM will be allowed.",
+            "All content will be allowed."
+          ],
           "enum": [
             "HARM_BLOCK_THRESHOLD_UNSPECIFIED",
             "BLOCK_LOW_AND_ABOVE",
@@ -2381,118 +971,735 @@
             "BLOCK_NONE"
           ],
           "type": "string",
-          "enumDescriptions": [
-            "Threshold is unspecified.",
-            "Content with NEGLIGIBLE will be allowed.",
-            "Content with NEGLIGIBLE and LOW will be allowed.",
-            "Content with NEGLIGIBLE, LOW, and MEDIUM will be allowed.",
-            "All content will be allowed."
-          ]
+          "description": "Required. Controls the probability threshold at which harm is blocked."
         }
       },
-      "id": "SafetySetting",
-      "type": "object",
-      "description": "Safety setting, affecting the safety-blocking behavior. Passing a safety setting for a category changes the allowed probability that content is blocked."
+      "id": "SafetySetting"
     },
-    "SafetyFeedback": {
-      "description": "Safety feedback for an entire request. This field is populated if content in the input and/or response is blocked due to safety settings. SafetyFeedback may not exist for every HarmCategory. Each SafetyFeedback will return the safety settings used by the request as well as the lowest HarmProbability that should be allowed in order to return a result.",
-      "type": "object",
-      "id": "SafetyFeedback",
+    "TuningExample": {
       "properties": {
-        "rating": {
-          "description": "Safety rating evaluated from content.",
-          "$ref": "SafetyRating"
+        "output": {
+          "type": "string",
+          "description": "Required. The expected model output."
         },
-        "setting": {
-          "$ref": "SafetySetting",
-          "description": "Safety settings applied to the request."
+        "textInput": {
+          "type": "string",
+          "description": "Optional. Text model input."
         }
-      }
-    },
-    "TransferOwnershipResponse": {
-      "id": "TransferOwnershipResponse",
+      },
       "type": "object",
-      "description": "Response from `TransferOwnership`.",
-      "properties": {}
+      "description": "A single example for tuning.",
+      "id": "TuningExample"
     },
-    "QueryCorpusRequest": {
+    "ListDocumentsResponse": {
+      "id": "ListDocumentsResponse",
       "type": "object",
       "properties": {
+        "nextPageToken": {
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages.",
+          "type": "string"
+        },
+        "documents": {
+          "description": "The returned `Document`s.",
+          "items": {
+            "$ref": "Document"
+          },
+          "type": "array"
+        }
+      },
+      "description": "Response from `ListDocuments` containing a paginated list of `Document`s. The `Document`s are sorted by ascending `document.create_time`."
+    },
+    "UpdateChunkRequest": {
+      "id": "UpdateChunkRequest",
+      "properties": {
+        "updateMask": {
+          "format": "google-fieldmask",
+          "type": "string",
+          "description": "Required. The list of fields to update. Currently, this only supports updating `custom_metadata` and `data`."
+        },
+        "chunk": {
+          "$ref": "Chunk",
+          "description": "Required. The `Chunk` to update."
+        }
+      },
+      "type": "object",
+      "description": "Request to update a `Chunk`."
+    },
+    "CachedContent": {
+      "description": "Content that has been preprocessed and can be used in subsequent request to GenerativeService. Cached content can be only used with model it was created for.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Optional. Identifier. The resource name referring to the cached content. Format: `cachedContents/{id}`"
+        },
+        "expireTime": {
+          "format": "google-datetime",
+          "description": "Timestamp in UTC of when this resource is considered expired. This is *always* provided on output, regardless of what was sent on input.",
+          "type": "string"
+        },
+        "toolConfig": {
+          "$ref": "ToolConfig",
+          "description": "Optional. Input only. Immutable. Tool config. This config is shared for all tools."
+        },
+        "ttl": {
+          "description": "Input only. New TTL for this resource, input only.",
+          "type": "string",
+          "format": "google-duration"
+        },
+        "tools": {
+          "description": "Optional. Input only. Immutable. A list of `Tools` the model may use to generate the next response",
+          "type": "array",
+          "items": {
+            "$ref": "Tool"
+          }
+        },
+        "updateTime": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. When the cache entry was last updated in UTC time.",
+          "format": "google-datetime"
+        },
+        "usageMetadata": {
+          "$ref": "CachedContentUsageMetadata",
+          "readOnly": true,
+          "description": "Output only. Metadata on the usage of the cached content."
+        },
+        "contents": {
+          "type": "array",
+          "description": "Optional. Input only. Immutable. The content to cache.",
+          "items": {
+            "$ref": "Content"
+          }
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Optional. Immutable. The user-generated meaningful display name of the cached content. Maximum 128 Unicode characters."
+        },
+        "systemInstruction": {
+          "$ref": "Content",
+          "description": "Optional. Input only. Immutable. Developer set system instruction. Currently text only."
+        },
+        "createTime": {
+          "type": "string",
+          "format": "google-datetime",
+          "readOnly": true,
+          "description": "Output only. Creation time of the cache entry."
+        },
+        "model": {
+          "type": "string",
+          "description": "Required. Immutable. The name of the `Model` to use for cached content Format: `models/{model}`"
+        }
+      },
+      "type": "object",
+      "id": "CachedContent"
+    },
+    "GenerateMessageRequest": {
+      "properties": {
+        "topK": {
+          "type": "integer",
+          "description": "Optional. The maximum number of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens.",
+          "format": "int32"
+        },
+        "prompt": {
+          "$ref": "MessagePrompt",
+          "description": "Required. The structured textual input given to the model as a prompt. Given a prompt, the model will return what it predicts is the next message in the discussion."
+        },
+        "candidateCount": {
+          "format": "int32",
+          "type": "integer",
+          "description": "Optional. The number of generated response messages to return. This value must be between `[1, 8]`, inclusive. If unset, this will default to `1`."
+        },
+        "topP": {
+          "format": "float",
+          "type": "number",
+          "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`."
+        },
+        "temperature": {
+          "format": "float",
+          "type": "number",
+          "description": "Optional. Controls the randomness of the output. Values can range over `[0.0,1.0]`, inclusive. A value closer to `1.0` will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model."
+        }
+      },
+      "description": "Request to generate a message response from the model.",
+      "type": "object",
+      "id": "GenerateMessageRequest"
+    },
+    "TunedModelSource": {
+      "type": "object",
+      "properties": {
+        "tunedModel": {
+          "type": "string",
+          "description": "Immutable. The name of the `TunedModel` to use as the starting point for training the new model. Example: `tunedModels/my-tuned-model`"
+        },
+        "baseModel": {
+          "description": "Output only. The name of the base `Model` this `TunedModel` was tuned from. Example: `models/text-bison-001`",
+          "type": "string",
+          "readOnly": true
+        }
+      },
+      "id": "TunedModelSource",
+      "description": "Tuned model as a source for training a new model."
+    },
+    "GenerateMessageResponse": {
+      "properties": {
+        "filters": {
+          "items": {
+            "$ref": "ContentFilter"
+          },
+          "description": "A set of content filtering metadata for the prompt and response text. This indicates which `SafetyCategory`(s) blocked a candidate from this response, the lowest `HarmProbability` that triggered a block, and the HarmThreshold setting for that category.",
+          "type": "array"
+        },
+        "messages": {
+          "items": {
+            "$ref": "Message"
+          },
+          "type": "array",
+          "description": "The conversation history used by the model."
+        },
+        "candidates": {
+          "items": {
+            "$ref": "Message"
+          },
+          "description": "Candidate response messages from the model.",
+          "type": "array"
+        }
+      },
+      "description": "The response from the model. This includes candidate messages and conversation history in the form of chronologically-ordered messages.",
+      "type": "object",
+      "id": "GenerateMessageResponse"
+    },
+    "File": {
+      "description": "A file uploaded to the API.",
+      "properties": {
+        "uri": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. The uri of the `File`."
+        },
+        "sizeBytes": {
+          "format": "int64",
+          "type": "string",
+          "description": "Output only. Size of the file in bytes.",
+          "readOnly": true
+        },
+        "state": {
+          "enum": [
+            "STATE_UNSPECIFIED",
+            "PROCESSING",
+            "ACTIVE",
+            "FAILED"
+          ],
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. Processing state of the File.",
+          "enumDescriptions": [
+            "The default value. This value is used if the state is omitted.",
+            "File is being processed and cannot be used for inference yet.",
+            "File is processed and available for inference.",
+            "File failed processing."
+          ]
+        },
+        "error": {
+          "description": "Output only. Error status if File processing failed.",
+          "$ref": "Status",
+          "readOnly": true
+        },
+        "mimeType": {
+          "readOnly": true,
+          "description": "Output only. MIME type of the file.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "Optional. The human-readable display name for the `File`. The display name must be no more than 512 characters in length, including spaces. Example: \"Welcome Image\"",
+          "type": "string"
+        },
+        "name": {
+          "description": "Immutable. Identifier. The `File` resource name. The ID (name excluding the \"files/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be generated. Example: `files/123-456`",
+          "type": "string"
+        },
+        "expirationTime": {
+          "description": "Output only. The timestamp of when the `File` will be deleted. Only set if the `File` is scheduled to expire.",
+          "readOnly": true,
+          "type": "string",
+          "format": "google-datetime"
+        },
+        "updateTime": {
+          "description": "Output only. The timestamp of when the `File` was last updated.",
+          "readOnly": true,
+          "type": "string",
+          "format": "google-datetime"
+        },
+        "videoMetadata": {
+          "description": "Output only. Metadata for a video.",
+          "readOnly": true,
+          "$ref": "VideoMetadata"
+        },
+        "sha256Hash": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. SHA-256 hash of the uploaded bytes.",
+          "format": "byte"
+        },
+        "createTime": {
+          "description": "Output only. The timestamp of when the `File` was created.",
+          "type": "string",
+          "readOnly": true,
+          "format": "google-datetime"
+        }
+      },
+      "type": "object",
+      "id": "File"
+    },
+    "SemanticRetrieverConfig": {
+      "id": "SemanticRetrieverConfig",
+      "type": "object",
+      "description": "Configuration for retrieving grounding content from a `Corpus` or `Document` created using the Semantic Retriever API.",
+      "properties": {
+        "minimumRelevanceScore": {
+          "format": "float",
+          "type": "number",
+          "description": "Optional. Minimum relevance score for retrieved relevant `Chunk`s."
+        },
         "metadataFilters": {
           "type": "array",
           "items": {
             "$ref": "MetadataFilter"
           },
-          "description": "Optional. Filter for `Chunk` and `Document` metadata. Each `MetadataFilter` object should correspond to a unique key. Multiple `MetadataFilter` objects are joined by logical \"AND\"s. Example query at document level: (year \u003e= 2020 OR year \u003c 2010) AND (genre = drama OR genre = action) `MetadataFilter` object list: metadata_filters = [ {key = \"document.custom_metadata.year\" conditions = [{int_value = 2020, operation = GREATER_EQUAL}, {int_value = 2010, operation = LESS}]}, {key = \"document.custom_metadata.year\" conditions = [{int_value = 2020, operation = GREATER_EQUAL}, {int_value = 2010, operation = LESS}]}, {key = \"document.custom_metadata.genre\" conditions = [{string_value = \"drama\", operation = EQUAL}, {string_value = \"action\", operation = EQUAL}]}] Example query at chunk level for a numeric range of values: (year \u003e 2015 AND year \u003c= 2020) `MetadataFilter` object list: metadata_filters = [ {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2015, operation = GREATER}]}, {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2020, operation = LESS_EQUAL}]}] Note: \"AND\"s for the same key are only supported for numeric values. String values only support \"OR\"s for the same key."
+          "description": "Optional. Filters for selecting `Document`s and/or `Chunk`s from the resource."
+        },
+        "source": {
+          "description": "Required. Name of the resource for retrieval, e.g. corpora/123 or corpora/123/documents/abc.",
+          "type": "string"
         },
         "query": {
-          "type": "string",
-          "description": "Required. Query string to perform semantic search."
+          "$ref": "Content",
+          "description": "Required. Query to use for similarity matching `Chunk`s in the given resource."
         },
-        "resultsCount": {
+        "maxChunksCount": {
           "type": "integer",
-          "format": "int32",
-          "description": "Optional. The maximum number of `Chunk`s to return. The service may return fewer `Chunk`s. If unspecified, at most 10 `Chunk`s will be returned. The maximum specified result count is 100."
-        }
-      },
-      "id": "QueryCorpusRequest",
-      "description": "Request for querying a `Corpus`."
-    },
-    "ListTunedModelsResponse": {
-      "type": "object",
-      "id": "ListTunedModelsResponse",
-      "description": "Response from `ListTunedModels` containing a paginated list of Models.",
-      "properties": {
-        "nextPageToken": {
-          "type": "string",
-          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
-        },
-        "tunedModels": {
-          "description": "The returned Models.",
-          "type": "array",
-          "items": {
-            "$ref": "TunedModel"
-          }
+          "description": "Optional. Maximum number of relevant `Chunk`s to retrieve.",
+          "format": "int32"
         }
       }
     },
-    "ListModelsResponse": {
+    "TextPrompt": {
+      "type": "object",
+      "description": "Text given to the model as a prompt. The Model will use this TextPrompt to Generate a text completion.",
+      "id": "TextPrompt",
       "properties": {
-        "nextPageToken": {
-          "type": "string",
-          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
+        "text": {
+          "description": "Required. The prompt text.",
+          "type": "string"
+        }
+      }
+    },
+    "GroundingPassage": {
+      "properties": {
+        "content": {
+          "$ref": "Content",
+          "description": "Content of the passage."
         },
-        "models": {
-          "description": "The returned Models.",
-          "items": {
-            "$ref": "Model"
-          },
-          "type": "array"
+        "id": {
+          "type": "string",
+          "description": "Identifier for the passage for attributing this passage in grounded answers."
         }
       },
-      "description": "Response from `ListModel` containing a paginated list of Models.",
-      "id": "ListModelsResponse",
+      "description": "Passage included inline with a grounding configuration.",
+      "type": "object",
+      "id": "GroundingPassage"
+    },
+    "Operation": {
+      "properties": {
+        "response": {
+          "additionalProperties": {
+            "description": "Properties of the object. Contains field @type with type URL.",
+            "type": "any"
+          },
+          "description": "The normal, successful response of the operation. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`.",
+          "type": "object"
+        },
+        "done": {
+          "type": "boolean",
+          "description": "If the value is `false`, it means the operation is still in progress. If `true`, the operation is completed, and either `error` or `response` is available."
+        },
+        "name": {
+          "type": "string",
+          "description": "The server-assigned name, which is only unique within the same service that originally returns it. If you use the default HTTP mapping, the `name` should be a resource name ending with `operations/{unique_id}`."
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "any",
+            "description": "Properties of the object. Contains field @type with type URL."
+          },
+          "description": "Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any."
+        },
+        "error": {
+          "description": "The error result of the operation in case of failure or cancellation.",
+          "$ref": "Status"
+        }
+      },
+      "id": "Operation",
+      "description": "This resource represents a long-running operation that is the result of a network API call.",
       "type": "object"
     },
-    "Embedding": {
-      "description": "A list of floats representing the embedding.",
+    "Status": {
+      "description": "The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).",
+      "id": "Status",
       "properties": {
-        "value": {
-          "description": "The embedding values.",
+        "details": {
           "items": {
-            "format": "float",
-            "type": "number"
+            "additionalProperties": {
+              "type": "any",
+              "description": "Properties of the object. Contains field @type with type URL."
+            },
+            "type": "object"
+          },
+          "description": "A list of messages that carry the error details. There is a common set of message types for APIs to use.",
+          "type": "array"
+        },
+        "code": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The status code, which should be an enum value of google.rpc.Code."
+        },
+        "message": {
+          "description": "A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "FunctionResponse": {
+      "type": "object",
+      "id": "FunctionResponse",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Required. The name of the function to call. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
+        },
+        "response": {
+          "description": "Required. The function response in JSON object format.",
+          "type": "object",
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          }
+        }
+      },
+      "description": "The result output from a `FunctionCall` that contains a string representing the `FunctionDeclaration.name` and a structured JSON object containing any output from the function is used as context to the model. This should contain the result of a`FunctionCall` made based on model prediction."
+    },
+    "TunedModel": {
+      "type": "object",
+      "properties": {
+        "tuningTask": {
+          "$ref": "TuningTask",
+          "description": "Required. The tuning task that creates the tuned model."
+        },
+        "tunedModelSource": {
+          "$ref": "TunedModelSource",
+          "description": "Optional. TunedModel to use as the starting point for training the new model."
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. The tuned model name. A unique name will be generated on create. Example: `tunedModels/az2mb0bpw6i` If display_name is set on create, the id portion of the name will be set by concatenating the words of the display_name with hyphens and adding a random portion for uniqueness. Example: display_name = \"Sentence Translator\" name = \"tunedModels/sentence-translator-u3b7m\""
+        },
+        "updateTime": {
+          "type": "string",
+          "format": "google-datetime",
+          "readOnly": true,
+          "description": "Output only. The timestamp when this model was updated."
+        },
+        "createTime": {
+          "readOnly": true,
+          "description": "Output only. The timestamp when this model was created.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "baseModel": {
+          "description": "Immutable. The name of the `Model` to tune. Example: `models/text-bison-001`",
+          "type": "string"
+        },
+        "topK": {
+          "description": "Optional. For Top-k sampling. Top-k sampling considers the set of `top_k` most probable tokens. This value specifies default to be used by the backend while making the call to the model. This value specifies default to be the one used by the base model while creating the model.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "temperature": {
+          "format": "float",
+          "description": "Optional. Controls the randomness of the output. Values can range over `[0.0,1.0]`, inclusive. A value closer to `1.0` will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model. This value specifies default to be the one used by the base model while creating the model.",
+          "type": "number"
+        },
+        "state": {
+          "enum": [
+            "STATE_UNSPECIFIED",
+            "CREATING",
+            "ACTIVE",
+            "FAILED"
+          ],
+          "description": "Output only. The state of the tuned model.",
+          "enumDescriptions": [
+            "The default value. This value is unused.",
+            "The model is being created.",
+            "The model is ready to be used.",
+            "The model failed to be created."
+          ],
+          "type": "string",
+          "readOnly": true
+        },
+        "displayName": {
+          "description": "Optional. The name to display for this model in user interfaces. The display name must be up to 40 characters including spaces.",
+          "type": "string"
+        },
+        "description": {
+          "type": "string",
+          "description": "Optional. A short description of this model."
+        },
+        "topP": {
+          "description": "Optional. For Nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`. This value specifies default to be the one used by the base model while creating the model.",
+          "type": "number",
+          "format": "float"
+        }
+      },
+      "id": "TunedModel",
+      "description": "A fine-tuned model created using ModelService.CreateTunedModel."
+    },
+    "GroundingAttribution": {
+      "description": "Attribution for a source that contributed to an answer.",
+      "properties": {
+        "content": {
+          "$ref": "Content",
+          "description": "Grounding source content that makes up this attribution."
+        },
+        "sourceId": {
+          "readOnly": true,
+          "description": "Output only. Identifier for the source contributing to this attribution.",
+          "$ref": "AttributionSourceId"
+        }
+      },
+      "id": "GroundingAttribution",
+      "type": "object"
+    },
+    "TuningSnapshot": {
+      "properties": {
+        "step": {
+          "type": "integer",
+          "description": "Output only. The tuning step.",
+          "readOnly": true,
+          "format": "int32"
+        },
+        "epoch": {
+          "format": "int32",
+          "type": "integer",
+          "description": "Output only. The epoch this step was part of.",
+          "readOnly": true
+        },
+        "meanLoss": {
+          "format": "float",
+          "description": "Output only. The mean loss of the training examples for this step.",
+          "type": "number",
+          "readOnly": true
+        },
+        "computeTime": {
+          "description": "Output only. The timestamp when this metric was computed.",
+          "format": "google-datetime",
+          "readOnly": true,
+          "type": "string"
+        }
+      },
+      "description": "Record for a single tuning step.",
+      "id": "TuningSnapshot",
+      "type": "object"
+    },
+    "Tool": {
+      "type": "object",
+      "properties": {
+        "functionDeclarations": {
+          "items": {
+            "$ref": "FunctionDeclaration"
+          },
+          "description": "Optional. A list of `FunctionDeclarations` available to the model that can be used for function calling. The model or system does not execute the function. Instead the defined function may be returned as a FunctionCall with arguments to the client side for execution. The model may decide to call a subset of these functions by populating FunctionCall in the response. The next conversation turn may contain a FunctionResponse with the [content.role] \"function\" generation context for the next model turn.",
+          "type": "array"
+        }
+      },
+      "id": "Tool",
+      "description": "Tool details that the model may use to generate response. A `Tool` is a piece of code that enables the system to interact with external systems to perform an action, or set of actions, outside of knowledge and scope of the model."
+    },
+    "EmbedTextResponse": {
+      "properties": {
+        "embedding": {
+          "description": "Output only. The embedding generated from the input text.",
+          "$ref": "Embedding",
+          "readOnly": true
+        }
+      },
+      "type": "object",
+      "id": "EmbedTextResponse",
+      "description": "The response to a EmbedTextRequest."
+    },
+    "RelevantChunk": {
+      "id": "RelevantChunk",
+      "description": "The information for a chunk relevant to a query.",
+      "properties": {
+        "chunk": {
+          "$ref": "Chunk",
+          "description": "`Chunk` associated with the query."
+        },
+        "chunkRelevanceScore": {
+          "type": "number",
+          "format": "float",
+          "description": "`Chunk` relevance to the query."
+        }
+      },
+      "type": "object"
+    },
+    "GroundingPassages": {
+      "properties": {
+        "passages": {
+          "description": "List of passages.",
+          "items": {
+            "$ref": "GroundingPassage"
           },
           "type": "array"
         }
       },
       "type": "object",
-      "id": "Embedding"
+      "description": "A repeated list of passages.",
+      "id": "GroundingPassages"
+    },
+    "Model": {
+      "type": "object",
+      "id": "Model",
+      "properties": {
+        "outputTokenLimit": {
+          "description": "Maximum number of output tokens available for this model.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "inputTokenLimit": {
+          "format": "int32",
+          "description": "Maximum number of input tokens allowed for this model.",
+          "type": "integer"
+        },
+        "supportedGenerationMethods": {
+          "description": "The model's supported generation methods. The method names are defined as Pascal case strings, such as `generateMessage` which correspond to API methods.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "type": "string",
+          "description": "Required. The resource name of the `Model`. Format: `models/{model}` with a `{model}` naming convention of: * \"{base_model_id}-{version}\" Examples: * `models/chat-bison-001`"
+        },
+        "baseModelId": {
+          "type": "string",
+          "description": "Required. The name of the base model, pass this to the generation request. Examples: * `chat-bison`"
+        },
+        "description": {
+          "type": "string",
+          "description": "A short description of the model."
+        },
+        "topP": {
+          "type": "number",
+          "description": "For Nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`. This value specifies default to be used by the backend while making the call to the model.",
+          "format": "float"
+        },
+        "version": {
+          "type": "string",
+          "description": "Required. The version number of the model. This represents the major version"
+        },
+        "topK": {
+          "description": "For Top-k sampling. Top-k sampling considers the set of `top_k` most probable tokens. This value specifies default to be used by the backend while making the call to the model. If empty, indicates the model doesn't use top-k sampling, and `top_k` isn't allowed as a generation parameter.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "maxTemperature": {
+          "description": "The maximum temperature this model can use.",
+          "type": "number",
+          "format": "float"
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Controls the randomness of the output. Values can range over `[0.0,max_temperature]`, inclusive. A higher value will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model. This value specifies default to be used by the backend while making the call to the model.",
+          "format": "float"
+        },
+        "displayName": {
+          "description": "The human-readable name of the model. E.g. \"Chat Bison\". The name can be up to 128 characters long and can consist of any UTF-8 characters.",
+          "type": "string"
+        }
+      },
+      "description": "Information about a Generative Language Model."
+    },
+    "StringList": {
+      "id": "StringList",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The string values of the metadata to store."
+        }
+      },
+      "description": "User provided string values assigned to a single metadata key.",
+      "type": "object"
+    },
+    "VideoMetadata": {
+      "type": "object",
+      "properties": {
+        "videoDuration": {
+          "format": "google-duration",
+          "description": "Duration of the video.",
+          "type": "string"
+        }
+      },
+      "id": "VideoMetadata",
+      "description": "Metadata for a video `File`."
+    },
+    "Empty": {
+      "description": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); }",
+      "id": "Empty",
+      "properties": {},
+      "type": "object"
+    },
+    "GenerateContentResponse": {
+      "properties": {
+        "candidates": {
+          "items": {
+            "$ref": "Candidate"
+          },
+          "description": "Candidate responses from the model.",
+          "type": "array"
+        },
+        "promptFeedback": {
+          "$ref": "PromptFeedback",
+          "description": "Returns the prompt's feedback related to the content filters."
+        },
+        "usageMetadata": {
+          "readOnly": true,
+          "$ref": "UsageMetadata",
+          "description": "Output only. Metadata on the generation requests' token usage."
+        }
+      },
+      "type": "object",
+      "description": "Response from the model supporting multiple candidates. Note on safety ratings and content filtering. They are reported for both prompt in `GenerateContentResponse.prompt_feedback` and for each candidate in `finish_reason` and in `safety_ratings`. The API contract is that: - either all requested candidates are returned or no candidates at all - no candidates are returned only if there was something wrong with the prompt (see `prompt_feedback`) - feedback on each candidate is reported on `finish_reason` and `safety_ratings`.",
+      "id": "GenerateContentResponse"
+    },
+    "CountTokensResponse": {
+      "description": "A response from `CountTokens`. It returns the model's `token_count` for the `prompt`.",
+      "properties": {
+        "totalTokens": {
+          "description": "The number of tokens that the `model` tokenizes the `prompt` into. Always non-negative. When cached_content is set, this is still the total effective prompt size. I.e. this includes the number of tokens in the cached content.",
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "id": "CountTokensResponse",
+      "type": "object"
     },
     "BatchEmbedTextRequest": {
-      "id": "BatchEmbedTextRequest",
-      "type": "object",
-      "description": "Batch request to get a text embedding from the model.",
       "properties": {
         "requests": {
           "description": "Optional. Embed requests for the batch. Only one of `texts` or `requests` can be set.",
@@ -2502,680 +1709,468 @@
           }
         },
         "texts": {
-          "description": "Optional. The free-form input texts that the model will turn into an embedding. The current limit is 100 texts, over which an error will be thrown.",
-          "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "Optional. The free-form input texts that the model will turn into an embedding. The current limit is 100 texts, over which an error will be thrown.",
+          "type": "array"
         }
-      }
+      },
+      "description": "Batch request to get a text embedding from the model.",
+      "id": "BatchEmbedTextRequest",
+      "type": "object"
+    },
+    "CountMessageTokensResponse": {
+      "properties": {
+        "tokenCount": {
+          "description": "The number of tokens that the `model` tokenizes the `prompt` into. Always non-negative.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "id": "CountMessageTokensResponse",
+      "description": "A response from `CountMessageTokens`. It returns the model's `token_count` for the `prompt`.",
+      "type": "object"
+    },
+    "Document": {
+      "type": "object",
+      "id": "Document",
+      "properties": {
+        "updateTime": {
+          "format": "google-datetime",
+          "type": "string",
+          "description": "Output only. The Timestamp of when the `Document` was last updated.",
+          "readOnly": true
+        },
+        "customMetadata": {
+          "description": "Optional. User provided custom metadata stored as key-value pairs used for querying. A `Document` can have a maximum of 20 `CustomMetadata`.",
+          "type": "array",
+          "items": {
+            "$ref": "CustomMetadata"
+          }
+        },
+        "displayName": {
+          "description": "Optional. The human-readable display name for the `Document`. The display name must be no more than 512 characters in length, including spaces. Example: \"Semantic Retriever Documentation\"",
+          "type": "string"
+        },
+        "createTime": {
+          "description": "Output only. The Timestamp of when the `Document` was created.",
+          "readOnly": true,
+          "type": "string",
+          "format": "google-datetime"
+        },
+        "name": {
+          "description": "Immutable. Identifier. The `Document` resource name. The ID (name excluding the \"corpora/*/documents/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/{corpus_id}/documents/my-awesome-doc-123a456b789c`",
+          "type": "string"
+        }
+      },
+      "description": "A `Document` is a collection of `Chunk`s. A `Corpus` can have a maximum of 10,000 `Document`s."
+    },
+    "CreateFileResponse": {
+      "description": "Response for `CreateFile`.",
+      "properties": {
+        "file": {
+          "$ref": "File",
+          "description": "Metadata for the created file."
+        }
+      },
+      "type": "object",
+      "id": "CreateFileResponse"
     },
     "ListChunksResponse": {
-      "id": "ListChunksResponse",
+      "type": "object",
       "properties": {
         "nextPageToken": {
           "type": "string",
           "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
         },
         "chunks": {
-          "description": "The returned `Chunk`s.",
           "items": {
             "$ref": "Chunk"
           },
-          "type": "array"
+          "type": "array",
+          "description": "The returned `Chunk`s."
         }
       },
-      "type": "object",
+      "id": "ListChunksResponse",
       "description": "Response from `ListChunks` containing a paginated list of `Chunk`s. The `Chunk`s are sorted by ascending `chunk.create_time`."
     },
-    "QueryCorpusResponse": {
+    "CountTokensRequest": {
       "type": "object",
-      "id": "QueryCorpusResponse",
+      "id": "CountTokensRequest",
+      "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`.",
       "properties": {
-        "relevantChunks": {
+        "contents": {
           "items": {
-            "$ref": "RelevantChunk"
+            "$ref": "Content"
           },
           "type": "array",
-          "description": "The relevant chunks."
-        }
-      },
-      "description": "Response from `QueryCorpus` containing a list of relevant chunks."
-    },
-    "FunctionCall": {
-      "id": "FunctionCall",
-      "description": "A predicted `FunctionCall` returned from the model that contains a string representing the `FunctionDeclaration.name` with the arguments and their values.",
-      "type": "object",
-      "properties": {
-        "name": {
-          "description": "Required. The name of the function to call. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63.",
-          "type": "string"
+          "description": "Optional. The input given to the model as a prompt. This field is ignored when `generate_content_request` is set."
         },
-        "args": {
-          "description": "Optional. The function parameters and values in JSON object format.",
-          "additionalProperties": {
-            "type": "any",
-            "description": "Properties of the object."
-          },
-          "type": "object"
+        "generateContentRequest": {
+          "description": "Optional. The overall input given to the model. CountTokens will count prompt, function calling, etc.",
+          "$ref": "GenerateContentRequest"
         }
       }
     },
-    "UsageMetadata": {
+    "CitationSource": {
       "properties": {
-        "candidatesTokenCount": {
-          "format": "int32",
-          "description": "Total number of tokens across the generated candidates.",
-          "type": "integer"
-        },
-        "totalTokenCount": {
-          "description": "Total token count for the generation request (prompt + candidates).",
+        "startIndex": {
           "type": "integer",
+          "description": "Optional. Start of segment of the response that is attributed to this source. Index indicates the start of the segment, measured in bytes.",
           "format": "int32"
         },
-        "cachedContentTokenCount": {
-          "description": "Number of tokens in the cached part of the prompt, i.e. in the cached content.",
-          "format": "int32",
-          "type": "integer"
-        },
-        "promptTokenCount": {
-          "format": "int32",
-          "type": "integer",
-          "description": "Number of tokens in the prompt. When cached_content is set, this is still the total effective prompt size. I.e. this includes the number of tokens in the cached content."
-        }
-      },
-      "id": "UsageMetadata",
-      "type": "object",
-      "description": "Metadata on the generation request's token usage."
-    },
-    "FunctionDeclaration": {
-      "description": "Structured representation of a function declaration as defined by the [OpenAPI 3.03 specification](https://spec.openapis.org/oas/v3.0.3). Included in this declaration are the function name and parameters. This FunctionDeclaration is a representation of a block of code that can be used as a `Tool` by the model and executed by the client.",
-      "id": "FunctionDeclaration",
-      "properties": {
-        "description": {
-          "description": "Required. A brief description of the function.",
-          "type": "string"
-        },
-        "parameters": {
-          "$ref": "Schema",
-          "description": "Optional. Describes the parameters to this function. Reflects the Open API 3.03 Parameter Object string Key: the name of the parameter. Parameter names are case sensitive. Schema Value: the Schema defining the type used for the parameter."
-        },
-        "name": {
+        "license": {
           "type": "string",
-          "description": "Required. The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
-        }
-      },
-      "type": "object"
-    },
-    "GenerateContentResponse": {
-      "id": "GenerateContentResponse",
-      "properties": {
-        "candidates": {
-          "description": "Candidate responses from the model.",
-          "type": "array",
-          "items": {
-            "$ref": "Candidate"
-          }
+          "description": "Optional. License for the GitHub project that is attributed as a source for segment. License info is required for code citations."
         },
-        "usageMetadata": {
-          "$ref": "UsageMetadata",
-          "readOnly": true,
-          "description": "Output only. Metadata on the generation requests' token usage."
-        },
-        "promptFeedback": {
-          "description": "Returns the prompt's feedback related to the content filters.",
-          "$ref": "PromptFeedback"
-        }
-      },
-      "description": "Response from the model supporting multiple candidates. Note on safety ratings and content filtering. They are reported for both prompt in `GenerateContentResponse.prompt_feedback` and for each candidate in `finish_reason` and in `safety_ratings`. The API contract is that: - either all requested candidates are returned or no candidates at all - no candidates are returned only if there was something wrong with the prompt (see `prompt_feedback`) - feedback on each candidate is reported on `finish_reason` and `safety_ratings`.",
-      "type": "object"
-    },
-    "TunedModelSource": {
-      "id": "TunedModelSource",
-      "description": "Tuned model as a source for training a new model.",
-      "type": "object",
-      "properties": {
-        "baseModel": {
-          "type": "string",
-          "readOnly": true,
-          "description": "Output only. The name of the base `Model` this `TunedModel` was tuned from. Example: `models/text-bison-001`"
-        },
-        "tunedModel": {
-          "description": "Immutable. The name of the `TunedModel` to use as the starting point for training the new model. Example: `tunedModels/my-tuned-model`",
-          "type": "string"
-        }
-      }
-    },
-    "BatchUpdateChunksResponse": {
-      "type": "object",
-      "id": "BatchUpdateChunksResponse",
-      "properties": {
-        "chunks": {
-          "type": "array",
-          "description": "`Chunk`s updated.",
-          "items": {
-            "$ref": "Chunk"
-          }
-        }
-      },
-      "description": "Response from `BatchUpdateChunks` containing a list of updated `Chunk`s."
-    },
-    "ListCachedContentsResponse": {
-      "id": "ListCachedContentsResponse",
-      "properties": {
-        "nextPageToken": {
-          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.",
-          "type": "string"
-        },
-        "cachedContents": {
-          "description": "List of cached contents.",
-          "type": "array",
-          "items": {
-            "$ref": "CachedContent"
-          }
-        }
-      },
-      "description": "Response with CachedContents list.",
-      "type": "object"
-    },
-    "Status": {
-      "description": "The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).",
-      "id": "Status",
-      "type": "object",
-      "properties": {
-        "code": {
-          "description": "The status code, which should be an enum value of google.rpc.Code.",
-          "format": "int32",
-          "type": "integer"
-        },
-        "message": {
-          "type": "string",
-          "description": "A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client."
-        },
-        "details": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "additionalProperties": {
-              "description": "Properties of the object. Contains field @type with type URL.",
-              "type": "any"
-            }
-          },
-          "description": "A list of messages that carry the error details. There is a common set of message types for APIs to use."
-        }
-      }
-    },
-    "Hyperparameters": {
-      "description": "Hyperparameters controlling the tuning process. Read more at https://ai.google.dev/docs/model_tuning_guidance",
-      "type": "object",
-      "id": "Hyperparameters",
-      "properties": {
-        "learningRate": {
-          "format": "float",
-          "description": "Optional. Immutable. The learning rate hyperparameter for tuning. If not set, a default of 0.001 or 0.0002 will be calculated based on the number of training examples.",
-          "type": "number"
-        },
-        "epochCount": {
-          "format": "int32",
-          "type": "integer",
-          "description": "Immutable. The number of training epochs. An epoch is one pass through the training data. If not set, a default of 5 will be used."
-        },
-        "learningRateMultiplier": {
-          "format": "float",
-          "description": "Optional. Immutable. The learning rate multiplier is used to calculate a final learning_rate based on the default (recommended) value. Actual learning rate := learning_rate_multiplier * default learning rate Default learning rate is dependent on base model and dataset size. If not set, a default of 1.0 will be used.",
-          "type": "number"
-        },
-        "batchSize": {
+        "endIndex": {
           "type": "integer",
           "format": "int32",
-          "description": "Immutable. The batch size hyperparameter for tuning. If not set, a default of 4 or 16 will be used based on the number of training examples."
-        }
-      }
-    },
-    "CountMessageTokensRequest": {
-      "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`.",
-      "type": "object",
-      "properties": {
-        "prompt": {
-          "$ref": "MessagePrompt",
-          "description": "Required. The prompt, whose token count is to be returned."
+          "description": "Optional. End of the attributed segment, exclusive."
+        },
+        "uri": {
+          "type": "string",
+          "description": "Optional. URI that is attributed as a source for a portion of the text."
         }
       },
-      "id": "CountMessageTokensRequest"
-    },
-    "Operation": {
-      "type": "object",
-      "properties": {
-        "error": {
-          "$ref": "Status",
-          "description": "The error result of the operation in case of failure or cancellation."
-        },
-        "done": {
-          "description": "If the value is `false`, it means the operation is still in progress. If `true`, the operation is completed, and either `error` or `response` is available.",
-          "type": "boolean"
-        },
-        "response": {
-          "description": "The normal, successful response of the operation. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`.",
-          "additionalProperties": {
-            "description": "Properties of the object. Contains field @type with type URL.",
-            "type": "any"
-          },
-          "type": "object"
-        },
-        "name": {
-          "description": "The server-assigned name, which is only unique within the same service that originally returns it. If you use the default HTTP mapping, the `name` should be a resource name ending with `operations/{unique_id}`.",
-          "type": "string"
-        },
-        "metadata": {
-          "additionalProperties": {
-            "description": "Properties of the object. Contains field @type with type URL.",
-            "type": "any"
-          },
-          "type": "object",
-          "description": "Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any."
-        }
-      },
-      "id": "Operation",
-      "description": "This resource represents a long-running operation that is the result of a network API call."
+      "id": "CitationSource",
+      "description": "A citation to a source for a portion of a specific response.",
+      "type": "object"
     },
     "Permission": {
+      "type": "object",
       "id": "Permission",
       "properties": {
-        "emailAddress": {
-          "description": "Optional. Immutable. The email address of the user of group which this permission refers. Field is not set when permission's grantee type is EVERYONE.",
-          "type": "string"
-        },
         "granteeType": {
-          "type": "string",
           "description": "Optional. Immutable. The type of the grantee.",
+          "enum": [
+            "GRANTEE_TYPE_UNSPECIFIED",
+            "USER",
+            "GROUP",
+            "EVERYONE"
+          ],
           "enumDescriptions": [
             "The default value. This value is unused.",
             "Represents a user. When set, you must provide email_address for the user.",
             "Represents a group. When set, you must provide email_address for the group.",
             "Represents access to everyone. No extra information is required."
           ],
-          "enum": [
-            "GRANTEE_TYPE_UNSPECIFIED",
-            "USER",
-            "GROUP",
-            "EVERYONE"
-          ]
+          "type": "string"
         },
         "name": {
           "readOnly": true,
+          "description": "Output only. Identifier. The permission name. A unique name will be generated on create. Examples: tunedModels/{tuned_model}/permissions/{permission} corpora/{corpus}/permissions/{permission} Output only.",
+          "type": "string"
+        },
+        "emailAddress": {
           "type": "string",
-          "description": "Output only. Identifier. The permission name. A unique name will be generated on create. Examples: tunedModels/{tuned_model}/permissions/{permission} corpora/{corpus}/permissions/{permission} Output only."
+          "description": "Optional. Immutable. The email address of the user of group which this permission refers. Field is not set when permission's grantee type is EVERYONE."
         },
         "role": {
-          "type": "string",
-          "enumDescriptions": [
-            "The default value. This value is unused.",
-            "Owner can use, update, share and delete the resource.",
-            "Writer can use, update and share the resource.",
-            "Reader can use the resource."
-          ],
           "enum": [
             "ROLE_UNSPECIFIED",
             "OWNER",
             "WRITER",
             "READER"
           ],
-          "description": "Required. The role granted by this permission."
+          "type": "string",
+          "description": "Required. The role granted by this permission.",
+          "enumDescriptions": [
+            "The default value. This value is unused.",
+            "Owner can use, update, share and delete the resource.",
+            "Writer can use, update and share the resource.",
+            "Reader can use the resource."
+          ]
         }
       },
-      "type": "object",
       "description": "Permission resource grants user, group or the rest of the world access to the PaLM API resource (e.g. a tuned model, corpus). A role is a collection of permitted operations that allows users to perform specific actions on PaLM API resources. To make them available to users, groups, or service accounts, you assign roles. When you assign a role, you grant permissions that the role contains. There are three concentric roles. Each role is a superset of the previous role's permitted operations: - reader can use the resource (e.g. tuned model, corpus) for inference - writer has reader's permissions and additionally can edit and share - owner has writer's permissions and additionally can delete"
     },
-    "SemanticRetrieverChunk": {
-      "description": "Identifier for a `Chunk` retrieved via Semantic Retriever specified in the `GenerateAnswerRequest` using `SemanticRetrieverConfig`.",
-      "type": "object",
+    "GenerateTextResponse": {
       "properties": {
-        "chunk": {
-          "readOnly": true,
-          "type": "string",
-          "description": "Output only. Name of the `Chunk` containing the attributed text. Example: `corpora/123/documents/abc/chunks/xyz`"
+        "candidates": {
+          "items": {
+            "$ref": "TextCompletion"
+          },
+          "type": "array",
+          "description": "Candidate responses from the model."
         },
-        "source": {
-          "description": "Output only. Name of the source matching the request's `SemanticRetrieverConfig.source`. Example: `corpora/123` or `corpora/123/documents/abc`",
-          "readOnly": true,
-          "type": "string"
+        "safetyFeedback": {
+          "items": {
+            "$ref": "SafetyFeedback"
+          },
+          "description": "Returns any safety feedback related to content filtering.",
+          "type": "array"
+        },
+        "filters": {
+          "description": "A set of content filtering metadata for the prompt and response text. This indicates which `SafetyCategory`(s) blocked a candidate from this response, the lowest `HarmProbability` that triggered a block, and the HarmThreshold setting for that category. This indicates the smallest change to the `SafetySettings` that would be necessary to unblock at least 1 response. The blocking is configured by the `SafetySettings` in the request (or the default `SafetySettings` of the API).",
+          "items": {
+            "$ref": "ContentFilter"
+          },
+          "type": "array"
         }
       },
-      "id": "SemanticRetrieverChunk"
+      "description": "The response from the model, including candidate completions.",
+      "id": "GenerateTextResponse",
+      "type": "object"
     },
-    "GroundingPassageId": {
+    "BatchUpdateChunksRequest": {
+      "type": "object",
       "properties": {
-        "passageId": {
-          "readOnly": true,
-          "type": "string",
-          "description": "Output only. ID of the passage matching the `GenerateAnswerRequest`'s `GroundingPassage.id`."
-        },
-        "partIndex": {
-          "description": "Output only. Index of the part within the `GenerateAnswerRequest`'s `GroundingPassage.content`.",
-          "format": "int32",
-          "type": "integer",
+        "requests": {
+          "items": {
+            "$ref": "UpdateChunkRequest"
+          },
+          "type": "array",
+          "description": "Required. The request messages specifying the `Chunk`s to update. A maximum of 100 `Chunk`s can be updated in a batch."
+        }
+      },
+      "id": "BatchUpdateChunksRequest",
+      "description": "Request to batch update `Chunk`s."
+    },
+    "EmbedContentResponse": {
+      "id": "EmbedContentResponse",
+      "properties": {
+        "embedding": {
+          "$ref": "ContentEmbedding",
+          "description": "Output only. The embedding generated from the input content.",
           "readOnly": true
         }
       },
-      "id": "GroundingPassageId",
       "type": "object",
-      "description": "Identifier for a part within a `GroundingPassage`."
+      "description": "The response to an `EmbedContentRequest`."
     },
-    "CountTokensRequest": {
+    "ContentFilter": {
+      "description": "Content filtering metadata associated with processing a single request. ContentFilter contains a reason and an optional supporting string. The reason may be unspecified.",
       "properties": {
-        "contents": {
-          "type": "array",
-          "description": "Optional. The input given to the model as a prompt. This field is ignored when `generate_content_request` is set.",
-          "items": {
-            "$ref": "Content"
-          }
-        },
-        "generateContentRequest": {
-          "description": "Optional. The overall input given to the model. CountTokens will count prompt, function calling, etc.",
-          "$ref": "GenerateContentRequest"
-        }
-      },
-      "type": "object",
-      "id": "CountTokensRequest",
-      "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`."
-    },
-    "Corpus": {
-      "properties": {
-        "updateTime": {
-          "readOnly": true,
-          "format": "google-datetime",
-          "description": "Output only. The Timestamp of when the `Corpus` was last updated.",
-          "type": "string"
-        },
-        "displayName": {
+        "message": {
           "type": "string",
-          "description": "Optional. The human-readable display name for the `Corpus`. The display name must be no more than 512 characters in length, including spaces. Example: \"Docs on Semantic Retriever\""
+          "description": "A string that describes the filtering behavior in more detail."
         },
-        "createTime": {
-          "type": "string",
-          "format": "google-datetime",
-          "readOnly": true,
-          "description": "Output only. The Timestamp of when the `Corpus` was created."
-        },
-        "name": {
-          "description": "Immutable. Identifier. The `Corpus` resource name. The ID (name excluding the \"corpora/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/my-awesome-corpora-123a456b789c`",
-          "type": "string"
-        }
-      },
-      "id": "Corpus",
-      "description": "A `Corpus` is a collection of `Document`s. A project can create up to 5 corpora.",
-      "type": "object"
-    },
-    "CreateFileResponse": {
-      "description": "Response for `CreateFile`.",
-      "type": "object",
-      "id": "CreateFileResponse",
-      "properties": {
-        "file": {
-          "$ref": "File",
-          "description": "Metadata for the created file."
-        }
-      }
-    },
-    "CountTextTokensRequest": {
-      "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`.",
-      "properties": {
-        "prompt": {
-          "$ref": "TextPrompt",
-          "description": "Required. The free-form input text given to the model as a prompt."
-        }
-      },
-      "id": "CountTextTokensRequest",
-      "type": "object"
-    },
-    "GroundingAttribution": {
-      "properties": {
-        "content": {
-          "description": "Grounding source content that makes up this attribution.",
-          "$ref": "Content"
-        },
-        "sourceId": {
-          "$ref": "AttributionSourceId",
-          "readOnly": true,
-          "description": "Output only. Identifier for the source contributing to this attribution."
-        }
-      },
-      "description": "Attribution for a source that contributed to an answer.",
-      "type": "object",
-      "id": "GroundingAttribution"
-    },
-    "Example": {
-      "description": "An input/output example used to instruct the Model. It demonstrates how the model should respond or format its response.",
-      "type": "object",
-      "properties": {
-        "input": {
-          "$ref": "Message",
-          "description": "Required. An example of an input `Message` from the user."
-        },
-        "output": {
-          "$ref": "Message",
-          "description": "Required. An example of what the model should output given the input."
-        }
-      },
-      "id": "Example"
-    },
-    "VideoMetadata": {
-      "properties": {
-        "videoDuration": {
-          "type": "string",
-          "description": "Duration of the video.",
-          "format": "google-duration"
-        }
-      },
-      "type": "object",
-      "description": "Metadata for a video `File`.",
-      "id": "VideoMetadata"
-    },
-    "InputFeedback": {
-      "properties": {
-        "blockReason": {
-          "description": "Optional. If set, the input was blocked and no candidates are returned. Rephrase your input.",
+        "reason": {
+          "description": "The reason content was blocked during request processing.",
           "enum": [
-            "BLOCK_REASON_UNSPECIFIED",
+            "BLOCKED_REASON_UNSPECIFIED",
             "SAFETY",
             "OTHER"
           ],
           "type": "string",
           "enumDescriptions": [
-            "Default value. This value is unused.",
-            "Input was blocked due to safety reasons. You can inspect `safety_ratings` to understand which safety category blocked it.",
-            "Input was blocked due to other reasons."
+            "A blocked reason was not specified.",
+            "Content was blocked by safety settings.",
+            "Content was blocked, but the reason is uncategorized."
           ]
-        },
-        "safetyRatings": {
-          "type": "array",
-          "items": {
-            "$ref": "SafetyRating"
-          },
-          "description": "Ratings for safety of the input. There is at most one rating per category."
         }
       },
-      "type": "object",
-      "description": "Feedback related to the input data used to answer the question, as opposed to model-generated response to the question.",
-      "id": "InputFeedback"
+      "id": "ContentFilter",
+      "type": "object"
     },
-    "FunctionCallingConfig": {
-      "description": "Configuration for specifying function calling behavior.",
+    "ChunkData": {
+      "id": "ChunkData",
       "properties": {
-        "allowedFunctionNames": {
-          "type": "array",
-          "description": "Optional. A set of function names that, when provided, limits the functions the model will call. This should only be set when the Mode is ANY. Function names should match [FunctionDeclaration.name]. With mode set to ANY, model will predict a function call from the set of function names provided.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "mode": {
+        "stringValue": {
           "type": "string",
-          "enumDescriptions": [
-            "Unspecified function calling mode. This value should not be used.",
-            "Default model behavior, model decides to predict either a function call or a natural language response.",
-            "Model is constrained to always predicting a function call only. If \"allowed_function_names\" are set, the predicted function call will be limited to any one of \"allowed_function_names\", else the predicted function call will be any one of the provided \"function_declarations\".",
-            "Model will not predict any function call. Model behavior is same as when not passing any function declarations."
-          ],
-          "enum": [
-            "MODE_UNSPECIFIED",
-            "AUTO",
-            "ANY",
-            "NONE"
-          ],
-          "description": "Optional. Specifies the mode in which function calling should execute. If unspecified, the default value will be set to AUTO."
+          "description": "The `Chunk` content as a string. The maximum number of tokens per chunk is 2043."
         }
       },
+      "description": "Extracted data that represents the `Chunk` content.",
+      "type": "object"
+    },
+    "CountTextTokensRequest": {
+      "id": "CountTextTokensRequest",
+      "properties": {
+        "prompt": {
+          "description": "Required. The free-form input text given to the model as a prompt.",
+          "$ref": "TextPrompt"
+        }
+      },
+      "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`.",
+      "type": "object"
+    },
+    "Hyperparameters": {
+      "description": "Hyperparameters controlling the tuning process. Read more at https://ai.google.dev/docs/model_tuning_guidance",
       "type": "object",
-      "id": "FunctionCallingConfig"
+      "id": "Hyperparameters",
+      "properties": {
+        "learningRateMultiplier": {
+          "description": "Optional. Immutable. The learning rate multiplier is used to calculate a final learning_rate based on the default (recommended) value. Actual learning rate := learning_rate_multiplier * default learning rate Default learning rate is dependent on base model and dataset size. If not set, a default of 1.0 will be used.",
+          "format": "float",
+          "type": "number"
+        },
+        "learningRate": {
+          "type": "number",
+          "description": "Optional. Immutable. The learning rate hyperparameter for tuning. If not set, a default of 0.001 or 0.0002 will be calculated based on the number of training examples.",
+          "format": "float"
+        },
+        "batchSize": {
+          "type": "integer",
+          "description": "Immutable. The batch size hyperparameter for tuning. If not set, a default of 4 or 16 will be used based on the number of training examples.",
+          "format": "int32"
+        },
+        "epochCount": {
+          "type": "integer",
+          "description": "Immutable. The number of training epochs. An epoch is one pass through the training data. If not set, a default of 5 will be used.",
+          "format": "int32"
+        }
+      }
     },
     "EmbedTextRequest": {
-      "id": "EmbedTextRequest",
+      "description": "Request to get a text embedding from the model.",
       "properties": {
         "text": {
-          "type": "string",
-          "description": "Optional. The free-form input text that the model will turn into an embedding."
+          "description": "Optional. The free-form input text that the model will turn into an embedding.",
+          "type": "string"
         },
         "model": {
           "description": "Required. The model name to use with the format model=models/{model}.",
           "type": "string"
         }
       },
-      "description": "Request to get a text embedding from the model.",
-      "type": "object"
-    },
-    "ListDocumentsResponse": {
       "type": "object",
-      "properties": {
-        "documents": {
-          "type": "array",
-          "items": {
-            "$ref": "Document"
-          },
-          "description": "The returned `Document`s."
-        },
-        "nextPageToken": {
-          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages.",
-          "type": "string"
-        }
-      },
-      "id": "ListDocumentsResponse",
-      "description": "Response from `ListDocuments` containing a paginated list of `Document`s. The `Document`s are sorted by ascending `document.create_time`."
+      "id": "EmbedTextRequest"
     },
-    "Part": {
+    "EmbedContentRequest": {
+      "id": "EmbedContentRequest",
+      "description": "Request containing the `Content` for the model to embed.",
       "properties": {
-        "functionCall": {
-          "description": "A predicted `FunctionCall` returned from the model that contains a string representing the `FunctionDeclaration.name` with the arguments and their values.",
-          "$ref": "FunctionCall"
-        },
-        "functionResponse": {
-          "description": "The result output of a `FunctionCall` that contains a string representing the `FunctionDeclaration.name` and a structured JSON object containing any output from the function is used as context to the model.",
-          "$ref": "FunctionResponse"
-        },
-        "fileData": {
-          "description": "URI based data.",
-          "$ref": "FileData"
-        },
-        "inlineData": {
-          "$ref": "Blob",
-          "description": "Inline media bytes."
-        },
-        "text": {
-          "type": "string",
-          "description": "Inline text."
-        }
-      },
-      "type": "object",
-      "id": "Part",
-      "description": "A datatype containing media that is part of a multi-part `Content` message. A `Part` consists of data which has an associated datatype. A `Part` can only contain one of the accepted types in `Part.data`. A `Part` must have a fixed IANA MIME type identifying the type and subtype of the media if the `inline_data` field is filled with raw bytes."
-    },
-    "BatchCreateChunksResponse": {
-      "type": "object",
-      "properties": {
-        "chunks": {
-          "description": "`Chunk`s created.",
-          "items": {
-            "$ref": "Chunk"
-          },
-          "type": "array"
-        }
-      },
-      "description": "Response from `BatchCreateChunks` containing a list of created `Chunk`s.",
-      "id": "BatchCreateChunksResponse"
-    },
-    "MetadataFilter": {
-      "id": "MetadataFilter",
-      "type": "object",
-      "properties": {
-        "key": {
-          "description": "Required. The key of the metadata to filter on.",
-          "type": "string"
-        },
-        "conditions": {
-          "description": "Required. The `Condition`s for the given key that will trigger this filter. Multiple `Condition`s are joined by logical ORs.",
-          "type": "array",
-          "items": {
-            "$ref": "Condition"
-          }
-        }
-      },
-      "description": "User provided filter to limit retrieval based on `Chunk` or `Document` level metadata values. Example (genre = drama OR genre = action): key = \"document.custom_metadata.genre\" conditions = [{string_value = \"drama\", operation = EQUAL}, {string_value = \"action\", operation = EQUAL}]"
-    },
-    "TuningExample": {
-      "id": "TuningExample",
-      "properties": {
-        "textInput": {
-          "type": "string",
-          "description": "Optional. Text model input."
-        },
-        "output": {
-          "description": "Required. The expected model output.",
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "description": "A single example for tuning."
-    },
-    "SafetyRating": {
-      "id": "SafetyRating",
-      "description": "Safety rating for a piece of content. The safety rating contains the category of harm and the harm probability level in that category for a piece of content. Content is classified for safety across a number of harm categories and the probability of the harm classification is included here.",
-      "properties": {
-        "blocked": {
-          "description": "Was this content blocked because of this rating?",
-          "type": "boolean"
-        },
-        "probability": {
-          "description": "Required. The probability of harm for this content.",
+        "taskType": {
           "enum": [
-            "HARM_PROBABILITY_UNSPECIFIED",
-            "NEGLIGIBLE",
-            "LOW",
-            "MEDIUM",
-            "HIGH"
+            "TASK_TYPE_UNSPECIFIED",
+            "RETRIEVAL_QUERY",
+            "RETRIEVAL_DOCUMENT",
+            "SEMANTIC_SIMILARITY",
+            "CLASSIFICATION",
+            "CLUSTERING",
+            "QUESTION_ANSWERING",
+            "FACT_VERIFICATION"
           ],
           "enumDescriptions": [
-            "Probability is unspecified.",
-            "Content has a negligible chance of being unsafe.",
-            "Content has a low chance of being unsafe.",
-            "Content has a medium chance of being unsafe.",
-            "Content has a high chance of being unsafe."
+            "Unset value, which will default to one of the other enum values.",
+            "Specifies the given text is a query in a search/retrieval setting.",
+            "Specifies the given text is a document from the corpus being searched.",
+            "Specifies the given text will be used for STS.",
+            "Specifies that the given text will be classified.",
+            "Specifies that the embeddings will be used for clustering.",
+            "Specifies that the given text will be used for question answering.",
+            "Specifies that the given text will be used for fact verification."
           ],
+          "description": "Optional. Optional task type for which the embeddings will be used. Can only be set for `models/embedding-001`.",
           "type": "string"
         },
+        "content": {
+          "$ref": "Content",
+          "description": "Required. The content to embed. Only the `parts.text` fields will be counted."
+        },
+        "outputDimensionality": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. Optional reduced dimension for the output embedding. If set, excessive values in the output embedding are truncated from the end. Supported by newer models since 2024, and the earlier model (`models/embedding-001`) cannot specify this value."
+        },
+        "model": {
+          "type": "string",
+          "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`"
+        },
+        "title": {
+          "description": "Optional. An optional title for the text. Only applicable when TaskType is `RETRIEVAL_DOCUMENT`. Note: Specifying a `title` for `RETRIEVAL_DOCUMENT` provides better quality embeddings for retrieval.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "GenerateAnswerResponse": {
+      "description": "Response from the model for a grounded answer.",
+      "type": "object",
+      "properties": {
+        "inputFeedback": {
+          "readOnly": true,
+          "$ref": "InputFeedback",
+          "description": "Output only. Feedback related to the input data used to answer the question, as opposed to model-generated response to the question. \"Input data\" can be one or more of the following: - Question specified by the last entry in `GenerateAnswerRequest.content` - Conversation history specified by the other entries in `GenerateAnswerRequest.content` - Grounding sources (`GenerateAnswerRequest.semantic_retriever` or `GenerateAnswerRequest.inline_passages`)"
+        },
+        "answerableProbability": {
+          "readOnly": true,
+          "description": "Output only. The model's estimate of the probability that its answer is correct and grounded in the input passages. A low answerable_probability indicates that the answer might not be grounded in the sources. When `answerable_probability` is low, some clients may wish to: * Display a message to the effect of \"We couldn’t answer that question\" to the user. * Fall back to a general-purpose LLM that answers the question from world knowledge. The threshold and nature of such fallbacks will depend on individual clients’ use cases. 0.5 is a good starting threshold.",
+          "type": "number",
+          "format": "float"
+        },
+        "answer": {
+          "$ref": "Candidate",
+          "description": "Candidate answer from the model. Note: The model *always* attempts to provide a grounded answer, even when the answer is unlikely to be answerable from the given passages. In that case, a low-quality or ungrounded answer may be provided, along with a low `answerable_probability`."
+        }
+      },
+      "id": "GenerateAnswerResponse"
+    },
+    "QueryCorpusResponse": {
+      "id": "QueryCorpusResponse",
+      "type": "object",
+      "description": "Response from `QueryCorpus` containing a list of relevant chunks.",
+      "properties": {
+        "relevantChunks": {
+          "type": "array",
+          "items": {
+            "$ref": "RelevantChunk"
+          },
+          "description": "The relevant chunks."
+        }
+      }
+    },
+    "DeleteChunkRequest": {
+      "id": "DeleteChunkRequest",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Required. The resource name of the `Chunk` to delete. Example: `corpora/my-corpus-123/documents/the-doc-abc/chunks/some-chunk`"
+        }
+      },
+      "description": "Request to delete a `Chunk`.",
+      "type": "object"
+    },
+    "CountMessageTokensRequest": {
+      "id": "CountMessageTokensRequest",
+      "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`.",
+      "properties": {
+        "prompt": {
+          "$ref": "MessagePrompt",
+          "description": "Required. The prompt, whose token count is to be returned."
+        }
+      },
+      "type": "object"
+    },
+    "Example": {
+      "properties": {
+        "output": {
+          "description": "Required. An example of what the model should output given the input.",
+          "$ref": "Message"
+        },
+        "input": {
+          "description": "Required. An example of an input `Message` from the user.",
+          "$ref": "Message"
+        }
+      },
+      "description": "An input/output example used to instruct the Model. It demonstrates how the model should respond or format its response.",
+      "id": "Example",
+      "type": "object"
+    },
+    "Content": {
+      "description": "The base structured datatype containing multi-part content of a message. A `Content` includes a `role` field designating the producer of the `Content` and a `parts` field containing multi-part data that contains the content of the message turn.",
+      "properties": {
+        "role": {
+          "type": "string",
+          "description": "Optional. The producer of the content. Must be either 'user' or 'model'. Useful to set for multi-turn conversations, otherwise can be left blank or unset."
+        },
+        "parts": {
+          "type": "array",
+          "items": {
+            "$ref": "Part"
+          },
+          "description": "Ordered `Parts` that constitute a single message. Parts may have different MIME types."
+        }
+      },
+      "id": "Content",
+      "type": "object"
+    },
+    "SafetyRating": {
+      "properties": {
         "category": {
-          "enum": [
-            "HARM_CATEGORY_UNSPECIFIED",
-            "HARM_CATEGORY_DEROGATORY",
-            "HARM_CATEGORY_TOXICITY",
-            "HARM_CATEGORY_VIOLENCE",
-            "HARM_CATEGORY_SEXUAL",
-            "HARM_CATEGORY_MEDICAL",
-            "HARM_CATEGORY_DANGEROUS",
-            "HARM_CATEGORY_HARASSMENT",
-            "HARM_CATEGORY_HATE_SPEECH",
-            "HARM_CATEGORY_SEXUALLY_EXPLICIT",
-            "HARM_CATEGORY_DANGEROUS_CONTENT"
-          ],
           "type": "string",
           "description": "Required. The category for this rating.",
           "enumDescriptions": [
@@ -3190,460 +2185,289 @@
             "Hate speech and content.",
             "Sexually explicit content.",
             "Dangerous content."
+          ],
+          "enum": [
+            "HARM_CATEGORY_UNSPECIFIED",
+            "HARM_CATEGORY_DEROGATORY",
+            "HARM_CATEGORY_TOXICITY",
+            "HARM_CATEGORY_VIOLENCE",
+            "HARM_CATEGORY_SEXUAL",
+            "HARM_CATEGORY_MEDICAL",
+            "HARM_CATEGORY_DANGEROUS",
+            "HARM_CATEGORY_HARASSMENT",
+            "HARM_CATEGORY_HATE_SPEECH",
+            "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+            "HARM_CATEGORY_DANGEROUS_CONTENT"
+          ]
+        },
+        "blocked": {
+          "type": "boolean",
+          "description": "Was this content blocked because of this rating?"
+        },
+        "probability": {
+          "type": "string",
+          "description": "Required. The probability of harm for this content.",
+          "enum": [
+            "HARM_PROBABILITY_UNSPECIFIED",
+            "NEGLIGIBLE",
+            "LOW",
+            "MEDIUM",
+            "HIGH"
+          ],
+          "enumDescriptions": [
+            "Probability is unspecified.",
+            "Content has a negligible chance of being unsafe.",
+            "Content has a low chance of being unsafe.",
+            "Content has a medium chance of being unsafe.",
+            "Content has a high chance of being unsafe."
           ]
         }
       },
+      "id": "SafetyRating",
+      "description": "Safety rating for a piece of content. The safety rating contains the category of harm and the harm probability level in that category for a piece of content. Content is classified for safety across a number of harm categories and the probability of the harm classification is included here.",
       "type": "object"
     },
-    "GenerateAnswerResponse": {
+    "CreateChunkRequest": {
       "properties": {
-        "answerableProbability": {
-          "description": "Output only. The model's estimate of the probability that its answer is correct and grounded in the input passages. A low answerable_probability indicates that the answer might not be grounded in the sources. When `answerable_probability` is low, some clients may wish to: * Display a message to the effect of \"We couldn’t answer that question\" to the user. * Fall back to a general-purpose LLM that answers the question from world knowledge. The threshold and nature of such fallbacks will depend on individual clients’ use cases. 0.5 is a good starting threshold.",
-          "readOnly": true,
-          "type": "number",
-          "format": "float"
-        },
-        "inputFeedback": {
-          "readOnly": true,
-          "description": "Output only. Feedback related to the input data used to answer the question, as opposed to model-generated response to the question. \"Input data\" can be one or more of the following: - Question specified by the last entry in `GenerateAnswerRequest.content` - Conversation history specified by the other entries in `GenerateAnswerRequest.content` - Grounding sources (`GenerateAnswerRequest.semantic_retriever` or `GenerateAnswerRequest.inline_passages`)",
-          "$ref": "InputFeedback"
-        },
-        "answer": {
-          "$ref": "Candidate",
-          "description": "Candidate answer from the model. Note: The model *always* attempts to provide a grounded answer, even when the answer is unlikely to be answerable from the given passages. In that case, a low-quality or ungrounded answer may be provided, along with a low `answerable_probability`."
-        }
-      },
-      "id": "GenerateAnswerResponse",
-      "description": "Response from the model for a grounded answer.",
-      "type": "object"
-    },
-    "PromptFeedback": {
-      "type": "object",
-      "id": "PromptFeedback",
-      "properties": {
-        "blockReason": {
-          "type": "string",
-          "enumDescriptions": [
-            "Default value. This value is unused.",
-            "Prompt was blocked due to safety reasons. You can inspect `safety_ratings` to understand which safety category blocked it.",
-            "Prompt was blocked due to unknown reasons."
-          ],
-          "enum": [
-            "BLOCK_REASON_UNSPECIFIED",
-            "SAFETY",
-            "OTHER"
-          ],
-          "description": "Optional. If set, the prompt was blocked and no candidates are returned. Rephrase your prompt."
-        },
-        "safetyRatings": {
-          "items": {
-            "$ref": "SafetyRating"
-          },
-          "description": "Ratings for safety of the prompt. There is at most one rating per category.",
-          "type": "array"
-        }
-      },
-      "description": "A set of the feedback metadata the prompt specified in `GenerateContentRequest.content`."
-    },
-    "ChunkData": {
-      "id": "ChunkData",
-      "properties": {
-        "stringValue": {
-          "description": "The `Chunk` content as a string. The maximum number of tokens per chunk is 2043.",
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "description": "Extracted data that represents the `Chunk` content."
-    },
-    "FunctionResponse": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Required. The name of the function to call. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
-        },
-        "response": {
-          "type": "object",
-          "description": "Required. The function response in JSON object format.",
-          "additionalProperties": {
-            "description": "Properties of the object.",
-            "type": "any"
-          }
-        }
-      },
-      "description": "The result output from a `FunctionCall` that contains a string representing the `FunctionDeclaration.name` and a structured JSON object containing any output from the function is used as context to the model. This should contain the result of a`FunctionCall` made based on model prediction.",
-      "id": "FunctionResponse"
-    },
-    "Message": {
-      "description": "The base unit of structured text. A `Message` includes an `author` and the `content` of the `Message`. The `author` is used to tag messages when they are fed to the model as text.",
-      "properties": {
-        "citationMetadata": {
-          "$ref": "CitationMetadata",
-          "description": "Output only. Citation information for model-generated `content` in this `Message`. If this `Message` was generated as output from the model, this field may be populated with attribution information for any text included in the `content`. This field is used only on output.",
-          "readOnly": true
-        },
-        "content": {
-          "type": "string",
-          "description": "Required. The text content of the structured `Message`."
-        },
-        "author": {
-          "description": "Optional. The author of this Message. This serves as a key for tagging the content of this Message when it is fed to the model as text. The author can be any alphanumeric string.",
-          "type": "string"
-        }
-      },
-      "id": "Message",
-      "type": "object"
-    },
-    "AttributionSourceId": {
-      "type": "object",
-      "description": "Identifier for the source contributing to this attribution.",
-      "properties": {
-        "semanticRetrieverChunk": {
-          "$ref": "SemanticRetrieverChunk",
-          "description": "Identifier for a `Chunk` fetched via Semantic Retriever."
-        },
-        "groundingPassage": {
-          "description": "Identifier for an inline passage.",
-          "$ref": "GroundingPassageId"
-        }
-      },
-      "id": "AttributionSourceId"
-    },
-    "Candidate": {
-      "description": "A response candidate generated from the model.",
-      "id": "Candidate",
-      "properties": {
-        "citationMetadata": {
-          "$ref": "CitationMetadata",
-          "readOnly": true,
-          "description": "Output only. Citation information for model-generated candidate. This field may be populated with recitation information for any text included in the `content`. These are passages that are \"recited\" from copyrighted material in the foundational LLM's training data."
-        },
-        "safetyRatings": {
-          "items": {
-            "$ref": "SafetyRating"
-          },
-          "description": "List of ratings for the safety of a response candidate. There is at most one rating per category.",
-          "type": "array"
-        },
-        "finishReason": {
-          "enum": [
-            "FINISH_REASON_UNSPECIFIED",
-            "STOP",
-            "MAX_TOKENS",
-            "SAFETY",
-            "RECITATION",
-            "OTHER"
-          ],
-          "description": "Optional. Output only. The reason why the model stopped generating tokens. If empty, the model has not stopped generating the tokens.",
-          "type": "string",
-          "enumDescriptions": [
-            "Default value. This value is unused.",
-            "Natural stop point of the model or provided stop sequence.",
-            "The maximum number of tokens as specified in the request was reached.",
-            "The candidate content was flagged for safety reasons.",
-            "The candidate content was flagged for recitation reasons.",
-            "Unknown reason."
-          ],
-          "readOnly": true
-        },
-        "content": {
-          "$ref": "Content",
-          "description": "Output only. Generated content returned from the model.",
-          "readOnly": true
-        },
-        "tokenCount": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Output only. Token count for this candidate.",
-          "readOnly": true
-        },
-        "groundingAttributions": {
-          "items": {
-            "$ref": "GroundingAttribution"
-          },
-          "type": "array",
-          "readOnly": true,
-          "description": "Output only. Attribution information for sources that contributed to a grounded answer. This field is populated for `GenerateAnswer` calls."
-        },
-        "index": {
-          "description": "Output only. Index of the candidate in the list of candidates.",
-          "type": "integer",
-          "format": "int32",
-          "readOnly": true
-        }
-      },
-      "type": "object"
-    },
-    "TuningSnapshot": {
-      "properties": {
-        "meanLoss": {
-          "readOnly": true,
-          "description": "Output only. The mean loss of the training examples for this step.",
-          "format": "float",
-          "type": "number"
-        },
-        "computeTime": {
-          "type": "string",
-          "description": "Output only. The timestamp when this metric was computed.",
-          "format": "google-datetime",
-          "readOnly": true
-        },
-        "step": {
-          "description": "Output only. The tuning step.",
-          "format": "int32",
-          "readOnly": true,
-          "type": "integer"
-        },
-        "epoch": {
-          "type": "integer",
-          "format": "int32",
-          "readOnly": true,
-          "description": "Output only. The epoch this step was part of."
-        }
-      },
-      "type": "object",
-      "id": "TuningSnapshot",
-      "description": "Record for a single tuning step."
-    },
-    "CachedContentUsageMetadata": {
-      "properties": {
-        "totalTokenCount": {
-          "description": "Total number of tokens that the cached content consumes.",
-          "type": "integer",
-          "format": "int32"
-        }
-      },
-      "id": "CachedContentUsageMetadata",
-      "description": "Metadata on the usage of the cached content.",
-      "type": "object"
-    },
-    "DeleteChunkRequest": {
-      "description": "Request to delete a `Chunk`.",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Required. The resource name of the `Chunk` to delete. Example: `corpora/my-corpus-123/documents/the-doc-abc/chunks/some-chunk`"
-        }
-      },
-      "type": "object",
-      "id": "DeleteChunkRequest"
-    },
-    "Condition": {
-      "properties": {
-        "operation": {
-          "enum": [
-            "OPERATOR_UNSPECIFIED",
-            "LESS",
-            "LESS_EQUAL",
-            "EQUAL",
-            "GREATER_EQUAL",
-            "GREATER",
-            "NOT_EQUAL",
-            "INCLUDES",
-            "EXCLUDES"
-          ],
-          "enumDescriptions": [
-            "The default value. This value is unused.",
-            "Supported by numeric.",
-            "Supported by numeric.",
-            "Supported by numeric & string.",
-            "Supported by numeric.",
-            "Supported by numeric.",
-            "Supported by numeric & string.",
-            "Supported by string only when `CustomMetadata` value type for the given key has a `string_list_value`.",
-            "Supported by string only when `CustomMetadata` value type for the given key has a `string_list_value`."
-          ],
-          "description": "Required. Operator applied to the given key-value pair to trigger the condition.",
+        "parent": {
+          "description": "Required. The name of the `Document` where this `Chunk` will be created. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
           "type": "string"
         },
-        "stringValue": {
-          "description": "The string value to filter the metadata on.",
-          "type": "string"
-        },
-        "numericValue": {
-          "description": "The numeric value to filter the metadata on.",
-          "type": "number",
-          "format": "float"
+        "chunk": {
+          "description": "Required. The `Chunk` to create.",
+          "$ref": "Chunk"
         }
       },
-      "id": "Condition",
       "type": "object",
-      "description": "Filter condition applicable to a single key."
+      "description": "Request to create a `Chunk`.",
+      "id": "CreateChunkRequest"
     },
-    "Document": {
-      "description": "A `Document` is a collection of `Chunk`s. A `Corpus` can have a maximum of 10,000 `Document`s.",
-      "properties": {
-        "name": {
-          "description": "Immutable. Identifier. The `Document` resource name. The ID (name excluding the \"corpora/*/documents/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/{corpus_id}/documents/my-awesome-doc-123a456b789c`",
-          "type": "string"
-        },
-        "createTime": {
-          "type": "string",
-          "format": "google-datetime",
-          "readOnly": true,
-          "description": "Output only. The Timestamp of when the `Document` was created."
-        },
-        "displayName": {
-          "type": "string",
-          "description": "Optional. The human-readable display name for the `Document`. The display name must be no more than 512 characters in length, including spaces. Example: \"Semantic Retriever Documentation\""
-        },
-        "updateTime": {
-          "readOnly": true,
-          "type": "string",
-          "format": "google-datetime",
-          "description": "Output only. The Timestamp of when the `Document` was last updated."
-        },
-        "customMetadata": {
-          "items": {
-            "$ref": "CustomMetadata"
-          },
-          "description": "Optional. User provided custom metadata stored as key-value pairs used for querying. A `Document` can have a maximum of 20 `CustomMetadata`.",
-          "type": "array"
-        }
-      },
-      "id": "Document",
-      "type": "object"
-    },
-    "GenerationConfig": {
+    "GenerateTextRequest": {
+      "description": "Request to generate a text completion response from the model.",
       "type": "object",
-      "description": "Configuration options for model generation and outputs. Not all parameters may be configurable for every model.",
-      "id": "GenerationConfig",
       "properties": {
-        "responseMimeType": {
-          "type": "string",
-          "description": "Optional. Output response mimetype of the generated candidate text. Supported mimetype: `text/plain`: (default) Text output. `application/json`: JSON response in the candidates."
-        },
-        "temperature": {
-          "format": "float",
-          "description": "Optional. Controls the randomness of the output. Note: The default value varies by model, see the `Model.temperature` attribute of the `Model` returned from the `getModel` function. Values can range from [0.0, 2.0].",
-          "type": "number"
-        },
-        "candidateCount": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Optional. Number of generated responses to return. Currently, this value can only be set to 1. If unset, this will default to 1."
-        },
-        "responseSchema": {
-          "description": "Optional. Output response schema of the generated candidate text when response mime type can have schema. Schema can be objects, primitives or arrays and is a subset of [OpenAPI schema](https://spec.openapis.org/oas/v3.0.3#schema). If set, a compatible response_mime_type must also be set. Compatible mimetypes: `application/json`: Schema for JSON response.",
-          "$ref": "Schema"
-        },
-        "topK": {
-          "format": "int32",
-          "description": "Optional. The maximum number of tokens to consider when sampling. Models use nucleus sampling or combined Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens. Models running with nucleus sampling don't allow top_k setting. Note: The default value varies by model, see the `Model.top_k` attribute of the `Model` returned from the `getModel` function. Empty `top_k` field in `Model` indicates the model doesn't apply top-k sampling and doesn't allow setting `top_k` on requests.",
-          "type": "integer"
-        },
-        "topP": {
-          "format": "float",
-          "type": "number",
-          "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Tokens are sorted based on their assigned probabilities so that only the most likely tokens are considered. Top-k sampling directly limits the maximum number of tokens to consider, while Nucleus sampling limits number of tokens based on the cumulative probability. Note: The default value varies by model, see the `Model.top_p` attribute of the `Model` returned from the `getModel` function."
-        },
-        "maxOutputTokens": {
-          "type": "integer",
-          "description": "Optional. The maximum number of tokens to include in a candidate. Note: The default value varies by model, see the `Model.output_token_limit` attribute of the `Model` returned from the `getModel` function.",
-          "format": "int32"
-        },
         "stopSequences": {
-          "description": "Optional. The set of character sequences (up to 5) that will stop output generation. If specified, the API will stop at the first appearance of a stop sequence. The stop sequence will not be included as part of the response.",
           "items": {
             "type": "string"
           },
+          "description": "The set of character sequences (up to 5) that will stop output generation. If specified, the API will stop at the first appearance of a stop sequence. The stop sequence will not be included as part of the response.",
           "type": "array"
-        }
-      }
-    },
-    "BatchDeleteChunksRequest": {
-      "id": "BatchDeleteChunksRequest",
-      "description": "Request to batch delete `Chunk`s.",
-      "properties": {
-        "requests": {
-          "description": "Required. The request messages specifying the `Chunk`s to delete.",
-          "items": {
-            "$ref": "DeleteChunkRequest"
-          },
-          "type": "array"
-        }
-      },
-      "type": "object"
-    },
-    "GenerateAnswerRequest": {
-      "properties": {
-        "answerStyle": {
-          "type": "string",
-          "description": "Required. Style in which answers should be returned.",
-          "enum": [
-            "ANSWER_STYLE_UNSPECIFIED",
-            "ABSTRACTIVE",
-            "EXTRACTIVE",
-            "VERBOSE"
-          ],
-          "enumDescriptions": [
-            "Unspecified answer style.",
-            "Succint but abstract style.",
-            "Very brief and extractive style.",
-            "Verbose style including extra details. The response may be formatted as a sentence, paragraph, multiple paragraphs, or bullet points, etc."
-          ]
-        },
-        "inlinePassages": {
-          "description": "Passages provided inline with the request.",
-          "$ref": "GroundingPassages"
-        },
-        "semanticRetriever": {
-          "$ref": "SemanticRetrieverConfig",
-          "description": "Content retrieved from resources created via the Semantic Retriever API."
         },
         "temperature": {
-          "description": "Optional. Controls the randomness of the output. Values can range from [0.0,1.0], inclusive. A value closer to 1.0 will produce responses that are more varied and creative, while a value closer to 0.0 will typically result in more straightforward responses from the model. A low temperature (~0.2) is usually recommended for Attributed-Question-Answering use cases.",
+          "type": "number",
           "format": "float",
-          "type": "number"
+          "description": "Optional. Controls the randomness of the output. Note: The default value varies by model, see the `Model.temperature` attribute of the `Model` returned the `getModel` function. Values can range from [0.0,1.0], inclusive. A value closer to 1.0 will produce responses that are more varied and creative, while a value closer to 0.0 will typically result in more straightforward responses from the model."
         },
-        "contents": {
-          "description": "Required. The content of the current conversation with the model. For single-turn queries, this is a single question to answer. For multi-turn queries, this is a repeated field that contains conversation history and the last `Content` in the list containing the question. Note: GenerateAnswer currently only supports queries in English.",
-          "items": {
-            "$ref": "Content"
-          },
-          "type": "array"
+        "candidateCount": {
+          "format": "int32",
+          "type": "integer",
+          "description": "Optional. Number of generated responses to return. This value must be between [1, 8], inclusive. If unset, this will default to 1."
+        },
+        "maxOutputTokens": {
+          "type": "integer",
+          "description": "Optional. The maximum number of tokens to include in a candidate. If unset, this will default to output_token_limit specified in the `Model` specification.",
+          "format": "int32"
+        },
+        "topK": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. The maximum number of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens. Defaults to 40. Note: The default value varies by model, see the `Model.top_k` attribute of the `Model` returned the `getModel` function."
+        },
+        "prompt": {
+          "description": "Required. The free-form input text given to the model as a prompt. Given a prompt, the model will generate a TextCompletion response it predicts as the completion of the input text.",
+          "$ref": "TextPrompt"
+        },
+        "topP": {
+          "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Tokens are sorted based on their assigned probabilities so that only the most likely tokens are considered. Top-k sampling directly limits the maximum number of tokens to consider, while Nucleus sampling limits number of tokens based on the cumulative probability. Note: The default value varies by model, see the `Model.top_p` attribute of the `Model` returned the `getModel` function.",
+          "type": "number",
+          "format": "float"
         },
         "safetySettings": {
-          "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content. This will be enforced on the `GenerateAnswerRequest.contents` and `GenerateAnswerResponse.candidate`. There should not be more than one setting for each `SafetyCategory` type. The API will block any contents and responses that fail to meet the thresholds set by these settings. This list overrides the default settings for each `SafetyCategory` specified in the safety_settings. If there is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use the default safety setting for that category. Harm categories HARM_CATEGORY_HATE_SPEECH, HARM_CATEGORY_SEXUALLY_EXPLICIT, HARM_CATEGORY_DANGEROUS_CONTENT, HARM_CATEGORY_HARASSMENT are supported.",
+          "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content. that will be enforced on the `GenerateTextRequest.prompt` and `GenerateTextResponse.candidates`. There should not be more than one setting for each `SafetyCategory` type. The API will block any prompts and responses that fail to meet the thresholds set by these settings. This list overrides the default settings for each `SafetyCategory` specified in the safety_settings. If there is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use the default safety setting for that category. Harm categories HARM_CATEGORY_DEROGATORY, HARM_CATEGORY_TOXICITY, HARM_CATEGORY_VIOLENCE, HARM_CATEGORY_SEXUAL, HARM_CATEGORY_MEDICAL, HARM_CATEGORY_DANGEROUS are supported in text service.",
           "items": {
             "$ref": "SafetySetting"
           },
           "type": "array"
         }
       },
-      "description": "Request to generate a grounded answer from the model.",
-      "id": "GenerateAnswerRequest",
-      "type": "object"
+      "id": "GenerateTextRequest"
     },
-    "Chunk": {
-      "description": "A `Chunk` is a subpart of a `Document` that is treated as an independent unit for the purposes of vector representation and storage. A `Corpus` can have a maximum of 1 million `Chunk`s.",
-      "id": "Chunk",
-      "type": "object",
+    "ListPermissionsResponse": {
       "properties": {
-        "customMetadata": {
+        "nextPageToken": {
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages.",
+          "type": "string"
+        },
+        "permissions": {
           "items": {
-            "$ref": "CustomMetadata"
+            "$ref": "Permission"
           },
           "type": "array",
-          "description": "Optional. User provided custom metadata stored as key-value pairs. The maximum number of `CustomMetadata` per chunk is 20."
+          "description": "Returned permissions."
+        }
+      },
+      "type": "object",
+      "description": "Response from `ListPermissions` containing a paginated list of permissions.",
+      "id": "ListPermissionsResponse"
+    },
+    "ListCorporaResponse": {
+      "type": "object",
+      "id": "ListCorporaResponse",
+      "description": "Response from `ListCorpora` containing a paginated list of `Corpora`. The results are sorted by ascending `corpus.create_time`.",
+      "properties": {
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
         },
-        "data": {
-          "$ref": "ChunkData",
-          "description": "Required. The content for the `Chunk`, such as the text string. The maximum number of tokens per chunk is 2043."
+        "corpora": {
+          "items": {
+            "$ref": "Corpus"
+          },
+          "description": "The returned corpora.",
+          "type": "array"
+        }
+      }
+    },
+    "CitationMetadata": {
+      "description": "A collection of source attributions for a piece of content.",
+      "id": "CitationMetadata",
+      "type": "object",
+      "properties": {
+        "citationSources": {
+          "description": "Citations to sources for a specific response.",
+          "items": {
+            "$ref": "CitationSource"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "TuningTask": {
+      "properties": {
+        "startTime": {
+          "format": "google-datetime",
+          "description": "Output only. The timestamp when tuning this model started.",
+          "type": "string",
+          "readOnly": true
         },
-        "updateTime": {
+        "snapshots": {
           "readOnly": true,
+          "type": "array",
+          "items": {
+            "$ref": "TuningSnapshot"
+          },
+          "description": "Output only. Metrics collected during tuning."
+        },
+        "completeTime": {
           "type": "string",
           "format": "google-datetime",
-          "description": "Output only. The Timestamp of when the `Chunk` was last updated."
+          "readOnly": true,
+          "description": "Output only. The timestamp when tuning this model completed."
+        },
+        "hyperparameters": {
+          "description": "Immutable. Hyperparameters controlling the tuning process. If not provided, default values will be used.",
+          "$ref": "Hyperparameters"
+        },
+        "trainingData": {
+          "$ref": "Dataset",
+          "description": "Required. Input only. Immutable. The model training data."
+        }
+      },
+      "type": "object",
+      "id": "TuningTask",
+      "description": "Tuning tasks that create tuned models."
+    },
+    "SafetyFeedback": {
+      "id": "SafetyFeedback",
+      "description": "Safety feedback for an entire request. This field is populated if content in the input and/or response is blocked due to safety settings. SafetyFeedback may not exist for every HarmCategory. Each SafetyFeedback will return the safety settings used by the request as well as the lowest HarmProbability that should be allowed in order to return a result.",
+      "type": "object",
+      "properties": {
+        "setting": {
+          "$ref": "SafetySetting",
+          "description": "Safety settings applied to the request."
+        },
+        "rating": {
+          "$ref": "SafetyRating",
+          "description": "Safety rating evaluated from content."
+        }
+      }
+    },
+    "MessagePrompt": {
+      "description": "All of the structured input text passed to the model as a prompt. A `MessagePrompt` contains a structured set of fields that provide context for the conversation, examples of user input/model output message pairs that prime the model to respond in different ways, and the conversation history or list of messages representing the alternating turns of the conversation between the user and the model.",
+      "properties": {
+        "context": {
+          "description": "Optional. Text that should be provided to the model first to ground the response. If not empty, this `context` will be given to the model first before the `examples` and `messages`. When using a `context` be sure to provide it with every request to maintain continuity. This field can be a description of your prompt to the model to help provide context and guide the responses. Examples: \"Translate the phrase from English to French.\" or \"Given a statement, classify the sentiment as happy, sad or neutral.\" Anything included in this field will take precedence over message history if the total input size exceeds the model's `input_token_limit` and the input request is truncated.",
+          "type": "string"
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "$ref": "Message"
+          },
+          "description": "Required. A snapshot of the recent conversation history sorted chronologically. Turns alternate between two authors. If the total input size exceeds the model's `input_token_limit` the input will be truncated: The oldest items will be dropped from `messages`."
+        },
+        "examples": {
+          "type": "array",
+          "description": "Optional. Examples of what the model should generate. This includes both user input and the response that the model should emulate. These `examples` are treated identically to conversation messages except that they take precedence over the history in `messages`: If the total input size exceeds the model's `input_token_limit` the input will be truncated. Items will be dropped from `messages` before `examples`.",
+          "items": {
+            "$ref": "Example"
+          }
+        }
+      },
+      "type": "object",
+      "id": "MessagePrompt"
+    },
+    "ContentEmbedding": {
+      "properties": {
+        "values": {
+          "items": {
+            "format": "float",
+            "type": "number"
+          },
+          "description": "The embedding values.",
+          "type": "array"
+        }
+      },
+      "description": "A list of floats representing an embedding.",
+      "type": "object",
+      "id": "ContentEmbedding"
+    },
+    "FunctionDeclaration": {
+      "type": "object",
+      "id": "FunctionDeclaration",
+      "description": "Structured representation of a function declaration as defined by the [OpenAPI 3.03 specification](https://spec.openapis.org/oas/v3.0.3). Included in this declaration are the function name and parameters. This FunctionDeclaration is a representation of a block of code that can be used as a `Tool` by the model and executed by the client.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Required. A brief description of the function."
         },
         "name": {
           "type": "string",
-          "description": "Immutable. Identifier. The `Chunk` resource name. The ID (name excluding the \"corpora/*/documents/*/chunks/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a random 12-character unique ID will be generated. Example: `corpora/{corpus_id}/documents/{document_id}/chunks/123a456b789c`"
+          "description": "Required. The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
+        },
+        "parameters": {
+          "$ref": "Schema",
+          "description": "Optional. Describes the parameters to this function. Reflects the Open API 3.03 Parameter Object string Key: the name of the parameter. Parameter names are case sensitive. Schema Value: the Schema defining the type used for the parameter."
+        }
+      }
+    },
+    "Chunk": {
+      "id": "Chunk",
+      "description": "A `Chunk` is a subpart of a `Document` that is treated as an independent unit for the purposes of vector representation and storage. A `Corpus` can have a maximum of 1 million `Chunk`s.",
+      "properties": {
+        "updateTime": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Output only. The Timestamp of when the `Chunk` was last updated.",
+          "format": "google-datetime"
         },
         "state": {
-          "type": "string",
+          "enum": [
+            "STATE_UNSPECIFIED",
+            "STATE_PENDING_PROCESSING",
+            "STATE_ACTIVE",
+            "STATE_FAILED"
+          ],
           "description": "Output only. Current state of the `Chunk`.",
           "enumDescriptions": [
             "The default value. This value is used if the state is omitted.",
@@ -3651,632 +2475,1808 @@
             "`Chunk` is processed and available for querying.",
             "`Chunk` failed processing."
           ],
-          "enum": [
-            "STATE_UNSPECIFIED",
-            "STATE_PENDING_PROCESSING",
-            "STATE_ACTIVE",
-            "STATE_FAILED"
-          ],
+          "type": "string",
           "readOnly": true
         },
-        "createTime": {
-          "format": "google-datetime",
-          "readOnly": true,
-          "description": "Output only. The Timestamp of when the `Chunk` was created.",
-          "type": "string"
-        }
-      }
-    },
-    "TuningTask": {
-      "type": "object",
-      "description": "Tuning tasks that create tuned models.",
-      "id": "TuningTask",
-      "properties": {
-        "snapshots": {
-          "description": "Output only. Metrics collected during tuning.",
+        "customMetadata": {
+          "type": "array",
           "items": {
-            "$ref": "TuningSnapshot"
+            "$ref": "CustomMetadata"
           },
-          "readOnly": true,
-          "type": "array"
-        },
-        "trainingData": {
-          "description": "Required. Input only. Immutable. The model training data.",
-          "$ref": "Dataset"
-        },
-        "hyperparameters": {
-          "$ref": "Hyperparameters",
-          "description": "Immutable. Hyperparameters controlling the tuning process. If not provided, default values will be used."
-        },
-        "completeTime": {
-          "readOnly": true,
-          "type": "string",
-          "description": "Output only. The timestamp when tuning this model completed.",
-          "format": "google-datetime"
-        },
-        "startTime": {
-          "description": "Output only. The timestamp when tuning this model started.",
-          "readOnly": true,
-          "format": "google-datetime",
-          "type": "string"
-        }
-      }
-    },
-    "CountTokensResponse": {
-      "type": "object",
-      "id": "CountTokensResponse",
-      "description": "A response from `CountTokens`. It returns the model's `token_count` for the `prompt`.",
-      "properties": {
-        "totalTokens": {
-          "format": "int32",
-          "description": "The number of tokens that the `model` tokenizes the `prompt` into. Always non-negative. When cached_content is set, this is still the total effective prompt size. I.e. this includes the number of tokens in the cached content.",
-          "type": "integer"
-        }
-      }
-    },
-    "CitationMetadata": {
-      "properties": {
-        "citationSources": {
-          "type": "array",
-          "description": "Citations to sources for a specific response.",
-          "items": {
-            "$ref": "CitationSource"
-          }
-        }
-      },
-      "description": "A collection of source attributions for a piece of content.",
-      "type": "object",
-      "id": "CitationMetadata"
-    },
-    "GenerateContentRequest": {
-      "type": "object",
-      "description": "Request to generate a completion from the model.",
-      "id": "GenerateContentRequest",
-      "properties": {
-        "systemInstruction": {
-          "$ref": "Content",
-          "description": "Optional. Developer set system instruction. Currently, text only."
-        },
-        "contents": {
-          "items": {
-            "$ref": "Content"
-          },
-          "description": "Required. The content of the current conversation with the model. For single-turn queries, this is a single instance. For multi-turn queries, this is a repeated field that contains conversation history + latest request.",
-          "type": "array"
-        },
-        "safetySettings": {
-          "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content. This will be enforced on the `GenerateContentRequest.contents` and `GenerateContentResponse.candidates`. There should not be more than one setting for each `SafetyCategory` type. The API will block any contents and responses that fail to meet the thresholds set by these settings. This list overrides the default settings for each `SafetyCategory` specified in the safety_settings. If there is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use the default safety setting for that category. Harm categories HARM_CATEGORY_HATE_SPEECH, HARM_CATEGORY_SEXUALLY_EXPLICIT, HARM_CATEGORY_DANGEROUS_CONTENT, HARM_CATEGORY_HARASSMENT are supported.",
-          "type": "array",
-          "items": {
-            "$ref": "SafetySetting"
-          }
-        },
-        "toolConfig": {
-          "$ref": "ToolConfig",
-          "description": "Optional. Tool configuration for any `Tool` specified in the request."
-        },
-        "model": {
-          "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`.",
-          "type": "string"
-        },
-        "cachedContent": {
-          "description": "Optional. The name of the cached content used as context to serve the prediction. Note: only used in explicit caching, where users can have control over caching (e.g. what content to cache) and enjoy guaranteed cost savings. Format: `cachedContents/{cachedContent}`",
-          "type": "string"
-        },
-        "generationConfig": {
-          "description": "Optional. Configuration options for model generation and outputs.",
-          "$ref": "GenerationConfig"
-        },
-        "tools": {
-          "description": "Optional. A list of `Tools` the model may use to generate the next response. A `Tool` is a piece of code that enables the system to interact with external systems to perform an action, or set of actions, outside of knowledge and scope of the model. The only supported tool is currently `Function`.",
-          "items": {
-            "$ref": "Tool"
-          },
-          "type": "array"
-        }
-      }
-    },
-    "ContentFilter": {
-      "id": "ContentFilter",
-      "description": "Content filtering metadata associated with processing a single request. ContentFilter contains a reason and an optional supporting string. The reason may be unspecified.",
-      "properties": {
-        "message": {
-          "description": "A string that describes the filtering behavior in more detail.",
-          "type": "string"
-        },
-        "reason": {
-          "description": "The reason content was blocked during request processing.",
-          "enumDescriptions": [
-            "A blocked reason was not specified.",
-            "Content was blocked by safety settings.",
-            "Content was blocked, but the reason is uncategorized."
-          ],
-          "enum": [
-            "BLOCKED_REASON_UNSPECIFIED",
-            "SAFETY",
-            "OTHER"
-          ],
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "EmbedTextResponse": {
-      "id": "EmbedTextResponse",
-      "properties": {
-        "embedding": {
-          "$ref": "Embedding",
-          "readOnly": true,
-          "description": "Output only. The embedding generated from the input text."
-        }
-      },
-      "type": "object",
-      "description": "The response to a EmbedTextRequest."
-    },
-    "EmbedContentRequest": {
-      "id": "EmbedContentRequest",
-      "type": "object",
-      "properties": {
-        "content": {
-          "$ref": "Content",
-          "description": "Required. The content to embed. Only the `parts.text` fields will be counted."
-        },
-        "outputDimensionality": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Optional. Optional reduced dimension for the output embedding. If set, excessive values in the output embedding are truncated from the end. Supported by newer models since 2024, and the earlier model (`models/embedding-001`) cannot specify this value."
-        },
-        "taskType": {
-          "enumDescriptions": [
-            "Unset value, which will default to one of the other enum values.",
-            "Specifies the given text is a query in a search/retrieval setting.",
-            "Specifies the given text is a document from the corpus being searched.",
-            "Specifies the given text will be used for STS.",
-            "Specifies that the given text will be classified.",
-            "Specifies that the embeddings will be used for clustering.",
-            "Specifies that the given text will be used for question answering.",
-            "Specifies that the given text will be used for fact verification."
-          ],
-          "description": "Optional. Optional task type for which the embeddings will be used. Can only be set for `models/embedding-001`.",
-          "enum": [
-            "TASK_TYPE_UNSPECIFIED",
-            "RETRIEVAL_QUERY",
-            "RETRIEVAL_DOCUMENT",
-            "SEMANTIC_SIMILARITY",
-            "CLASSIFICATION",
-            "CLUSTERING",
-            "QUESTION_ANSWERING",
-            "FACT_VERIFICATION"
-          ],
-          "type": "string"
-        },
-        "title": {
-          "description": "Optional. An optional title for the text. Only applicable when TaskType is `RETRIEVAL_DOCUMENT`. Note: Specifying a `title` for `RETRIEVAL_DOCUMENT` provides better quality embeddings for retrieval.",
-          "type": "string"
-        },
-        "model": {
-          "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
-          "type": "string"
-        }
-      },
-      "description": "Request containing the `Content` for the model to embed."
-    },
-    "GenerateTextResponse": {
-      "description": "The response from the model, including candidate completions.",
-      "type": "object",
-      "id": "GenerateTextResponse",
-      "properties": {
-        "safetyFeedback": {
-          "description": "Returns any safety feedback related to content filtering.",
-          "type": "array",
-          "items": {
-            "$ref": "SafetyFeedback"
-          }
-        },
-        "filters": {
-          "description": "A set of content filtering metadata for the prompt and response text. This indicates which `SafetyCategory`(s) blocked a candidate from this response, the lowest `HarmProbability` that triggered a block, and the HarmThreshold setting for that category. This indicates the smallest change to the `SafetySettings` that would be necessary to unblock at least 1 response. The blocking is configured by the `SafetySettings` in the request (or the default `SafetySettings` of the API).",
-          "type": "array",
-          "items": {
-            "$ref": "ContentFilter"
-          }
-        },
-        "candidates": {
-          "items": {
-            "$ref": "TextCompletion"
-          },
-          "type": "array",
-          "description": "Candidate responses from the model."
-        }
-      }
-    },
-    "Schema": {
-      "description": "The `Schema` object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. Represents a select subset of an [OpenAPI 3.0 schema object](https://spec.openapis.org/oas/v3.0.3#schema).",
-      "type": "object",
-      "id": "Schema",
-      "properties": {
-        "items": {
-          "description": "Optional. Schema of the elements of Type.ARRAY.",
-          "$ref": "Schema"
-        },
-        "enum": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "Optional. Possible values of the element of Type.STRING with enum format. For example we can define an Enum Direction as : {type:STRING, format:enum, enum:[\"EAST\", NORTH\", \"SOUTH\", \"WEST\"]}"
-        },
-        "required": {
-          "type": "array",
-          "description": "Optional. Required properties of Type.OBJECT.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "nullable": {
-          "type": "boolean",
-          "description": "Optional. Indicates if the value may be null."
-        },
-        "description": {
-          "description": "Optional. A brief description of the parameter. This could contain examples of use. Parameter description may be formatted as Markdown.",
-          "type": "string"
-        },
-        "properties": {
-          "additionalProperties": {
-            "$ref": "Schema"
-          },
-          "type": "object",
-          "description": "Optional. Properties of Type.OBJECT."
-        },
-        "format": {
-          "description": "Optional. The format of the data. This is used only for primitive datatypes. Supported formats: for NUMBER type: float, double for INTEGER type: int32, int64",
-          "type": "string"
-        },
-        "type": {
-          "enum": [
-            "TYPE_UNSPECIFIED",
-            "STRING",
-            "NUMBER",
-            "INTEGER",
-            "BOOLEAN",
-            "ARRAY",
-            "OBJECT"
-          ],
-          "type": "string",
-          "enumDescriptions": [
-            "Not specified, should not be used.",
-            "String type.",
-            "Number type.",
-            "Integer type.",
-            "Boolean type.",
-            "Array type.",
-            "Object type."
-          ],
-          "description": "Required. Data type."
-        }
-      }
-    },
-    "MessagePrompt": {
-      "id": "MessagePrompt",
-      "description": "All of the structured input text passed to the model as a prompt. A `MessagePrompt` contains a structured set of fields that provide context for the conversation, examples of user input/model output message pairs that prime the model to respond in different ways, and the conversation history or list of messages representing the alternating turns of the conversation between the user and the model.",
-      "properties": {
-        "examples": {
-          "type": "array",
-          "description": "Optional. Examples of what the model should generate. This includes both user input and the response that the model should emulate. These `examples` are treated identically to conversation messages except that they take precedence over the history in `messages`: If the total input size exceeds the model's `input_token_limit` the input will be truncated. Items will be dropped from `messages` before `examples`.",
-          "items": {
-            "$ref": "Example"
-          }
-        },
-        "messages": {
-          "description": "Required. A snapshot of the recent conversation history sorted chronologically. Turns alternate between two authors. If the total input size exceeds the model's `input_token_limit` the input will be truncated: The oldest items will be dropped from `messages`.",
-          "type": "array",
-          "items": {
-            "$ref": "Message"
-          }
-        },
-        "context": {
-          "type": "string",
-          "description": "Optional. Text that should be provided to the model first to ground the response. If not empty, this `context` will be given to the model first before the `examples` and `messages`. When using a `context` be sure to provide it with every request to maintain continuity. This field can be a description of your prompt to the model to help provide context and guide the responses. Examples: \"Translate the phrase from English to French.\" or \"Given a statement, classify the sentiment as happy, sad or neutral.\" Anything included in this field will take precedence over message history if the total input size exceeds the model's `input_token_limit` and the input request is truncated."
-        }
-      },
-      "type": "object"
-    },
-    "Dataset": {
-      "properties": {
-        "examples": {
-          "description": "Optional. Inline examples.",
-          "$ref": "TuningExamples"
-        }
-      },
-      "type": "object",
-      "description": "Dataset for training or validation.",
-      "id": "Dataset"
-    },
-    "CachedContent": {
-      "id": "CachedContent",
-      "type": "object",
-      "properties": {
-        "updateTime": {
-          "format": "google-datetime",
-          "type": "string",
-          "description": "Output only. When the cache entry was last updated in UTC time.",
-          "readOnly": true
+          "description": "Optional. User provided custom metadata stored as key-value pairs. The maximum number of `CustomMetadata` per chunk is 20."
         },
         "name": {
-          "description": "Optional. Identifier. The resource name referring to the cached content. Format: `cachedContents/{id}`",
+          "description": "Immutable. Identifier. The `Chunk` resource name. The ID (name excluding the \"corpora/*/documents/*/chunks/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a random 12-character unique ID will be generated. Example: `corpora/{corpus_id}/documents/{document_id}/chunks/123a456b789c`",
           "type": "string"
-        },
-        "ttl": {
-          "format": "google-duration",
-          "description": "Input only. New TTL for this resource, input only.",
-          "type": "string"
-        },
-        "displayName": {
-          "description": "Optional. Immutable. The user-generated meaningful display name of the cached content. Maximum 128 Unicode characters.",
-          "type": "string"
-        },
-        "expireTime": {
-          "format": "google-datetime",
-          "type": "string",
-          "description": "Timestamp in UTC of when this resource is considered expired. This is *always* provided on output, regardless of what was sent on input."
-        },
-        "model": {
-          "type": "string",
-          "description": "Required. Immutable. The name of the `Model` to use for cached content Format: `models/{model}`"
-        },
-        "toolConfig": {
-          "$ref": "ToolConfig",
-          "description": "Optional. Input only. Immutable. Tool config. This config is shared for all tools."
-        },
-        "tools": {
-          "type": "array",
-          "items": {
-            "$ref": "Tool"
-          },
-          "description": "Optional. Input only. Immutable. A list of `Tools` the model may use to generate the next response"
-        },
-        "createTime": {
-          "description": "Output only. Creation time of the cache entry.",
-          "readOnly": true,
-          "format": "google-datetime",
-          "type": "string"
-        },
-        "systemInstruction": {
-          "$ref": "Content",
-          "description": "Optional. Input only. Immutable. Developer set system instruction. Currently text only."
-        },
-        "usageMetadata": {
-          "$ref": "CachedContentUsageMetadata",
-          "readOnly": true,
-          "description": "Output only. Metadata on the usage of the cached content."
-        },
-        "contents": {
-          "items": {
-            "$ref": "Content"
-          },
-          "description": "Optional. Input only. Immutable. The content to cache.",
-          "type": "array"
-        }
-      },
-      "description": "Content that has been preprocessed and can be used in subsequent request to GenerativeService. Cached content can be only used with model it was created for."
-    },
-    "TextCompletion": {
-      "type": "object",
-      "id": "TextCompletion",
-      "description": "Output text returned from a model.",
-      "properties": {
-        "citationMetadata": {
-          "description": "Output only. Citation information for model-generated `output` in this `TextCompletion`. This field may be populated with attribution information for any text included in the `output`.",
-          "$ref": "CitationMetadata",
-          "readOnly": true
-        },
-        "output": {
-          "description": "Output only. The generated text returned from the model.",
-          "readOnly": true,
-          "type": "string"
-        },
-        "safetyRatings": {
-          "type": "array",
-          "description": "Ratings for the safety of a response. There is at most one rating per category.",
-          "items": {
-            "$ref": "SafetyRating"
-          }
-        }
-      }
-    },
-    "QueryDocumentRequest": {
-      "description": "Request for querying a `Document`.",
-      "id": "QueryDocumentRequest",
-      "type": "object",
-      "properties": {
-        "query": {
-          "type": "string",
-          "description": "Required. Query string to perform semantic search."
-        },
-        "metadataFilters": {
-          "items": {
-            "$ref": "MetadataFilter"
-          },
-          "type": "array",
-          "description": "Optional. Filter for `Chunk` metadata. Each `MetadataFilter` object should correspond to a unique key. Multiple `MetadataFilter` objects are joined by logical \"AND\"s. Note: `Document`-level filtering is not supported for this request because a `Document` name is already specified. Example query: (year \u003e= 2020 OR year \u003c 2010) AND (genre = drama OR genre = action) `MetadataFilter` object list: metadata_filters = [ {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2020, operation = GREATER_EQUAL}, {int_value = 2010, operation = LESS}}, {key = \"chunk.custom_metadata.genre\" conditions = [{string_value = \"drama\", operation = EQUAL}, {string_value = \"action\", operation = EQUAL}}] Example query for a numeric range of values: (year \u003e 2015 AND year \u003c= 2020) `MetadataFilter` object list: metadata_filters = [ {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2015, operation = GREATER}]}, {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2020, operation = LESS_EQUAL}]}] Note: \"AND\"s for the same key are only supported for numeric values. String values only support \"OR\"s for the same key."
-        },
-        "resultsCount": {
-          "description": "Optional. The maximum number of `Chunk`s to return. The service may return fewer `Chunk`s. If unspecified, at most 10 `Chunk`s will be returned. The maximum specified result count is 100.",
-          "format": "int32",
-          "type": "integer"
-        }
-      }
-    },
-    "TuningExamples": {
-      "id": "TuningExamples",
-      "type": "object",
-      "description": "A set of tuning examples. Can be training or validation data.",
-      "properties": {
-        "examples": {
-          "items": {
-            "$ref": "TuningExample"
-          },
-          "description": "Required. The examples. Example input can be for text or discuss, but all examples in a set must be of the same type.",
-          "type": "array"
-        }
-      }
-    },
-    "StringList": {
-      "type": "object",
-      "properties": {
-        "values": {
-          "description": "The string values of the metadata to store.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        }
-      },
-      "id": "StringList",
-      "description": "User provided string values assigned to a single metadata key."
-    },
-    "CountTextTokensResponse": {
-      "description": "A response from `CountTextTokens`. It returns the model's `token_count` for the `prompt`.",
-      "type": "object",
-      "id": "CountTextTokensResponse",
-      "properties": {
-        "tokenCount": {
-          "type": "integer",
-          "format": "int32",
-          "description": "The number of tokens that the `model` tokenizes the `prompt` into. Always non-negative."
-        }
-      }
-    },
-    "SemanticRetrieverConfig": {
-      "type": "object",
-      "properties": {
-        "query": {
-          "$ref": "Content",
-          "description": "Required. Query to use for similarity matching `Chunk`s in the given resource."
-        },
-        "metadataFilters": {
-          "items": {
-            "$ref": "MetadataFilter"
-          },
-          "description": "Optional. Filters for selecting `Document`s and/or `Chunk`s from the resource.",
-          "type": "array"
-        },
-        "minimumRelevanceScore": {
-          "type": "number",
-          "format": "float",
-          "description": "Optional. Minimum relevance score for retrieved relevant `Chunk`s."
-        },
-        "source": {
-          "type": "string",
-          "description": "Required. Name of the resource for retrieval, e.g. corpora/123 or corpora/123/documents/abc."
-        },
-        "maxChunksCount": {
-          "format": "int32",
-          "description": "Optional. Maximum number of relevant `Chunk`s to retrieve.",
-          "type": "integer"
-        }
-      },
-      "id": "SemanticRetrieverConfig",
-      "description": "Configuration for retrieving grounding content from a `Corpus` or `Document` created using the Semantic Retriever API."
-    },
-    "Blob": {
-      "properties": {
-        "mimeType": {
-          "type": "string",
-          "description": "The IANA standard MIME type of the source data. Examples: - image/png - image/jpeg If an unsupported MIME type is provided, an error will be returned. For a complete list of supported types, see [Supported file formats](https://ai.google.dev/gemini-api/docs/prompting_with_media#supported_file_formats)."
         },
         "data": {
-          "description": "Raw bytes for media formats.",
+          "$ref": "ChunkData",
+          "description": "Required. The content for the `Chunk`, such as the text string. The maximum number of tokens per chunk is 2043."
+        },
+        "createTime": {
+          "readOnly": true,
           "type": "string",
-          "format": "byte"
+          "description": "Output only. The Timestamp of when the `Chunk` was created.",
+          "format": "google-datetime"
         }
       },
-      "description": "Raw media bytes. Text should not be sent as raw bytes, use the 'text' field.",
-      "id": "Blob",
       "type": "object"
     },
-    "TextPrompt": {
-      "type": "object",
-      "description": "Text given to the model as a prompt. The Model will use this TextPrompt to Generate a text completion.",
-      "id": "TextPrompt",
+    "GenerationConfig": {
+      "description": "Configuration options for model generation and outputs. Not all parameters may be configurable for every model.",
       "properties": {
-        "text": {
-          "type": "string",
-          "description": "Required. The prompt text."
-        }
-      }
-    },
-    "GenerateTextRequest": {
-      "description": "Request to generate a text completion response from the model.",
-      "properties": {
-        "topK": {
-          "format": "int32",
-          "description": "Optional. The maximum number of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens. Defaults to 40. Note: The default value varies by model, see the `Model.top_k` attribute of the `Model` returned the `getModel` function.",
-          "type": "integer"
-        },
-        "prompt": {
-          "$ref": "TextPrompt",
-          "description": "Required. The free-form input text given to the model as a prompt. Given a prompt, the model will generate a TextCompletion response it predicts as the completion of the input text."
-        },
-        "maxOutputTokens": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Optional. The maximum number of tokens to include in a candidate. If unset, this will default to output_token_limit specified in the `Model` specification."
-        },
-        "safetySettings": {
-          "items": {
-            "$ref": "SafetySetting"
-          },
-          "type": "array",
-          "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content. that will be enforced on the `GenerateTextRequest.prompt` and `GenerateTextResponse.candidates`. There should not be more than one setting for each `SafetyCategory` type. The API will block any prompts and responses that fail to meet the thresholds set by these settings. This list overrides the default settings for each `SafetyCategory` specified in the safety_settings. If there is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use the default safety setting for that category. Harm categories HARM_CATEGORY_DEROGATORY, HARM_CATEGORY_TOXICITY, HARM_CATEGORY_VIOLENCE, HARM_CATEGORY_SEXUAL, HARM_CATEGORY_MEDICAL, HARM_CATEGORY_DANGEROUS are supported in text service."
+        "temperature": {
+          "format": "float",
+          "description": "Optional. Controls the randomness of the output. Note: The default value varies by model, see the `Model.temperature` attribute of the `Model` returned from the `getModel` function. Values can range from [0.0, 2.0].",
+          "type": "number"
         },
         "candidateCount": {
           "format": "int32",
           "type": "integer",
-          "description": "Optional. Number of generated responses to return. This value must be between [1, 8], inclusive. If unset, this will default to 1."
+          "description": "Optional. Number of generated responses to return. Currently, this value can only be set to 1. If unset, this will default to 1."
         },
-        "temperature": {
-          "type": "number",
-          "description": "Optional. Controls the randomness of the output. Note: The default value varies by model, see the `Model.temperature` attribute of the `Model` returned the `getModel` function. Values can range from [0.0,1.0], inclusive. A value closer to 1.0 will produce responses that are more varied and creative, while a value closer to 0.0 will typically result in more straightforward responses from the model.",
-          "format": "float"
+        "responseMimeType": {
+          "description": "Optional. Output response mimetype of the generated candidate text. Supported mimetype: `text/plain`: (default) Text output. `application/json`: JSON response in the candidates.",
+          "type": "string"
+        },
+        "topK": {
+          "description": "Optional. The maximum number of tokens to consider when sampling. Models use nucleus sampling or combined Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens. Models running with nucleus sampling don't allow top_k setting. Note: The default value varies by model, see the `Model.top_k` attribute of the `Model` returned from the `getModel` function. Empty `top_k` field in `Model` indicates the model doesn't apply top-k sampling and doesn't allow setting `top_k` on requests.",
+          "format": "int32",
+          "type": "integer"
         },
         "stopSequences": {
-          "description": "The set of character sequences (up to 5) that will stop output generation. If specified, the API will stop at the first appearance of a stop sequence. The stop sequence will not be included as part of the response.",
-          "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "type": "array",
+          "description": "Optional. The set of character sequences (up to 5) that will stop output generation. If specified, the API will stop at the first appearance of a stop sequence. The stop sequence will not be included as part of the response."
         },
         "topP": {
-          "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Tokens are sorted based on their assigned probabilities so that only the most likely tokens are considered. Top-k sampling directly limits the maximum number of tokens to consider, while Nucleus sampling limits number of tokens based on the cumulative probability. Note: The default value varies by model, see the `Model.top_p` attribute of the `Model` returned the `getModel` function.",
+          "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Tokens are sorted based on their assigned probabilities so that only the most likely tokens are considered. Top-k sampling directly limits the maximum number of tokens to consider, while Nucleus sampling limits number of tokens based on the cumulative probability. Note: The default value varies by model, see the `Model.top_p` attribute of the `Model` returned from the `getModel` function.",
           "format": "float",
           "type": "number"
+        },
+        "maxOutputTokens": {
+          "description": "Optional. The maximum number of tokens to include in a candidate. Note: The default value varies by model, see the `Model.output_token_limit` attribute of the `Model` returned from the `getModel` function.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "responseSchema": {
+          "description": "Optional. Output response schema of the generated candidate text when response mime type can have schema. Schema can be objects, primitives or arrays and is a subset of [OpenAPI schema](https://spec.openapis.org/oas/v3.0.3#schema). If set, a compatible response_mime_type must also be set. Compatible mimetypes: `application/json`: Schema for JSON response.",
+          "$ref": "Schema"
         }
       },
-      "id": "GenerateTextRequest",
+      "id": "GenerationConfig",
       "type": "object"
     },
-    "FileData": {
+    "BatchEmbedContentsRequest": {
+      "description": "Batch request to get embeddings from the model for a list of prompts.",
+      "type": "object",
       "properties": {
-        "fileUri": {
-          "type": "string",
-          "description": "Required. URI."
-        },
-        "mimeType": {
-          "description": "Optional. The IANA standard MIME type of the source data.",
-          "type": "string"
+        "requests": {
+          "type": "array",
+          "description": "Required. Embed requests for the batch. The model in each of these requests must match the model specified `BatchEmbedContentsRequest.model`.",
+          "items": {
+            "$ref": "EmbedContentRequest"
+          }
         }
       },
-      "description": "URI based data.",
+      "id": "BatchEmbedContentsRequest"
+    },
+    "Part": {
+      "id": "Part",
       "type": "object",
-      "id": "FileData"
+      "properties": {
+        "inlineData": {
+          "$ref": "Blob",
+          "description": "Inline media bytes."
+        },
+        "functionCall": {
+          "description": "A predicted `FunctionCall` returned from the model that contains a string representing the `FunctionDeclaration.name` with the arguments and their values.",
+          "$ref": "FunctionCall"
+        },
+        "text": {
+          "type": "string",
+          "description": "Inline text."
+        },
+        "functionResponse": {
+          "$ref": "FunctionResponse",
+          "description": "The result output of a `FunctionCall` that contains a string representing the `FunctionDeclaration.name` and a structured JSON object containing any output from the function is used as context to the model."
+        },
+        "fileData": {
+          "$ref": "FileData",
+          "description": "URI based data."
+        }
+      },
+      "description": "A datatype containing media that is part of a multi-part `Content` message. A `Part` consists of data which has an associated datatype. A `Part` can only contain one of the accepted types in `Part.data`. A `Part` must have a fixed IANA MIME type identifying the type and subtype of the media if the `inline_data` field is filled with raw bytes."
+    }
+  },
+  "version_module": true,
+  "basePath": "",
+  "fullyEncodeReservedExpansion": true,
+  "icons": {
+    "x32": "http://www.google.com/images/icons/product/search-32.gif",
+    "x16": "http://www.google.com/images/icons/product/search-16.gif"
+  },
+  "version": "v1beta",
+  "protocol": "rest",
+  "resources": {
+    "files": {
+      "methods": {
+        "delete": {
+          "path": "v1beta/{+name}",
+          "id": "generativelanguage.files.delete",
+          "parameters": {
+            "name": {
+              "type": "string",
+              "required": true,
+              "description": "Required. The name of the `File` to delete. Example: `files/abc-123`",
+              "location": "path",
+              "pattern": "^files/[^/]+$"
+            }
+          },
+          "response": {
+            "$ref": "Empty"
+          },
+          "description": "Deletes the `File`.",
+          "parameterOrder": [
+            "name"
+          ],
+          "flatPath": "v1beta/files/{filesId}",
+          "httpMethod": "DELETE"
+        },
+        "get": {
+          "parameterOrder": [
+            "name"
+          ],
+          "description": "Gets the metadata for the given `File`.",
+          "parameters": {
+            "name": {
+              "location": "path",
+              "type": "string",
+              "description": "Required. The name of the `File` to get. Example: `files/abc-123`",
+              "required": true,
+              "pattern": "^files/[^/]+$"
+            }
+          },
+          "flatPath": "v1beta/files/{filesId}",
+          "response": {
+            "$ref": "File"
+          },
+          "path": "v1beta/{+name}",
+          "id": "generativelanguage.files.get",
+          "httpMethod": "GET"
+        },
+        "list": {
+          "httpMethod": "GET",
+          "path": "v1beta/files",
+          "id": "generativelanguage.files.list",
+          "parameterOrder": [],
+          "description": "Lists the metadata for `File`s owned by the requesting project.",
+          "response": {
+            "$ref": "ListFilesResponse"
+          },
+          "parameters": {
+            "pageToken": {
+              "type": "string",
+              "description": "Optional. A page token from a previous `ListFiles` call.",
+              "location": "query"
+            },
+            "pageSize": {
+              "location": "query",
+              "type": "integer",
+              "description": "Optional. Maximum number of `File`s to return per page. If unspecified, defaults to 10. Maximum `page_size` is 100.",
+              "format": "int32"
+            }
+          },
+          "flatPath": "v1beta/files"
+        }
+      }
+    },
+    "tunedModels": {
+      "resources": {
+        "permissions": {
+          "methods": {
+            "patch": {
+              "description": "Updates the permission.",
+              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions/{permissionsId}",
+              "parameterOrder": [
+                "name"
+              ],
+              "id": "generativelanguage.tunedModels.permissions.patch",
+              "httpMethod": "PATCH",
+              "response": {
+                "$ref": "Permission"
+              },
+              "request": {
+                "$ref": "Permission"
+              },
+              "path": "v1beta/{+name}",
+              "parameters": {
+                "updateMask": {
+                  "type": "string",
+                  "location": "query",
+                  "format": "google-fieldmask",
+                  "description": "Required. The list of fields to update. Accepted ones: - role (`Permission.role` field)"
+                },
+                "name": {
+                  "type": "string",
+                  "required": true,
+                  "pattern": "^tunedModels/[^/]+/permissions/[^/]+$",
+                  "location": "path",
+                  "description": "Output only. Identifier. The permission name. A unique name will be generated on create. Examples: tunedModels/{tuned_model}/permissions/{permission} corpora/{corpus}/permissions/{permission} Output only."
+                }
+              }
+            },
+            "get": {
+              "parameters": {
+                "name": {
+                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
+                  "pattern": "^tunedModels/[^/]+/permissions/[^/]+$",
+                  "type": "string",
+                  "required": true,
+                  "location": "path"
+                }
+              },
+              "httpMethod": "GET",
+              "parameterOrder": [
+                "name"
+              ],
+              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions/{permissionsId}",
+              "id": "generativelanguage.tunedModels.permissions.get",
+              "description": "Gets information about a specific Permission.",
+              "path": "v1beta/{+name}",
+              "response": {
+                "$ref": "Permission"
+              }
+            },
+            "create": {
+              "description": "Create a permission to a specific resource.",
+              "parameterOrder": [
+                "parent"
+              ],
+              "path": "v1beta/{+parent}/permissions",
+              "id": "generativelanguage.tunedModels.permissions.create",
+              "request": {
+                "$ref": "Permission"
+              },
+              "httpMethod": "POST",
+              "response": {
+                "$ref": "Permission"
+              },
+              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions",
+              "parameters": {
+                "parent": {
+                  "type": "string",
+                  "location": "path",
+                  "required": true,
+                  "pattern": "^tunedModels/[^/]+$",
+                  "description": "Required. The parent resource of the `Permission`. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`"
+                }
+              }
+            },
+            "delete": {
+              "parameterOrder": [
+                "name"
+              ],
+              "parameters": {
+                "name": {
+                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
+                  "pattern": "^tunedModels/[^/]+/permissions/[^/]+$",
+                  "location": "path",
+                  "type": "string",
+                  "required": true
+                }
+              },
+              "description": "Deletes the permission.",
+              "httpMethod": "DELETE",
+              "path": "v1beta/{+name}",
+              "id": "generativelanguage.tunedModels.permissions.delete",
+              "response": {
+                "$ref": "Empty"
+              },
+              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions/{permissionsId}"
+            },
+            "list": {
+              "parameterOrder": [
+                "parent"
+              ],
+              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions",
+              "description": "Lists permissions for the specific resource.",
+              "path": "v1beta/{+parent}/permissions",
+              "response": {
+                "$ref": "ListPermissionsResponse"
+              },
+              "httpMethod": "GET",
+              "parameters": {
+                "pageToken": {
+                  "location": "query",
+                  "type": "string",
+                  "description": "Optional. A page token, received from a previous `ListPermissions` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListPermissions` must match the call that provided the page token."
+                },
+                "pageSize": {
+                  "format": "int32",
+                  "description": "Optional. The maximum number of `Permission`s to return (per page). The service may return fewer permissions. If unspecified, at most 10 permissions will be returned. This method returns at most 1000 permissions per page, even if you pass larger page_size.",
+                  "type": "integer",
+                  "location": "query"
+                },
+                "parent": {
+                  "pattern": "^tunedModels/[^/]+$",
+                  "description": "Required. The parent resource of the permissions. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`",
+                  "type": "string",
+                  "location": "path",
+                  "required": true
+                }
+              },
+              "id": "generativelanguage.tunedModels.permissions.list"
+            }
+          }
+        }
+      },
+      "methods": {
+        "generateText": {
+          "description": "Generates a response from the model given an input message.",
+          "id": "generativelanguage.tunedModels.generateText",
+          "request": {
+            "$ref": "GenerateTextRequest"
+          },
+          "httpMethod": "POST",
+          "flatPath": "v1beta/tunedModels/{tunedModelsId}:generateText",
+          "parameters": {
+            "model": {
+              "pattern": "^tunedModels/[^/]+$",
+              "type": "string",
+              "required": true,
+              "description": "Required. The name of the `Model` or `TunedModel` to use for generating the completion. Examples: models/text-bison-001 tunedModels/sentence-translator-u3b7m",
+              "location": "path"
+            }
+          },
+          "path": "v1beta/{+model}:generateText",
+          "parameterOrder": [
+            "model"
+          ],
+          "response": {
+            "$ref": "GenerateTextResponse"
+          }
+        },
+        "transferOwnership": {
+          "id": "generativelanguage.tunedModels.transferOwnership",
+          "httpMethod": "POST",
+          "description": "Transfers ownership of the tuned model. This is the only way to change ownership of the tuned model. The current owner will be downgraded to writer role.",
+          "response": {
+            "$ref": "TransferOwnershipResponse"
+          },
+          "flatPath": "v1beta/tunedModels/{tunedModelsId}:transferOwnership",
+          "path": "v1beta/{+name}:transferOwnership",
+          "parameterOrder": [
+            "name"
+          ],
+          "request": {
+            "$ref": "TransferOwnershipRequest"
+          },
+          "parameters": {
+            "name": {
+              "pattern": "^tunedModels/[^/]+$",
+              "location": "path",
+              "description": "Required. The resource name of the tuned model to transfer ownership. Format: `tunedModels/my-model-id`",
+              "type": "string",
+              "required": true
+            }
+          }
+        },
+        "generateContent": {
+          "id": "generativelanguage.tunedModels.generateContent",
+          "request": {
+            "$ref": "GenerateContentRequest"
+          },
+          "parameters": {
+            "model": {
+              "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`.",
+              "required": true,
+              "type": "string",
+              "location": "path",
+              "pattern": "^tunedModels/[^/]+$"
+            }
+          },
+          "httpMethod": "POST",
+          "flatPath": "v1beta/tunedModels/{tunedModelsId}:generateContent",
+          "response": {
+            "$ref": "GenerateContentResponse"
+          },
+          "description": "Generates a response from the model given an input `GenerateContentRequest`. Input capabilities differ between models, including tuned models. See the [model guide](https://ai.google.dev/models/gemini) and [tuning guide](https://ai.google.dev/docs/model_tuning_guidance) for details.",
+          "parameterOrder": [
+            "model"
+          ],
+          "path": "v1beta/{+model}:generateContent"
+        },
+        "patch": {
+          "httpMethod": "PATCH",
+          "id": "generativelanguage.tunedModels.patch",
+          "flatPath": "v1beta/tunedModels/{tunedModelsId}",
+          "path": "v1beta/{+name}",
+          "description": "Updates a tuned model.",
+          "request": {
+            "$ref": "TunedModel"
+          },
+          "response": {
+            "$ref": "TunedModel"
+          },
+          "parameters": {
+            "updateMask": {
+              "location": "query",
+              "description": "Required. The list of fields to update.",
+              "format": "google-fieldmask",
+              "type": "string"
+            },
+            "name": {
+              "type": "string",
+              "description": "Output only. The tuned model name. A unique name will be generated on create. Example: `tunedModels/az2mb0bpw6i` If display_name is set on create, the id portion of the name will be set by concatenating the words of the display_name with hyphens and adding a random portion for uniqueness. Example: display_name = \"Sentence Translator\" name = \"tunedModels/sentence-translator-u3b7m\"",
+              "required": true,
+              "pattern": "^tunedModels/[^/]+$",
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "name"
+          ]
+        },
+        "create": {
+          "flatPath": "v1beta/tunedModels",
+          "path": "v1beta/tunedModels",
+          "response": {
+            "$ref": "Operation"
+          },
+          "httpMethod": "POST",
+          "request": {
+            "$ref": "TunedModel"
+          },
+          "parameterOrder": [],
+          "parameters": {
+            "tunedModelId": {
+              "location": "query",
+              "type": "string",
+              "description": "Optional. The unique id for the tuned model if specified. This value should be up to 40 characters, the first character must be a letter, the last could be a letter or a number. The id must match the regular expression: [a-z]([a-z0-9-]{0,38}[a-z0-9])?."
+            }
+          },
+          "id": "generativelanguage.tunedModels.create",
+          "description": "Creates a tuned model. Intermediate tuning progress (if any) is accessed through the [google.longrunning.Operations] service. Status and results can be accessed through the Operations service. Example: GET /v1/tunedModels/az2mb0bpw6i/operations/000-111-222"
+        },
+        "get": {
+          "httpMethod": "GET",
+          "id": "generativelanguage.tunedModels.get",
+          "response": {
+            "$ref": "TunedModel"
+          },
+          "parameterOrder": [
+            "name"
+          ],
+          "flatPath": "v1beta/tunedModels/{tunedModelsId}",
+          "parameters": {
+            "name": {
+              "pattern": "^tunedModels/[^/]+$",
+              "required": true,
+              "location": "path",
+              "description": "Required. The resource name of the model. Format: `tunedModels/my-model-id`",
+              "type": "string"
+            }
+          },
+          "description": "Gets information about a specific TunedModel.",
+          "path": "v1beta/{+name}"
+        },
+        "delete": {
+          "id": "generativelanguage.tunedModels.delete",
+          "parameters": {
+            "name": {
+              "description": "Required. The resource name of the model. Format: `tunedModels/my-model-id`",
+              "location": "path",
+              "type": "string",
+              "pattern": "^tunedModels/[^/]+$",
+              "required": true
+            }
+          },
+          "flatPath": "v1beta/tunedModels/{tunedModelsId}",
+          "path": "v1beta/{+name}",
+          "response": {
+            "$ref": "Empty"
+          },
+          "httpMethod": "DELETE",
+          "description": "Deletes a tuned model.",
+          "parameterOrder": [
+            "name"
+          ]
+        },
+        "list": {
+          "httpMethod": "GET",
+          "id": "generativelanguage.tunedModels.list",
+          "path": "v1beta/tunedModels",
+          "parameterOrder": [],
+          "response": {
+            "$ref": "ListTunedModelsResponse"
+          },
+          "parameters": {
+            "pageSize": {
+              "type": "integer",
+              "description": "Optional. The maximum number of `TunedModels` to return (per page). The service may return fewer tuned models. If unspecified, at most 10 tuned models will be returned. This method returns at most 1000 models per page, even if you pass a larger page_size.",
+              "location": "query",
+              "format": "int32"
+            },
+            "filter": {
+              "description": "Optional. A filter is a full text search over the tuned model's description and display name. By default, results will not include tuned models shared with everyone. Additional operators: - owner:me - writers:me - readers:me - readers:everyone Examples: \"owner:me\" returns all tuned models to which caller has owner role \"readers:me\" returns all tuned models to which caller has reader role \"readers:everyone\" returns all tuned models that are shared with everyone",
+              "location": "query",
+              "type": "string"
+            },
+            "pageToken": {
+              "location": "query",
+              "type": "string",
+              "description": "Optional. A page token, received from a previous `ListTunedModels` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListTunedModels` must match the call that provided the page token."
+            }
+          },
+          "flatPath": "v1beta/tunedModels",
+          "description": "Lists tuned models owned by the user."
+        }
+      }
+    },
+    "cachedContents": {
+      "methods": {
+        "get": {
+          "parameters": {
+            "name": {
+              "type": "string",
+              "location": "path",
+              "required": true,
+              "pattern": "^cachedContents/[^/]+$",
+              "description": "Required. The resource name referring to the content cache entry. Format: `cachedContents/{id}`"
+            }
+          },
+          "parameterOrder": [
+            "name"
+          ],
+          "httpMethod": "GET",
+          "response": {
+            "$ref": "CachedContent"
+          },
+          "flatPath": "v1beta/cachedContents/{cachedContentsId}",
+          "description": "Reads CachedContent resource.",
+          "id": "generativelanguage.cachedContents.get",
+          "path": "v1beta/{+name}"
+        },
+        "create": {
+          "request": {
+            "$ref": "CachedContent"
+          },
+          "httpMethod": "POST",
+          "parameterOrder": [],
+          "flatPath": "v1beta/cachedContents",
+          "response": {
+            "$ref": "CachedContent"
+          },
+          "id": "generativelanguage.cachedContents.create",
+          "description": "Creates CachedContent resource.",
+          "path": "v1beta/cachedContents",
+          "parameters": {}
+        },
+        "delete": {
+          "description": "Deletes CachedContent resource.",
+          "parameters": {
+            "name": {
+              "required": true,
+              "pattern": "^cachedContents/[^/]+$",
+              "location": "path",
+              "description": "Required. The resource name referring to the content cache entry Format: `cachedContents/{id}`",
+              "type": "string"
+            }
+          },
+          "flatPath": "v1beta/cachedContents/{cachedContentsId}",
+          "httpMethod": "DELETE",
+          "response": {
+            "$ref": "Empty"
+          },
+          "parameterOrder": [
+            "name"
+          ],
+          "path": "v1beta/{+name}",
+          "id": "generativelanguage.cachedContents.delete"
+        },
+        "list": {
+          "httpMethod": "GET",
+          "parameters": {
+            "pageSize": {
+              "type": "integer",
+              "location": "query",
+              "description": "Optional. The maximum number of cached contents to return. The service may return fewer than this value. If unspecified, some default (under maximum) number of items will be returned. The maximum value is 1000; values above 1000 will be coerced to 1000.",
+              "format": "int32"
+            },
+            "pageToken": {
+              "description": "Optional. A page token, received from a previous `ListCachedContents` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListCachedContents` must match the call that provided the page token.",
+              "type": "string",
+              "location": "query"
+            }
+          },
+          "id": "generativelanguage.cachedContents.list",
+          "response": {
+            "$ref": "ListCachedContentsResponse"
+          },
+          "description": "Lists CachedContents.",
+          "parameterOrder": [],
+          "path": "v1beta/cachedContents",
+          "flatPath": "v1beta/cachedContents"
+        },
+        "patch": {
+          "flatPath": "v1beta/cachedContents/{cachedContentsId}",
+          "request": {
+            "$ref": "CachedContent"
+          },
+          "response": {
+            "$ref": "CachedContent"
+          },
+          "path": "v1beta/{+name}",
+          "description": "Updates CachedContent resource (only expiration is updatable).",
+          "parameterOrder": [
+            "name"
+          ],
+          "parameters": {
+            "name": {
+              "required": true,
+              "pattern": "^cachedContents/[^/]+$",
+              "type": "string",
+              "location": "path",
+              "description": "Optional. Identifier. The resource name referring to the cached content. Format: `cachedContents/{id}`"
+            },
+            "updateMask": {
+              "type": "string",
+              "format": "google-fieldmask",
+              "description": "The list of fields to update.",
+              "location": "query"
+            }
+          },
+          "id": "generativelanguage.cachedContents.patch",
+          "httpMethod": "PATCH"
+        }
+      }
+    },
+    "media": {
+      "methods": {
+        "upload": {
+          "path": "v1beta/files",
+          "flatPath": "v1beta/files",
+          "mediaUpload": {
+            "accept": [
+              "*/*"
+            ],
+            "maxSize": "2147483648",
+            "protocols": {
+              "resumable": {
+                "multipart": true,
+                "path": "/resumable/upload/v1beta/files"
+              },
+              "simple": {
+                "multipart": true,
+                "path": "/upload/v1beta/files"
+              }
+            }
+          },
+          "parameterOrder": [],
+          "httpMethod": "POST",
+          "supportsMediaUpload": true,
+          "parameters": {},
+          "id": "generativelanguage.media.upload",
+          "response": {
+            "$ref": "CreateFileResponse"
+          },
+          "request": {
+            "$ref": "CreateFileRequest"
+          },
+          "description": "Creates a `File`."
+        }
+      }
+    },
+    "models": {
+      "methods": {
+        "countMessageTokens": {
+          "httpMethod": "POST",
+          "response": {
+            "$ref": "CountMessageTokensResponse"
+          },
+          "description": "Runs a model's tokenizer on a string and returns the token count.",
+          "id": "generativelanguage.models.countMessageTokens",
+          "path": "v1beta/{+model}:countMessageTokens",
+          "parameters": {
+            "model": {
+              "type": "string",
+              "pattern": "^models/[^/]+$",
+              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "model"
+          ],
+          "flatPath": "v1beta/models/{modelsId}:countMessageTokens",
+          "request": {
+            "$ref": "CountMessageTokensRequest"
+          }
+        },
+        "get": {
+          "parameterOrder": [
+            "name"
+          ],
+          "response": {
+            "$ref": "Model"
+          },
+          "path": "v1beta/{+name}",
+          "description": "Gets information about a specific Model.",
+          "parameters": {
+            "name": {
+              "required": true,
+              "type": "string",
+              "description": "Required. The resource name of the model. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
+              "pattern": "^models/[^/]+$",
+              "location": "path"
+            }
+          },
+          "httpMethod": "GET",
+          "id": "generativelanguage.models.get",
+          "flatPath": "v1beta/models/{modelsId}"
+        },
+        "countTextTokens": {
+          "path": "v1beta/{+model}:countTextTokens",
+          "parameterOrder": [
+            "model"
+          ],
+          "description": "Runs a model's tokenizer on a text and returns the token count.",
+          "response": {
+            "$ref": "CountTextTokensResponse"
+          },
+          "parameters": {
+            "model": {
+              "pattern": "^models/[^/]+$",
+              "required": true,
+              "type": "string",
+              "location": "path",
+              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`"
+            }
+          },
+          "httpMethod": "POST",
+          "request": {
+            "$ref": "CountTextTokensRequest"
+          },
+          "flatPath": "v1beta/models/{modelsId}:countTextTokens",
+          "id": "generativelanguage.models.countTextTokens"
+        },
+        "generateMessage": {
+          "parameters": {
+            "model": {
+              "required": true,
+              "type": "string",
+              "pattern": "^models/[^/]+$",
+              "description": "Required. The name of the model to use. Format: `name=models/{model}`.",
+              "location": "path"
+            }
+          },
+          "flatPath": "v1beta/models/{modelsId}:generateMessage",
+          "request": {
+            "$ref": "GenerateMessageRequest"
+          },
+          "parameterOrder": [
+            "model"
+          ],
+          "path": "v1beta/{+model}:generateMessage",
+          "description": "Generates a response from the model given an input `MessagePrompt`.",
+          "httpMethod": "POST",
+          "id": "generativelanguage.models.generateMessage",
+          "response": {
+            "$ref": "GenerateMessageResponse"
+          }
+        },
+        "countTokens": {
+          "description": "Runs a model's tokenizer on input content and returns the token count.",
+          "request": {
+            "$ref": "CountTokensRequest"
+          },
+          "parameterOrder": [
+            "model"
+          ],
+          "parameters": {
+            "model": {
+              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
+              "type": "string",
+              "location": "path",
+              "required": true,
+              "pattern": "^models/[^/]+$"
+            }
+          },
+          "flatPath": "v1beta/models/{modelsId}:countTokens",
+          "httpMethod": "POST",
+          "id": "generativelanguage.models.countTokens",
+          "path": "v1beta/{+model}:countTokens",
+          "response": {
+            "$ref": "CountTokensResponse"
+          }
+        },
+        "batchEmbedText": {
+          "description": "Generates multiple embeddings from the model given input text in a synchronous call.",
+          "id": "generativelanguage.models.batchEmbedText",
+          "parameters": {
+            "model": {
+              "type": "string",
+              "required": true,
+              "pattern": "^models/[^/]+$",
+              "description": "Required. The name of the `Model` to use for generating the embedding. Examples: models/embedding-gecko-001",
+              "location": "path"
+            }
+          },
+          "request": {
+            "$ref": "BatchEmbedTextRequest"
+          },
+          "response": {
+            "$ref": "BatchEmbedTextResponse"
+          },
+          "parameterOrder": [
+            "model"
+          ],
+          "httpMethod": "POST",
+          "path": "v1beta/{+model}:batchEmbedText",
+          "flatPath": "v1beta/models/{modelsId}:batchEmbedText"
+        },
+        "embedContent": {
+          "flatPath": "v1beta/models/{modelsId}:embedContent",
+          "request": {
+            "$ref": "EmbedContentRequest"
+          },
+          "response": {
+            "$ref": "EmbedContentResponse"
+          },
+          "path": "v1beta/{+model}:embedContent",
+          "httpMethod": "POST",
+          "description": "Generates an embedding from the model given an input `Content`.",
+          "parameterOrder": [
+            "model"
+          ],
+          "id": "generativelanguage.models.embedContent",
+          "parameters": {
+            "model": {
+              "pattern": "^models/[^/]+$",
+              "required": true,
+              "location": "path",
+              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
+              "type": "string"
+            }
+          }
+        },
+        "generateContent": {
+          "path": "v1beta/{+model}:generateContent",
+          "parameterOrder": [
+            "model"
+          ],
+          "response": {
+            "$ref": "GenerateContentResponse"
+          },
+          "request": {
+            "$ref": "GenerateContentRequest"
+          },
+          "httpMethod": "POST",
+          "id": "generativelanguage.models.generateContent",
+          "parameters": {
+            "model": {
+              "pattern": "^models/[^/]+$",
+              "location": "path",
+              "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`.",
+              "required": true,
+              "type": "string"
+            }
+          },
+          "flatPath": "v1beta/models/{modelsId}:generateContent",
+          "description": "Generates a response from the model given an input `GenerateContentRequest`. Input capabilities differ between models, including tuned models. See the [model guide](https://ai.google.dev/models/gemini) and [tuning guide](https://ai.google.dev/docs/model_tuning_guidance) for details."
+        },
+        "batchEmbedContents": {
+          "parameterOrder": [
+            "model"
+          ],
+          "response": {
+            "$ref": "BatchEmbedContentsResponse"
+          },
+          "id": "generativelanguage.models.batchEmbedContents",
+          "flatPath": "v1beta/models/{modelsId}:batchEmbedContents",
+          "httpMethod": "POST",
+          "description": "Generates multiple embeddings from the model given input text in a synchronous call.",
+          "parameters": {
+            "model": {
+              "type": "string",
+              "pattern": "^models/[^/]+$",
+              "location": "path",
+              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
+              "required": true
+            }
+          },
+          "request": {
+            "$ref": "BatchEmbedContentsRequest"
+          },
+          "path": "v1beta/{+model}:batchEmbedContents"
+        },
+        "streamGenerateContent": {
+          "description": "Generates a streamed response from the model given an input `GenerateContentRequest`.",
+          "response": {
+            "$ref": "GenerateContentResponse"
+          },
+          "flatPath": "v1beta/models/{modelsId}:streamGenerateContent",
+          "id": "generativelanguage.models.streamGenerateContent",
+          "parameters": {
+            "model": {
+              "location": "path",
+              "type": "string",
+              "pattern": "^models/[^/]+$",
+              "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`.",
+              "required": true
+            }
+          },
+          "parameterOrder": [
+            "model"
+          ],
+          "path": "v1beta/{+model}:streamGenerateContent",
+          "httpMethod": "POST",
+          "request": {
+            "$ref": "GenerateContentRequest"
+          }
+        },
+        "embedText": {
+          "parameterOrder": [
+            "model"
+          ],
+          "request": {
+            "$ref": "EmbedTextRequest"
+          },
+          "id": "generativelanguage.models.embedText",
+          "response": {
+            "$ref": "EmbedTextResponse"
+          },
+          "httpMethod": "POST",
+          "path": "v1beta/{+model}:embedText",
+          "flatPath": "v1beta/models/{modelsId}:embedText",
+          "parameters": {
+            "model": {
+              "required": true,
+              "type": "string",
+              "description": "Required. The model name to use with the format model=models/{model}.",
+              "pattern": "^models/[^/]+$",
+              "location": "path"
+            }
+          },
+          "description": "Generates an embedding from the model given an input message."
+        },
+        "generateAnswer": {
+          "id": "generativelanguage.models.generateAnswer",
+          "request": {
+            "$ref": "GenerateAnswerRequest"
+          },
+          "response": {
+            "$ref": "GenerateAnswerResponse"
+          },
+          "parameters": {
+            "model": {
+              "required": true,
+              "type": "string",
+              "pattern": "^models/[^/]+$",
+              "description": "Required. The name of the `Model` to use for generating the grounded response. Format: `model=models/{model}`.",
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "model"
+          ],
+          "flatPath": "v1beta/models/{modelsId}:generateAnswer",
+          "description": "Generates a grounded answer from the model given an input `GenerateAnswerRequest`.",
+          "path": "v1beta/{+model}:generateAnswer",
+          "httpMethod": "POST"
+        },
+        "generateText": {
+          "parameters": {
+            "model": {
+              "required": true,
+              "pattern": "^models/[^/]+$",
+              "description": "Required. The name of the `Model` or `TunedModel` to use for generating the completion. Examples: models/text-bison-001 tunedModels/sentence-translator-u3b7m",
+              "type": "string",
+              "location": "path"
+            }
+          },
+          "flatPath": "v1beta/models/{modelsId}:generateText",
+          "httpMethod": "POST",
+          "parameterOrder": [
+            "model"
+          ],
+          "id": "generativelanguage.models.generateText",
+          "path": "v1beta/{+model}:generateText",
+          "request": {
+            "$ref": "GenerateTextRequest"
+          },
+          "description": "Generates a response from the model given an input message.",
+          "response": {
+            "$ref": "GenerateTextResponse"
+          }
+        },
+        "list": {
+          "parameterOrder": [],
+          "id": "generativelanguage.models.list",
+          "path": "v1beta/models",
+          "flatPath": "v1beta/models",
+          "parameters": {
+            "pageSize": {
+              "type": "integer",
+              "description": "The maximum number of `Models` to return (per page). The service may return fewer models. If unspecified, at most 50 models will be returned per page. This method returns at most 1000 models per page, even if you pass a larger page_size.",
+              "format": "int32",
+              "location": "query"
+            },
+            "pageToken": {
+              "location": "query",
+              "type": "string",
+              "description": "A page token, received from a previous `ListModels` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListModels` must match the call that provided the page token."
+            }
+          },
+          "httpMethod": "GET",
+          "description": "Lists models available through the API.",
+          "response": {
+            "$ref": "ListModelsResponse"
+          }
+        }
+      }
+    },
+    "corpora": {
+      "methods": {
+        "query": {
+          "description": "Performs semantic search over a `Corpus`.",
+          "parameterOrder": [
+            "name"
+          ],
+          "flatPath": "v1beta/corpora/{corporaId}:query",
+          "request": {
+            "$ref": "QueryCorpusRequest"
+          },
+          "response": {
+            "$ref": "QueryCorpusResponse"
+          },
+          "path": "v1beta/{+name}:query",
+          "parameters": {
+            "name": {
+              "pattern": "^corpora/[^/]+$",
+              "required": true,
+              "type": "string",
+              "description": "Required. The name of the `Corpus` to query. Example: `corpora/my-corpus-123`",
+              "location": "path"
+            }
+          },
+          "httpMethod": "POST",
+          "id": "generativelanguage.corpora.query"
+        },
+        "patch": {
+          "httpMethod": "PATCH",
+          "flatPath": "v1beta/corpora/{corporaId}",
+          "response": {
+            "$ref": "Corpus"
+          },
+          "parameterOrder": [
+            "name"
+          ],
+          "id": "generativelanguage.corpora.patch",
+          "parameters": {
+            "updateMask": {
+              "format": "google-fieldmask",
+              "location": "query",
+              "type": "string",
+              "description": "Required. The list of fields to update. Currently, this only supports updating `display_name`."
+            },
+            "name": {
+              "required": true,
+              "location": "path",
+              "pattern": "^corpora/[^/]+$",
+              "description": "Immutable. Identifier. The `Corpus` resource name. The ID (name excluding the \"corpora/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/my-awesome-corpora-123a456b789c`",
+              "type": "string"
+            }
+          },
+          "description": "Updates a `Corpus`.",
+          "request": {
+            "$ref": "Corpus"
+          },
+          "path": "v1beta/{+name}"
+        },
+        "create": {
+          "parameterOrder": [],
+          "request": {
+            "$ref": "Corpus"
+          },
+          "id": "generativelanguage.corpora.create",
+          "flatPath": "v1beta/corpora",
+          "path": "v1beta/corpora",
+          "response": {
+            "$ref": "Corpus"
+          },
+          "description": "Creates an empty `Corpus`.",
+          "parameters": {},
+          "httpMethod": "POST"
+        },
+        "delete": {
+          "parameterOrder": [
+            "name"
+          ],
+          "httpMethod": "DELETE",
+          "path": "v1beta/{+name}",
+          "parameters": {
+            "force": {
+              "type": "boolean",
+              "location": "query",
+              "description": "Optional. If set to true, any `Document`s and objects related to this `Corpus` will also be deleted. If false (the default), a `FAILED_PRECONDITION` error will be returned if `Corpus` contains any `Document`s."
+            },
+            "name": {
+              "description": "Required. The resource name of the `Corpus`. Example: `corpora/my-corpus-123`",
+              "pattern": "^corpora/[^/]+$",
+              "type": "string",
+              "required": true,
+              "location": "path"
+            }
+          },
+          "response": {
+            "$ref": "Empty"
+          },
+          "flatPath": "v1beta/corpora/{corporaId}",
+          "id": "generativelanguage.corpora.delete",
+          "description": "Deletes a `Corpus`."
+        },
+        "get": {
+          "parameters": {
+            "name": {
+              "pattern": "^corpora/[^/]+$",
+              "location": "path",
+              "required": true,
+              "description": "Required. The name of the `Corpus`. Example: `corpora/my-corpus-123`",
+              "type": "string"
+            }
+          },
+          "description": "Gets information about a specific `Corpus`.",
+          "path": "v1beta/{+name}",
+          "id": "generativelanguage.corpora.get",
+          "httpMethod": "GET",
+          "response": {
+            "$ref": "Corpus"
+          },
+          "parameterOrder": [
+            "name"
+          ],
+          "flatPath": "v1beta/corpora/{corporaId}"
+        },
+        "list": {
+          "response": {
+            "$ref": "ListCorporaResponse"
+          },
+          "parameterOrder": [],
+          "id": "generativelanguage.corpora.list",
+          "flatPath": "v1beta/corpora",
+          "description": "Lists all `Corpora` owned by the user.",
+          "path": "v1beta/corpora",
+          "parameters": {
+            "pageSize": {
+              "type": "integer",
+              "format": "int32",
+              "location": "query",
+              "description": "Optional. The maximum number of `Corpora` to return (per page). The service may return fewer `Corpora`. If unspecified, at most 10 `Corpora` will be returned. The maximum size limit is 20 `Corpora` per page."
+            },
+            "pageToken": {
+              "type": "string",
+              "location": "query",
+              "description": "Optional. A page token, received from a previous `ListCorpora` call. Provide the `next_page_token` returned in the response as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListCorpora` must match the call that provided the page token."
+            }
+          },
+          "httpMethod": "GET"
+        }
+      },
+      "resources": {
+        "permissions": {
+          "methods": {
+            "patch": {
+              "parameterOrder": [
+                "name"
+              ],
+              "flatPath": "v1beta/corpora/{corporaId}/permissions/{permissionsId}",
+              "httpMethod": "PATCH",
+              "response": {
+                "$ref": "Permission"
+              },
+              "path": "v1beta/{+name}",
+              "id": "generativelanguage.corpora.permissions.patch",
+              "description": "Updates the permission.",
+              "parameters": {
+                "updateMask": {
+                  "location": "query",
+                  "format": "google-fieldmask",
+                  "description": "Required. The list of fields to update. Accepted ones: - role (`Permission.role` field)",
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string",
+                  "required": true,
+                  "location": "path",
+                  "pattern": "^corpora/[^/]+/permissions/[^/]+$",
+                  "description": "Output only. Identifier. The permission name. A unique name will be generated on create. Examples: tunedModels/{tuned_model}/permissions/{permission} corpora/{corpus}/permissions/{permission} Output only."
+                }
+              },
+              "request": {
+                "$ref": "Permission"
+              }
+            },
+            "create": {
+              "request": {
+                "$ref": "Permission"
+              },
+              "flatPath": "v1beta/corpora/{corporaId}/permissions",
+              "httpMethod": "POST",
+              "response": {
+                "$ref": "Permission"
+              },
+              "id": "generativelanguage.corpora.permissions.create",
+              "description": "Create a permission to a specific resource.",
+              "parameterOrder": [
+                "parent"
+              ],
+              "path": "v1beta/{+parent}/permissions",
+              "parameters": {
+                "parent": {
+                  "required": true,
+                  "location": "path",
+                  "type": "string",
+                  "pattern": "^corpora/[^/]+$",
+                  "description": "Required. The parent resource of the `Permission`. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`"
+                }
+              }
+            },
+            "delete": {
+              "parameterOrder": [
+                "name"
+              ],
+              "response": {
+                "$ref": "Empty"
+              },
+              "path": "v1beta/{+name}",
+              "flatPath": "v1beta/corpora/{corporaId}/permissions/{permissionsId}",
+              "description": "Deletes the permission.",
+              "parameters": {
+                "name": {
+                  "location": "path",
+                  "pattern": "^corpora/[^/]+/permissions/[^/]+$",
+                  "required": true,
+                  "type": "string",
+                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`"
+                }
+              },
+              "id": "generativelanguage.corpora.permissions.delete",
+              "httpMethod": "DELETE"
+            },
+            "get": {
+              "response": {
+                "$ref": "Permission"
+              },
+              "id": "generativelanguage.corpora.permissions.get",
+              "parameterOrder": [
+                "name"
+              ],
+              "description": "Gets information about a specific Permission.",
+              "httpMethod": "GET",
+              "path": "v1beta/{+name}",
+              "parameters": {
+                "name": {
+                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
+                  "pattern": "^corpora/[^/]+/permissions/[^/]+$",
+                  "required": true,
+                  "location": "path",
+                  "type": "string"
+                }
+              },
+              "flatPath": "v1beta/corpora/{corporaId}/permissions/{permissionsId}"
+            },
+            "list": {
+              "parameterOrder": [
+                "parent"
+              ],
+              "httpMethod": "GET",
+              "id": "generativelanguage.corpora.permissions.list",
+              "response": {
+                "$ref": "ListPermissionsResponse"
+              },
+              "parameters": {
+                "parent": {
+                  "type": "string",
+                  "description": "Required. The parent resource of the permissions. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`",
+                  "location": "path",
+                  "required": true,
+                  "pattern": "^corpora/[^/]+$"
+                },
+                "pageToken": {
+                  "description": "Optional. A page token, received from a previous `ListPermissions` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListPermissions` must match the call that provided the page token.",
+                  "location": "query",
+                  "type": "string"
+                },
+                "pageSize": {
+                  "format": "int32",
+                  "location": "query",
+                  "type": "integer",
+                  "description": "Optional. The maximum number of `Permission`s to return (per page). The service may return fewer permissions. If unspecified, at most 10 permissions will be returned. This method returns at most 1000 permissions per page, even if you pass larger page_size."
+                }
+              },
+              "path": "v1beta/{+parent}/permissions",
+              "flatPath": "v1beta/corpora/{corporaId}/permissions",
+              "description": "Lists permissions for the specific resource."
+            }
+          }
+        },
+        "documents": {
+          "resources": {
+            "chunks": {
+              "methods": {
+                "list": {
+                  "id": "generativelanguage.corpora.documents.chunks.list",
+                  "description": "Lists all `Chunk`s in a `Document`.",
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks",
+                  "response": {
+                    "$ref": "ListChunksResponse"
+                  },
+                  "path": "v1beta/{+parent}/chunks",
+                  "httpMethod": "GET",
+                  "parameters": {
+                    "parent": {
+                      "type": "string",
+                      "location": "path",
+                      "required": true,
+                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                      "description": "Required. The name of the `Document` containing `Chunk`s. Example: `corpora/my-corpus-123/documents/the-doc-abc`"
+                    },
+                    "pageSize": {
+                      "description": "Optional. The maximum number of `Chunk`s to return (per page). The service may return fewer `Chunk`s. If unspecified, at most 10 `Chunk`s will be returned. The maximum size limit is 100 `Chunk`s per page.",
+                      "type": "integer",
+                      "format": "int32",
+                      "location": "query"
+                    },
+                    "pageToken": {
+                      "location": "query",
+                      "type": "string",
+                      "description": "Optional. A page token, received from a previous `ListChunks` call. Provide the `next_page_token` returned in the response as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListChunks` must match the call that provided the page token."
+                    }
+                  },
+                  "parameterOrder": [
+                    "parent"
+                  ]
+                },
+                "batchDelete": {
+                  "description": "Batch delete `Chunk`s.",
+                  "httpMethod": "POST",
+                  "id": "generativelanguage.corpora.documents.chunks.batchDelete",
+                  "request": {
+                    "$ref": "BatchDeleteChunksRequest"
+                  },
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "parameters": {
+                    "parent": {
+                      "location": "path",
+                      "required": true,
+                      "type": "string",
+                      "description": "Optional. The name of the `Document` containing the `Chunk`s to delete. The parent field in every `DeleteChunkRequest` must match this value. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
+                      "pattern": "^corpora/[^/]+/documents/[^/]+$"
+                    }
+                  },
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks:batchDelete",
+                  "path": "v1beta/{+parent}/chunks:batchDelete"
+                },
+                "batchUpdate": {
+                  "description": "Batch update `Chunk`s.",
+                  "request": {
+                    "$ref": "BatchUpdateChunksRequest"
+                  },
+                  "parameters": {
+                    "parent": {
+                      "type": "string",
+                      "location": "path",
+                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                      "required": true,
+                      "description": "Optional. The name of the `Document` containing the `Chunk`s to update. The parent field in every `UpdateChunkRequest` must match this value. Example: `corpora/my-corpus-123/documents/the-doc-abc`"
+                    }
+                  },
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "id": "generativelanguage.corpora.documents.chunks.batchUpdate",
+                  "path": "v1beta/{+parent}/chunks:batchUpdate",
+                  "response": {
+                    "$ref": "BatchUpdateChunksResponse"
+                  },
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks:batchUpdate",
+                  "httpMethod": "POST"
+                },
+                "create": {
+                  "id": "generativelanguage.corpora.documents.chunks.create",
+                  "description": "Creates a `Chunk`.",
+                  "path": "v1beta/{+parent}/chunks",
+                  "response": {
+                    "$ref": "Chunk"
+                  },
+                  "parameters": {
+                    "parent": {
+                      "type": "string",
+                      "location": "path",
+                      "required": true,
+                      "description": "Required. The name of the `Document` where this `Chunk` will be created. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
+                      "pattern": "^corpora/[^/]+/documents/[^/]+$"
+                    }
+                  },
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks",
+                  "httpMethod": "POST",
+                  "request": {
+                    "$ref": "Chunk"
+                  },
+                  "parameterOrder": [
+                    "parent"
+                  ]
+                },
+                "get": {
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "path": "v1beta/{+name}",
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "location": "path",
+                      "required": true,
+                      "pattern": "^corpora/[^/]+/documents/[^/]+/chunks/[^/]+$",
+                      "description": "Required. The name of the `Chunk` to retrieve. Example: `corpora/my-corpus-123/documents/the-doc-abc/chunks/some-chunk`"
+                    }
+                  },
+                  "description": "Gets information about a specific `Chunk`.",
+                  "httpMethod": "GET",
+                  "id": "generativelanguage.corpora.documents.chunks.get",
+                  "response": {
+                    "$ref": "Chunk"
+                  },
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks/{chunksId}"
+                },
+                "patch": {
+                  "path": "v1beta/{+name}",
+                  "request": {
+                    "$ref": "Chunk"
+                  },
+                  "description": "Updates a `Chunk`.",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "id": "generativelanguage.corpora.documents.chunks.patch",
+                  "parameters": {
+                    "updateMask": {
+                      "format": "google-fieldmask",
+                      "description": "Required. The list of fields to update. Currently, this only supports updating `custom_metadata` and `data`.",
+                      "type": "string",
+                      "location": "query"
+                    },
+                    "name": {
+                      "pattern": "^corpora/[^/]+/documents/[^/]+/chunks/[^/]+$",
+                      "location": "path",
+                      "description": "Immutable. Identifier. The `Chunk` resource name. The ID (name excluding the \"corpora/*/documents/*/chunks/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a random 12-character unique ID will be generated. Example: `corpora/{corpus_id}/documents/{document_id}/chunks/123a456b789c`",
+                      "type": "string",
+                      "required": true
+                    }
+                  },
+                  "httpMethod": "PATCH",
+                  "response": {
+                    "$ref": "Chunk"
+                  },
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks/{chunksId}"
+                },
+                "delete": {
+                  "description": "Deletes a `Chunk`.",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "parameters": {
+                    "name": {
+                      "description": "Required. The resource name of the `Chunk` to delete. Example: `corpora/my-corpus-123/documents/the-doc-abc/chunks/some-chunk`",
+                      "type": "string",
+                      "location": "path",
+                      "required": true,
+                      "pattern": "^corpora/[^/]+/documents/[^/]+/chunks/[^/]+$"
+                    }
+                  },
+                  "id": "generativelanguage.corpora.documents.chunks.delete",
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks/{chunksId}",
+                  "httpMethod": "DELETE",
+                  "path": "v1beta/{+name}"
+                },
+                "batchCreate": {
+                  "description": "Batch create `Chunk`s.",
+                  "response": {
+                    "$ref": "BatchCreateChunksResponse"
+                  },
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "request": {
+                    "$ref": "BatchCreateChunksRequest"
+                  },
+                  "id": "generativelanguage.corpora.documents.chunks.batchCreate",
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks:batchCreate",
+                  "parameters": {
+                    "parent": {
+                      "required": true,
+                      "type": "string",
+                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                      "description": "Optional. The name of the `Document` where this batch of `Chunk`s will be created. The parent field in every `CreateChunkRequest` must match this value. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
+                      "location": "path"
+                    }
+                  },
+                  "path": "v1beta/{+parent}/chunks:batchCreate",
+                  "httpMethod": "POST"
+                }
+              }
+            }
+          },
+          "methods": {
+            "query": {
+              "request": {
+                "$ref": "QueryDocumentRequest"
+              },
+              "httpMethod": "POST",
+              "path": "v1beta/{+name}:query",
+              "id": "generativelanguage.corpora.documents.query",
+              "parameters": {
+                "name": {
+                  "type": "string",
+                  "description": "Required. The name of the `Document` to query. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
+                  "required": true,
+                  "location": "path",
+                  "pattern": "^corpora/[^/]+/documents/[^/]+$"
+                }
+              },
+              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}:query",
+              "response": {
+                "$ref": "QueryDocumentResponse"
+              },
+              "description": "Performs semantic search over a `Document`.",
+              "parameterOrder": [
+                "name"
+              ]
+            },
+            "get": {
+              "path": "v1beta/{+name}",
+              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}",
+              "httpMethod": "GET",
+              "parameters": {
+                "name": {
+                  "type": "string",
+                  "required": true,
+                  "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                  "location": "path",
+                  "description": "Required. The name of the `Document` to retrieve. Example: `corpora/my-corpus-123/documents/the-doc-abc`"
+                }
+              },
+              "description": "Gets information about a specific `Document`.",
+              "response": {
+                "$ref": "Document"
+              },
+              "id": "generativelanguage.corpora.documents.get",
+              "parameterOrder": [
+                "name"
+              ]
+            },
+            "delete": {
+              "httpMethod": "DELETE",
+              "parameters": {
+                "force": {
+                  "description": "Optional. If set to true, any `Chunk`s and objects related to this `Document` will also be deleted. If false (the default), a `FAILED_PRECONDITION` error will be returned if `Document` contains any `Chunk`s.",
+                  "location": "query",
+                  "type": "boolean"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Required. The resource name of the `Document` to delete. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
+                  "required": true,
+                  "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                  "location": "path"
+                }
+              },
+              "id": "generativelanguage.corpora.documents.delete",
+              "path": "v1beta/{+name}",
+              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}",
+              "response": {
+                "$ref": "Empty"
+              },
+              "description": "Deletes a `Document`.",
+              "parameterOrder": [
+                "name"
+              ]
+            },
+            "patch": {
+              "parameters": {
+                "updateMask": {
+                  "type": "string",
+                  "format": "google-fieldmask",
+                  "description": "Required. The list of fields to update. Currently, this only supports updating `display_name` and `custom_metadata`.",
+                  "location": "query"
+                },
+                "name": {
+                  "required": true,
+                  "location": "path",
+                  "description": "Immutable. Identifier. The `Document` resource name. The ID (name excluding the \"corpora/*/documents/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/{corpus_id}/documents/my-awesome-doc-123a456b789c`",
+                  "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                  "type": "string"
+                }
+              },
+              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}",
+              "id": "generativelanguage.corpora.documents.patch",
+              "parameterOrder": [
+                "name"
+              ],
+              "description": "Updates a `Document`.",
+              "path": "v1beta/{+name}",
+              "request": {
+                "$ref": "Document"
+              },
+              "httpMethod": "PATCH",
+              "response": {
+                "$ref": "Document"
+              }
+            },
+            "list": {
+              "flatPath": "v1beta/corpora/{corporaId}/documents",
+              "description": "Lists all `Document`s in a `Corpus`.",
+              "id": "generativelanguage.corpora.documents.list",
+              "parameterOrder": [
+                "parent"
+              ],
+              "parameters": {
+                "pageSize": {
+                  "description": "Optional. The maximum number of `Document`s to return (per page). The service may return fewer `Document`s. If unspecified, at most 10 `Document`s will be returned. The maximum size limit is 20 `Document`s per page.",
+                  "type": "integer",
+                  "format": "int32",
+                  "location": "query"
+                },
+                "pageToken": {
+                  "type": "string",
+                  "description": "Optional. A page token, received from a previous `ListDocuments` call. Provide the `next_page_token` returned in the response as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListDocuments` must match the call that provided the page token.",
+                  "location": "query"
+                },
+                "parent": {
+                  "type": "string",
+                  "required": true,
+                  "location": "path",
+                  "pattern": "^corpora/[^/]+$",
+                  "description": "Required. The name of the `Corpus` containing `Document`s. Example: `corpora/my-corpus-123`"
+                }
+              },
+              "httpMethod": "GET",
+              "path": "v1beta/{+parent}/documents",
+              "response": {
+                "$ref": "ListDocumentsResponse"
+              }
+            },
+            "create": {
+              "response": {
+                "$ref": "Document"
+              },
+              "request": {
+                "$ref": "Document"
+              },
+              "httpMethod": "POST",
+              "id": "generativelanguage.corpora.documents.create",
+              "flatPath": "v1beta/corpora/{corporaId}/documents",
+              "parameterOrder": [
+                "parent"
+              ],
+              "path": "v1beta/{+parent}/documents",
+              "description": "Creates an empty `Document`.",
+              "parameters": {
+                "parent": {
+                  "description": "Required. The name of the `Corpus` where this `Document` will be created. Example: `corpora/my-corpus-123`",
+                  "pattern": "^corpora/[^/]+$",
+                  "type": "string",
+                  "required": true,
+                  "location": "path"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "baseUrl": "https://generativelanguage.googleapis.com/",
+  "documentationLink": "https://developers.generativeai.google/api",
+  "revision": "20240619",
+  "parameters": {
+    "prettyPrint": {
+      "default": "true",
+      "location": "query",
+      "description": "Returns response with indentations and line breaks.",
+      "type": "boolean"
+    },
+    "fields": {
+      "type": "string",
+      "description": "Selector specifying which fields to include in a partial response.",
+      "location": "query"
+    },
+    "quotaUser": {
+      "type": "string",
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+      "location": "query"
+    },
+    "uploadType": {
+      "type": "string",
+      "location": "query",
+      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\")."
+    },
+    "callback": {
+      "type": "string",
+      "description": "JSONP",
+      "location": "query"
+    },
+    "$.xgafv": {
+      "location": "query",
+      "enumDescriptions": [
+        "v1 error format",
+        "v2 error format"
+      ],
+      "enum": [
+        "1",
+        "2"
+      ],
+      "description": "V1 error format.",
+      "type": "string"
+    },
+    "key": {
+      "type": "string",
+      "location": "query",
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token."
+    },
+    "oauth_token": {
+      "location": "query",
+      "type": "string",
+      "description": "OAuth 2.0 token for the current user."
+    },
+    "access_token": {
+      "type": "string",
+      "location": "query",
+      "description": "OAuth access token."
+    },
+    "alt": {
+      "type": "string",
+      "description": "Data format for response.",
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json",
+        "Media download with context-dependent Content-Type",
+        "Responses with Content-Type of application/x-protobuf"
+      ],
+      "location": "query",
+      "enum": [
+        "json",
+        "media",
+        "proto"
+      ],
+      "default": "json"
+    },
+    "upload_protocol": {
+      "type": "string",
+      "location": "query",
+      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\")."
     }
   },
   "ownerDomain": "google.com",
-  "title": "Generative Language API",
-  "revision": "20240619",
-  "basePath": "",
-  "version": "v1beta",
+  "ownerName": "Google",
+  "mtlsRootUrl": "https://generativelanguage.mtls.googleapis.com/",
   "canonicalName": "Generative Language",
   "id": "generativelanguage:v1beta",
-  "ownerName": "Google"
+  "title": "Generative Language API",
+  "description": "The Gemini API allows developers to build generative AI applications using Gemini models. Gemini is our most capable model, built from the ground up to be multimodal. It can generalize and seamlessly understand, operate across, and combine different types of information including language, images, audio, video, and code. You can use the Gemini API for use cases like reasoning across text and images, content generation, dialogue agents, summarization and classification systems, and more.",
+  "rootUrl": "https://generativelanguage.googleapis.com/",
+  "batchPath": "batch",
+  "kind": "discovery#restDescription"
 }

--- a/genai/internal/generativelanguage/v1beta/generativelanguage-api.json
+++ b/genai/internal/generativelanguage/v1beta/generativelanguage-api.json
@@ -1,1419 +1,1711 @@
 {
-  "kind": "discovery#restDescription",
+  "protocol": "rest",
   "mtlsRootUrl": "https://generativelanguage.mtls.googleapis.com/",
-  "version": "v1beta",
+  "icons": {
+    "x16": "http://www.google.com/images/icons/product/search-16.gif",
+    "x32": "http://www.google.com/images/icons/product/search-32.gif"
+  },
   "batchPath": "batch",
-  "schemas": {
-    "ChunkData": {
-      "type": "object",
-      "description": "Extracted data that represents the `Chunk` content.",
-      "id": "ChunkData",
-      "properties": {
-        "stringValue": {
-          "type": "string",
-          "description": "The `Chunk` content as a string. The maximum number of tokens per chunk is 2043."
-        }
-      }
+  "description": "The Gemini API allows developers to build generative AI applications using Gemini models. Gemini is our most capable model, built from the ground up to be multimodal. It can generalize and seamlessly understand, operate across, and combine different types of information including language, images, audio, video, and code. You can use the Gemini API for use cases like reasoning across text and images, content generation, dialogue agents, summarization and classification systems, and more.",
+  "servicePath": "",
+  "rootUrl": "https://generativelanguage.googleapis.com/",
+  "name": "generativelanguage",
+  "documentationLink": "https://developers.generativeai.google/api",
+  "baseUrl": "https://generativelanguage.googleapis.com/",
+  "kind": "discovery#restDescription",
+  "version_module": true,
+  "parameters": {
+    "callback": {
+      "type": "string",
+      "description": "JSONP",
+      "location": "query"
     },
-    "BatchUpdateChunksResponse": {
-      "description": "Response from `BatchUpdateChunks` containing a list of updated `Chunk`s.",
-      "properties": {
-        "chunks": {
-          "description": "`Chunk`s updated.",
-          "type": "array",
-          "items": {
-            "$ref": "Chunk"
+    "uploadType": {
+      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+      "location": "query",
+      "type": "string"
+    },
+    "fields": {
+      "description": "Selector specifying which fields to include in a partial response.",
+      "type": "string",
+      "location": "query"
+    },
+    "alt": {
+      "enum": [
+        "json",
+        "media",
+        "proto"
+      ],
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json",
+        "Media download with context-dependent Content-Type",
+        "Responses with Content-Type of application/x-protobuf"
+      ],
+      "location": "query",
+      "type": "string",
+      "default": "json",
+      "description": "Data format for response."
+    },
+    "upload_protocol": {
+      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
+      "location": "query",
+      "type": "string"
+    },
+    "$.xgafv": {
+      "location": "query",
+      "description": "V1 error format.",
+      "type": "string",
+      "enumDescriptions": [
+        "v1 error format",
+        "v2 error format"
+      ],
+      "enum": [
+        "1",
+        "2"
+      ]
+    },
+    "prettyPrint": {
+      "default": "true",
+      "type": "boolean",
+      "location": "query",
+      "description": "Returns response with indentations and line breaks."
+    },
+    "oauth_token": {
+      "description": "OAuth 2.0 token for the current user.",
+      "type": "string",
+      "location": "query"
+    },
+    "access_token": {
+      "location": "query",
+      "type": "string",
+      "description": "OAuth access token."
+    },
+    "quotaUser": {
+      "location": "query",
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+      "type": "string"
+    },
+    "key": {
+      "type": "string",
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "location": "query"
+    }
+  },
+  "discoveryVersion": "v1",
+  "fullyEncodeReservedExpansion": true,
+  "resources": {
+    "models": {
+      "methods": {
+        "batchEmbedContents": {
+          "path": "v1beta/{+model}:batchEmbedContents",
+          "parameters": {
+            "model": {
+              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
+              "location": "path",
+              "required": true,
+              "pattern": "^models/[^/]+$",
+              "type": "string"
+            }
+          },
+          "description": "Generates multiple embeddings from the model given input text in a synchronous call.",
+          "flatPath": "v1beta/models/{modelsId}:batchEmbedContents",
+          "id": "generativelanguage.models.batchEmbedContents",
+          "parameterOrder": [
+            "model"
+          ],
+          "httpMethod": "POST",
+          "response": {
+            "$ref": "BatchEmbedContentsResponse"
+          },
+          "request": {
+            "$ref": "BatchEmbedContentsRequest"
           }
-        }
-      },
-      "type": "object",
-      "id": "BatchUpdateChunksResponse"
-    },
-    "RelevantChunk": {
-      "description": "The information for a chunk relevant to a query.",
-      "properties": {
-        "chunk": {
-          "$ref": "Chunk",
-          "description": "`Chunk` associated with the query."
         },
-        "chunkRelevanceScore": {
-          "type": "number",
-          "format": "float",
-          "description": "`Chunk` relevance to the query."
-        }
-      },
-      "type": "object",
-      "id": "RelevantChunk"
-    },
-    "Permission": {
-      "properties": {
-        "granteeType": {
-          "enum": [
-            "GRANTEE_TYPE_UNSPECIFIED",
-            "USER",
-            "GROUP",
-            "EVERYONE"
-          ],
-          "description": "Optional. Immutable. The type of the grantee.",
-          "type": "string",
-          "enumDescriptions": [
-            "The default value. This value is unused.",
-            "Represents a user. When set, you must provide email_address for the user.",
-            "Represents a group. When set, you must provide email_address for the group.",
-            "Represents access to everyone. No extra information is required."
-          ]
-        },
-        "emailAddress": {
-          "type": "string",
-          "description": "Optional. Immutable. The email address of the user of group which this permission refers. Field is not set when permission's grantee type is EVERYONE."
-        },
-        "name": {
-          "type": "string",
-          "readOnly": true,
-          "description": "Output only. Identifier. The permission name. A unique name will be generated on create. Examples: tunedModels/{tuned_model}/permissions/{permission} corpora/{corpus}/permissions/{permission} Output only."
-        },
-        "role": {
-          "enum": [
-            "ROLE_UNSPECIFIED",
-            "OWNER",
-            "WRITER",
-            "READER"
-          ],
-          "description": "Required. The role granted by this permission.",
-          "enumDescriptions": [
-            "The default value. This value is unused.",
-            "Owner can use, update, share and delete the resource.",
-            "Writer can use, update and share the resource.",
-            "Reader can use the resource."
-          ],
-          "type": "string"
-        }
-      },
-      "description": "Permission resource grants user, group or the rest of the world access to the PaLM API resource (e.g. a tuned model, corpus). A role is a collection of permitted operations that allows users to perform specific actions on PaLM API resources. To make them available to users, groups, or service accounts, you assign roles. When you assign a role, you grant permissions that the role contains. There are three concentric roles. Each role is a superset of the previous role's permitted operations: - reader can use the resource (e.g. tuned model, corpus) for inference - writer has reader's permissions and additionally can edit and share - owner has writer's permissions and additionally can delete",
-      "type": "object",
-      "id": "Permission"
-    },
-    "TunedModelSource": {
-      "id": "TunedModelSource",
-      "properties": {
-        "baseModel": {
-          "readOnly": true,
-          "description": "Output only. The name of the base `Model` this `TunedModel` was tuned from. Example: `models/text-bison-001`",
-          "type": "string"
-        },
-        "tunedModel": {
-          "description": "Immutable. The name of the `TunedModel` to use as the starting point for training the new model. Example: `tunedModels/my-tuned-model`",
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "description": "Tuned model as a source for training a new model."
-    },
-    "BatchEmbedTextResponse": {
-      "properties": {
-        "embeddings": {
-          "readOnly": true,
-          "type": "array",
-          "items": {
-            "$ref": "Embedding"
+        "embedText": {
+          "path": "v1beta/{+model}:embedText",
+          "description": "Generates an embedding from the model given an input message.",
+          "flatPath": "v1beta/models/{modelsId}:embedText",
+          "httpMethod": "POST",
+          "response": {
+            "$ref": "EmbedTextResponse"
           },
-          "description": "Output only. The embeddings generated from the input text."
-        }
-      },
-      "type": "object",
-      "description": "The response to a EmbedTextRequest.",
-      "id": "BatchEmbedTextResponse"
-    },
-    "FileData": {
-      "type": "object",
-      "properties": {
-        "fileUri": {
-          "type": "string",
-          "description": "Required. URI."
-        },
-        "mimeType": {
-          "type": "string",
-          "description": "Optional. The IANA standard MIME type of the source data."
-        }
-      },
-      "description": "URI based data.",
-      "id": "FileData"
-    },
-    "QueryDocumentRequest": {
-      "id": "QueryDocumentRequest",
-      "properties": {
-        "query": {
-          "description": "Required. Query string to perform semantic search.",
-          "type": "string"
-        },
-        "metadataFilters": {
-          "items": {
-            "$ref": "MetadataFilter"
+          "request": {
+            "$ref": "EmbedTextRequest"
           },
-          "description": "Optional. Filter for `Chunk` metadata. Each `MetadataFilter` object should correspond to a unique key. Multiple `MetadataFilter` objects are joined by logical \"AND\"s. Note: `Document`-level filtering is not supported for this request because a `Document` name is already specified. Example query: (year \u003e= 2020 OR year \u003c 2010) AND (genre = drama OR genre = action) `MetadataFilter` object list: metadata_filters = [ {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2020, operation = GREATER_EQUAL}, {int_value = 2010, operation = LESS}}, {key = \"chunk.custom_metadata.genre\" conditions = [{string_value = \"drama\", operation = EQUAL}, {string_value = \"action\", operation = EQUAL}}] Example query for a numeric range of values: (year \u003e 2015 AND year \u003c= 2020) `MetadataFilter` object list: metadata_filters = [ {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2015, operation = GREATER}]}, {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2020, operation = LESS_EQUAL}]}] Note: \"AND\"s for the same key are only supported for numeric values. String values only support \"OR\"s for the same key.",
-          "type": "array"
-        },
-        "resultsCount": {
-          "type": "integer",
-          "description": "Optional. The maximum number of `Chunk`s to return. The service may return fewer `Chunk`s. If unspecified, at most 10 `Chunk`s will be returned. The maximum specified result count is 100.",
-          "format": "int32"
-        }
-      },
-      "description": "Request for querying a `Document`.",
-      "type": "object"
-    },
-    "BatchEmbedContentsResponse": {
-      "type": "object",
-      "id": "BatchEmbedContentsResponse",
-      "description": "The response to a `BatchEmbedContentsRequest`.",
-      "properties": {
-        "embeddings": {
-          "type": "array",
-          "items": {
-            "$ref": "ContentEmbedding"
+          "parameters": {
+            "model": {
+              "type": "string",
+              "required": true,
+              "description": "Required. The model name to use with the format model=models/{model}.",
+              "pattern": "^models/[^/]+$",
+              "location": "path"
+            }
           },
-          "description": "Output only. The embeddings for each request, in the same order as provided in the batch request.",
-          "readOnly": true
-        }
-      }
-    },
-    "TextPrompt": {
-      "id": "TextPrompt",
-      "description": "Text given to the model as a prompt. The Model will use this TextPrompt to Generate a text completion.",
-      "properties": {
-        "text": {
-          "description": "Required. The prompt text.",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "SafetySetting": {
-      "type": "object",
-      "id": "SafetySetting",
-      "properties": {
-        "threshold": {
-          "type": "string",
-          "description": "Required. Controls the probability threshold at which harm is blocked.",
-          "enum": [
-            "HARM_BLOCK_THRESHOLD_UNSPECIFIED",
-            "BLOCK_LOW_AND_ABOVE",
-            "BLOCK_MEDIUM_AND_ABOVE",
-            "BLOCK_ONLY_HIGH",
-            "BLOCK_NONE"
+          "parameterOrder": [
+            "model"
           ],
-          "enumDescriptions": [
-            "Threshold is unspecified.",
-            "Content with NEGLIGIBLE will be allowed.",
-            "Content with NEGLIGIBLE and LOW will be allowed.",
-            "Content with NEGLIGIBLE, LOW, and MEDIUM will be allowed.",
-            "All content will be allowed."
-          ]
+          "id": "generativelanguage.models.embedText"
         },
-        "category": {
-          "enum": [
-            "HARM_CATEGORY_UNSPECIFIED",
-            "HARM_CATEGORY_DEROGATORY",
-            "HARM_CATEGORY_TOXICITY",
-            "HARM_CATEGORY_VIOLENCE",
-            "HARM_CATEGORY_SEXUAL",
-            "HARM_CATEGORY_MEDICAL",
-            "HARM_CATEGORY_DANGEROUS",
-            "HARM_CATEGORY_HARASSMENT",
-            "HARM_CATEGORY_HATE_SPEECH",
-            "HARM_CATEGORY_SEXUALLY_EXPLICIT",
-            "HARM_CATEGORY_DANGEROUS_CONTENT"
-          ],
-          "description": "Required. The category for this setting.",
-          "type": "string",
-          "enumDescriptions": [
-            "Category is unspecified.",
-            "Negative or harmful comments targeting identity and/or protected attribute.",
-            "Content that is rude, disrespectful, or profane.",
-            "Describes scenarios depicting violence against an individual or group, or general descriptions of gore.",
-            "Contains references to sexual acts or other lewd content.",
-            "Promotes unchecked medical advice.",
-            "Dangerous content that promotes, facilitates, or encourages harmful acts.",
-            "Harasment content.",
-            "Hate speech and content.",
-            "Sexually explicit content.",
-            "Dangerous content."
-          ]
-        }
-      },
-      "description": "Safety setting, affecting the safety-blocking behavior. Passing a safety setting for a category changes the allowed probability that content is blocked."
-    },
-    "TuningSnapshot": {
-      "properties": {
-        "computeTime": {
-          "type": "string",
-          "readOnly": true,
-          "description": "Output only. The timestamp when this metric was computed.",
-          "format": "google-datetime"
-        },
-        "epoch": {
-          "format": "int32",
-          "type": "integer",
-          "readOnly": true,
-          "description": "Output only. The epoch this step was part of."
-        },
-        "step": {
-          "format": "int32",
-          "description": "Output only. The tuning step.",
-          "type": "integer",
-          "readOnly": true
-        },
-        "meanLoss": {
-          "readOnly": true,
-          "type": "number",
-          "description": "Output only. The mean loss of the training examples for this step.",
-          "format": "float"
-        }
-      },
-      "id": "TuningSnapshot",
-      "description": "Record for a single tuning step.",
-      "type": "object"
-    },
-    "BatchUpdateChunksRequest": {
-      "properties": {
-        "requests": {
-          "items": {
-            "$ref": "UpdateChunkRequest"
+        "list": {
+          "flatPath": "v1beta/models",
+          "response": {
+            "$ref": "ListModelsResponse"
           },
-          "type": "array",
-          "description": "Required. The request messages specifying the `Chunk`s to update. A maximum of 100 `Chunk`s can be updated in a batch."
-        }
-      },
-      "id": "BatchUpdateChunksRequest",
-      "description": "Request to batch update `Chunk`s.",
-      "type": "object"
-    },
-    "ListModelsResponse": {
-      "properties": {
-        "nextPageToken": {
-          "type": "string",
-          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
+          "description": "Lists models available through the API.",
+          "parameterOrder": [],
+          "path": "v1beta/models",
+          "httpMethod": "GET",
+          "parameters": {
+            "pageToken": {
+              "description": "A page token, received from a previous `ListModels` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListModels` must match the call that provided the page token.",
+              "location": "query",
+              "type": "string"
+            },
+            "pageSize": {
+              "description": "The maximum number of `Models` to return (per page). The service may return fewer models. If unspecified, at most 50 models will be returned per page. This method returns at most 1000 models per page, even if you pass a larger page_size.",
+              "location": "query",
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "id": "generativelanguage.models.list"
         },
-        "models": {
-          "type": "array",
-          "items": {
+        "embedContent": {
+          "parameters": {
+            "model": {
+              "location": "path",
+              "required": true,
+              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
+              "pattern": "^models/[^/]+$",
+              "type": "string"
+            }
+          },
+          "parameterOrder": [
+            "model"
+          ],
+          "description": "Generates an embedding from the model given an input `Content`.",
+          "request": {
+            "$ref": "EmbedContentRequest"
+          },
+          "path": "v1beta/{+model}:embedContent",
+          "httpMethod": "POST",
+          "response": {
+            "$ref": "EmbedContentResponse"
+          },
+          "flatPath": "v1beta/models/{modelsId}:embedContent",
+          "id": "generativelanguage.models.embedContent"
+        },
+        "streamGenerateContent": {
+          "flatPath": "v1beta/models/{modelsId}:streamGenerateContent",
+          "description": "Generates a streamed response from the model given an input `GenerateContentRequest`.",
+          "path": "v1beta/{+model}:streamGenerateContent",
+          "httpMethod": "POST",
+          "request": {
+            "$ref": "GenerateContentRequest"
+          },
+          "response": {
+            "$ref": "GenerateContentResponse"
+          },
+          "id": "generativelanguage.models.streamGenerateContent",
+          "parameterOrder": [
+            "model"
+          ],
+          "parameters": {
+            "model": {
+              "type": "string",
+              "pattern": "^models/[^/]+$",
+              "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`.",
+              "required": true,
+              "location": "path"
+            }
+          }
+        },
+        "countMessageTokens": {
+          "response": {
+            "$ref": "CountMessageTokensResponse"
+          },
+          "parameterOrder": [
+            "model"
+          ],
+          "flatPath": "v1beta/models/{modelsId}:countMessageTokens",
+          "path": "v1beta/{+model}:countMessageTokens",
+          "request": {
+            "$ref": "CountMessageTokensRequest"
+          },
+          "description": "Runs a model's tokenizer on a string and returns the token count.",
+          "httpMethod": "POST",
+          "id": "generativelanguage.models.countMessageTokens",
+          "parameters": {
+            "model": {
+              "location": "path",
+              "required": true,
+              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
+              "pattern": "^models/[^/]+$",
+              "type": "string"
+            }
+          }
+        },
+        "get": {
+          "parameterOrder": [
+            "name"
+          ],
+          "path": "v1beta/{+name}",
+          "httpMethod": "GET",
+          "flatPath": "v1beta/models/{modelsId}",
+          "parameters": {
+            "name": {
+              "description": "Required. The resource name of the model. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
+              "required": true,
+              "type": "string",
+              "pattern": "^models/[^/]+$",
+              "location": "path"
+            }
+          },
+          "description": "Gets information about a specific Model.",
+          "response": {
             "$ref": "Model"
           },
-          "description": "The returned Models."
-        }
-      },
-      "id": "ListModelsResponse",
-      "type": "object",
-      "description": "Response from `ListModel` containing a paginated list of Models."
-    },
-    "ListCorporaResponse": {
-      "properties": {
-        "nextPageToken": {
-          "type": "string",
-          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
+          "id": "generativelanguage.models.get"
         },
-        "corpora": {
-          "items": {
+        "generateMessage": {
+          "response": {
+            "$ref": "GenerateMessageResponse"
+          },
+          "flatPath": "v1beta/models/{modelsId}:generateMessage",
+          "id": "generativelanguage.models.generateMessage",
+          "request": {
+            "$ref": "GenerateMessageRequest"
+          },
+          "parameters": {
+            "model": {
+              "location": "path",
+              "pattern": "^models/[^/]+$",
+              "description": "Required. The name of the model to use. Format: `name=models/{model}`.",
+              "type": "string",
+              "required": true
+            }
+          },
+          "description": "Generates a response from the model given an input `MessagePrompt`.",
+          "path": "v1beta/{+model}:generateMessage",
+          "httpMethod": "POST",
+          "parameterOrder": [
+            "model"
+          ]
+        },
+        "generateContent": {
+          "description": "Generates a response from the model given an input `GenerateContentRequest`. Input capabilities differ between models, including tuned models. See the [model guide](https://ai.google.dev/models/gemini) and [tuning guide](https://ai.google.dev/docs/model_tuning_guidance) for details.",
+          "parameters": {
+            "model": {
+              "pattern": "^models/[^/]+$",
+              "required": true,
+              "type": "string",
+              "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`.",
+              "location": "path"
+            }
+          },
+          "path": "v1beta/{+model}:generateContent",
+          "id": "generativelanguage.models.generateContent",
+          "parameterOrder": [
+            "model"
+          ],
+          "flatPath": "v1beta/models/{modelsId}:generateContent",
+          "response": {
+            "$ref": "GenerateContentResponse"
+          },
+          "request": {
+            "$ref": "GenerateContentRequest"
+          },
+          "httpMethod": "POST"
+        },
+        "generateAnswer": {
+          "response": {
+            "$ref": "GenerateAnswerResponse"
+          },
+          "httpMethod": "POST",
+          "flatPath": "v1beta/models/{modelsId}:generateAnswer",
+          "description": "Generates a grounded answer from the model given an input `GenerateAnswerRequest`.",
+          "request": {
+            "$ref": "GenerateAnswerRequest"
+          },
+          "parameterOrder": [
+            "model"
+          ],
+          "path": "v1beta/{+model}:generateAnswer",
+          "id": "generativelanguage.models.generateAnswer",
+          "parameters": {
+            "model": {
+              "type": "string",
+              "pattern": "^models/[^/]+$",
+              "required": true,
+              "location": "path",
+              "description": "Required. The name of the `Model` to use for generating the grounded response. Format: `model=models/{model}`."
+            }
+          }
+        },
+        "batchEmbedText": {
+          "response": {
+            "$ref": "BatchEmbedTextResponse"
+          },
+          "path": "v1beta/{+model}:batchEmbedText",
+          "flatPath": "v1beta/models/{modelsId}:batchEmbedText",
+          "parameterOrder": [
+            "model"
+          ],
+          "id": "generativelanguage.models.batchEmbedText",
+          "description": "Generates multiple embeddings from the model given input text in a synchronous call.",
+          "request": {
+            "$ref": "BatchEmbedTextRequest"
+          },
+          "httpMethod": "POST",
+          "parameters": {
+            "model": {
+              "description": "Required. The name of the `Model` to use for generating the embedding. Examples: models/embedding-gecko-001",
+              "location": "path",
+              "required": true,
+              "pattern": "^models/[^/]+$",
+              "type": "string"
+            }
+          }
+        },
+        "generateText": {
+          "path": "v1beta/{+model}:generateText",
+          "response": {
+            "$ref": "GenerateTextResponse"
+          },
+          "flatPath": "v1beta/models/{modelsId}:generateText",
+          "id": "generativelanguage.models.generateText",
+          "request": {
+            "$ref": "GenerateTextRequest"
+          },
+          "parameterOrder": [
+            "model"
+          ],
+          "parameters": {
+            "model": {
+              "location": "path",
+              "type": "string",
+              "required": true,
+              "pattern": "^models/[^/]+$",
+              "description": "Required. The name of the `Model` or `TunedModel` to use for generating the completion. Examples: models/text-bison-001 tunedModels/sentence-translator-u3b7m"
+            }
+          },
+          "description": "Generates a response from the model given an input message.",
+          "httpMethod": "POST"
+        },
+        "countTokens": {
+          "description": "Runs a model's tokenizer on input content and returns the token count.",
+          "path": "v1beta/{+model}:countTokens",
+          "flatPath": "v1beta/models/{modelsId}:countTokens",
+          "parameterOrder": [
+            "model"
+          ],
+          "httpMethod": "POST",
+          "response": {
+            "$ref": "CountTokensResponse"
+          },
+          "id": "generativelanguage.models.countTokens",
+          "parameters": {
+            "model": {
+              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
+              "location": "path",
+              "pattern": "^models/[^/]+$",
+              "required": true,
+              "type": "string"
+            }
+          },
+          "request": {
+            "$ref": "CountTokensRequest"
+          }
+        },
+        "countTextTokens": {
+          "parameterOrder": [
+            "model"
+          ],
+          "flatPath": "v1beta/models/{modelsId}:countTextTokens",
+          "path": "v1beta/{+model}:countTextTokens",
+          "id": "generativelanguage.models.countTextTokens",
+          "parameters": {
+            "model": {
+              "required": true,
+              "type": "string",
+              "location": "path",
+              "pattern": "^models/[^/]+$",
+              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`"
+            }
+          },
+          "request": {
+            "$ref": "CountTextTokensRequest"
+          },
+          "description": "Runs a model's tokenizer on a text and returns the token count.",
+          "response": {
+            "$ref": "CountTextTokensResponse"
+          },
+          "httpMethod": "POST"
+        }
+      }
+    },
+    "corpora": {
+      "methods": {
+        "list": {
+          "response": {
+            "$ref": "ListCorporaResponse"
+          },
+          "description": "Lists all `Corpora` owned by the user.",
+          "id": "generativelanguage.corpora.list",
+          "parameterOrder": [],
+          "path": "v1beta/corpora",
+          "httpMethod": "GET",
+          "flatPath": "v1beta/corpora",
+          "parameters": {
+            "pageSize": {
+              "description": "Optional. The maximum number of `Corpora` to return (per page). The service may return fewer `Corpora`. If unspecified, at most 10 `Corpora` will be returned. The maximum size limit is 20 `Corpora` per page.",
+              "type": "integer",
+              "format": "int32",
+              "location": "query"
+            },
+            "pageToken": {
+              "description": "Optional. A page token, received from a previous `ListCorpora` call. Provide the `next_page_token` returned in the response as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListCorpora` must match the call that provided the page token.",
+              "location": "query",
+              "type": "string"
+            }
+          }
+        },
+        "query": {
+          "httpMethod": "POST",
+          "path": "v1beta/{+name}:query",
+          "id": "generativelanguage.corpora.query",
+          "response": {
+            "$ref": "QueryCorpusResponse"
+          },
+          "parameterOrder": [
+            "name"
+          ],
+          "flatPath": "v1beta/corpora/{corporaId}:query",
+          "request": {
+            "$ref": "QueryCorpusRequest"
+          },
+          "parameters": {
+            "name": {
+              "required": true,
+              "description": "Required. The name of the `Corpus` to query. Example: `corpora/my-corpus-123`",
+              "pattern": "^corpora/[^/]+$",
+              "location": "path",
+              "type": "string"
+            }
+          },
+          "description": "Performs semantic search over a `Corpus`."
+        },
+        "create": {
+          "request": {
             "$ref": "Corpus"
           },
-          "description": "The returned corpora.",
-          "type": "array"
-        }
-      },
-      "description": "Response from `ListCorpora` containing a paginated list of `Corpora`. The results are sorted by ascending `corpus.create_time`.",
-      "id": "ListCorporaResponse",
-      "type": "object"
-    },
-    "MessagePrompt": {
-      "description": "All of the structured input text passed to the model as a prompt. A `MessagePrompt` contains a structured set of fields that provide context for the conversation, examples of user input/model output message pairs that prime the model to respond in different ways, and the conversation history or list of messages representing the alternating turns of the conversation between the user and the model.",
-      "id": "MessagePrompt",
-      "properties": {
-        "context": {
-          "type": "string",
-          "description": "Optional. Text that should be provided to the model first to ground the response. If not empty, this `context` will be given to the model first before the `examples` and `messages`. When using a `context` be sure to provide it with every request to maintain continuity. This field can be a description of your prompt to the model to help provide context and guide the responses. Examples: \"Translate the phrase from English to French.\" or \"Given a statement, classify the sentiment as happy, sad or neutral.\" Anything included in this field will take precedence over message history if the total input size exceeds the model's `input_token_limit` and the input request is truncated."
-        },
-        "messages": {
-          "description": "Required. A snapshot of the recent conversation history sorted chronologically. Turns alternate between two authors. If the total input size exceeds the model's `input_token_limit` the input will be truncated: The oldest items will be dropped from `messages`.",
-          "type": "array",
-          "items": {
-            "$ref": "Message"
-          }
-        },
-        "examples": {
-          "description": "Optional. Examples of what the model should generate. This includes both user input and the response that the model should emulate. These `examples` are treated identically to conversation messages except that they take precedence over the history in `messages`: If the total input size exceeds the model's `input_token_limit` the input will be truncated. Items will be dropped from `messages` before `examples`.",
-          "type": "array",
-          "items": {
-            "$ref": "Example"
-          }
-        }
-      },
-      "type": "object"
-    },
-    "GenerateContentResponse": {
-      "properties": {
-        "usageMetadata": {
-          "$ref": "UsageMetadata",
-          "description": "Output only. Metadata on the generation requests' token usage.",
-          "readOnly": true
-        },
-        "candidates": {
-          "items": {
-            "$ref": "Candidate"
+          "response": {
+            "$ref": "Corpus"
           },
-          "description": "Candidate responses from the model.",
-          "type": "array"
+          "parameterOrder": [],
+          "flatPath": "v1beta/corpora",
+          "httpMethod": "POST",
+          "parameters": {},
+          "description": "Creates an empty `Corpus`.",
+          "path": "v1beta/corpora",
+          "id": "generativelanguage.corpora.create"
         },
-        "promptFeedback": {
-          "$ref": "PromptFeedback",
-          "description": "Returns the prompt's feedback related to the content filters."
-        }
-      },
-      "type": "object",
-      "description": "Response from the model supporting multiple candidates. Note on safety ratings and content filtering. They are reported for both prompt in `GenerateContentResponse.prompt_feedback` and for each candidate in `finish_reason` and in `safety_ratings`. The API contract is that: - either all requested candidates are returned or no candidates at all - no candidates are returned only if there was something wrong with the prompt (see `prompt_feedback`) - feedback on each candidate is reported on `finish_reason` and `safety_ratings`.",
-      "id": "GenerateContentResponse"
-    },
-    "TuningExamples": {
-      "description": "A set of tuning examples. Can be training or validation data.",
-      "type": "object",
-      "properties": {
-        "examples": {
-          "type": "array",
-          "description": "Required. The examples. Example input can be for text or discuss, but all examples in a set must be of the same type.",
-          "items": {
-            "$ref": "TuningExample"
-          }
-        }
-      },
-      "id": "TuningExamples"
-    },
-    "CreateFileResponse": {
-      "type": "object",
-      "id": "CreateFileResponse",
-      "properties": {
-        "file": {
-          "$ref": "File",
-          "description": "Metadata for the created file."
-        }
-      },
-      "description": "Response for `CreateFile`."
-    },
-    "QueryDocumentResponse": {
-      "properties": {
-        "relevantChunks": {
-          "description": "The returned relevant chunks.",
-          "type": "array",
-          "items": {
-            "$ref": "RelevantChunk"
-          }
-        }
-      },
-      "type": "object",
-      "id": "QueryDocumentResponse",
-      "description": "Response from `QueryDocument` containing a list of relevant chunks."
-    },
-    "CachedContent": {
-      "type": "object",
-      "properties": {
-        "ttl": {
-          "format": "google-duration",
-          "type": "string",
-          "description": "Input only. New TTL for this resource, input only."
-        },
-        "createTime": {
-          "readOnly": true,
-          "format": "google-datetime",
-          "description": "Output only. Creation time of the cache entry.",
-          "type": "string"
-        },
-        "model": {
-          "type": "string",
-          "description": "Required. Immutable. The name of the `Model` to use for cached content Format: `models/{model}`"
-        },
-        "contents": {
-          "type": "array",
-          "items": {
-            "$ref": "Content"
-          },
-          "description": "Optional. Input only. Immutable. The content to cache."
-        },
-        "displayName": {
-          "description": "Optional. Immutable. The user-generated meaningful display name of the cached content. Maximum 128 Unicode characters.",
-          "type": "string"
-        },
-        "toolConfig": {
-          "$ref": "ToolConfig",
-          "description": "Optional. Input only. Immutable. Tool config. This config is shared for all tools."
-        },
-        "expireTime": {
-          "format": "google-datetime",
-          "description": "Timestamp in UTC of when this resource is considered expired. This is *always* provided on output, regardless of what was sent on input.",
-          "type": "string"
-        },
-        "updateTime": {
-          "description": "Output only. When the cache entry was last updated in UTC time.",
-          "type": "string",
-          "format": "google-datetime",
-          "readOnly": true
-        },
-        "name": {
-          "description": "Optional. Identifier. The resource name referring to the cached content. Format: `cachedContents/{id}`",
-          "type": "string"
-        },
-        "systemInstruction": {
-          "$ref": "Content",
-          "description": "Optional. Input only. Immutable. Developer set system instruction. Currently text only."
-        },
-        "tools": {
-          "type": "array",
-          "description": "Optional. Input only. Immutable. A list of `Tools` the model may use to generate the next response",
-          "items": {
-            "$ref": "Tool"
-          }
-        },
-        "usageMetadata": {
-          "description": "Output only. Metadata on the usage of the cached content.",
-          "readOnly": true,
-          "$ref": "CachedContentUsageMetadata"
-        }
-      },
-      "description": "Content that has been preprocessed and can be used in subsequent request to GenerativeService. Cached content can be only used with model it was created for.",
-      "id": "CachedContent"
-    },
-    "PromptFeedback": {
-      "properties": {
-        "safetyRatings": {
-          "type": "array",
-          "items": {
-            "$ref": "SafetyRating"
-          },
-          "description": "Ratings for safety of the prompt. There is at most one rating per category."
-        },
-        "blockReason": {
-          "enumDescriptions": [
-            "Default value. This value is unused.",
-            "Prompt was blocked due to safety reasons. You can inspect `safety_ratings` to understand which safety category blocked it.",
-            "Prompt was blocked due to unknown reasons."
+        "patch": {
+          "parameterOrder": [
+            "name"
           ],
-          "description": "Optional. If set, the prompt was blocked and no candidates are returned. Rephrase your prompt.",
-          "type": "string",
-          "enum": [
-            "BLOCK_REASON_UNSPECIFIED",
-            "SAFETY",
-            "OTHER"
-          ]
-        }
-      },
-      "id": "PromptFeedback",
-      "description": "A set of the feedback metadata the prompt specified in `GenerateContentRequest.content`.",
-      "type": "object"
-    },
-    "FunctionCall": {
-      "type": "object",
-      "properties": {
-        "args": {
-          "description": "Optional. The function parameters and values in JSON object format.",
-          "additionalProperties": {
-            "description": "Properties of the object.",
-            "type": "any"
+          "id": "generativelanguage.corpora.patch",
+          "response": {
+            "$ref": "Corpus"
           },
-          "type": "object"
-        },
-        "name": {
-          "type": "string",
-          "description": "Required. The name of the function to call. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
-        }
-      },
-      "description": "A predicted `FunctionCall` returned from the model that contains a string representing the `FunctionDeclaration.name` with the arguments and their values.",
-      "id": "FunctionCall"
-    },
-    "Schema": {
-      "description": "The `Schema` object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. Represents a select subset of an [OpenAPI 3.0 schema object](https://spec.openapis.org/oas/v3.0.3#schema).",
-      "type": "object",
-      "properties": {
-        "enum": {
-          "type": "array",
-          "description": "Optional. Possible values of the element of Type.STRING with enum format. For example we can define an Enum Direction as : {type:STRING, format:enum, enum:[\"EAST\", NORTH\", \"SOUTH\", \"WEST\"]}",
-          "items": {
-            "type": "string"
-          }
-        },
-        "properties": {
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "Schema"
+          "request": {
+            "$ref": "Corpus"
           },
-          "description": "Optional. Properties of Type.OBJECT."
+          "httpMethod": "PATCH",
+          "flatPath": "v1beta/corpora/{corporaId}",
+          "parameters": {
+            "name": {
+              "location": "path",
+              "description": "Immutable. Identifier. The `Corpus` resource name. The ID (name excluding the \"corpora/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/my-awesome-corpora-123a456b789c`",
+              "pattern": "^corpora/[^/]+$",
+              "type": "string",
+              "required": true
+            },
+            "updateMask": {
+              "description": "Required. The list of fields to update. Currently, this only supports updating `display_name`.",
+              "format": "google-fieldmask",
+              "location": "query",
+              "type": "string"
+            }
+          },
+          "description": "Updates a `Corpus`.",
+          "path": "v1beta/{+name}"
         },
-        "format": {
-          "type": "string",
-          "description": "Optional. The format of the data. This is used only for primitive datatypes. Supported formats: for NUMBER type: float, double for INTEGER type: int32, int64"
-        },
-        "description": {
-          "description": "Optional. A brief description of the parameter. This could contain examples of use. Parameter description may be formatted as Markdown.",
-          "type": "string"
-        },
-        "required": {
-          "type": "array",
-          "description": "Optional. Required properties of Type.OBJECT.",
-          "items": {
-            "type": "string"
-          }
-        },
-        "items": {
-          "description": "Optional. Schema of the elements of Type.ARRAY.",
-          "$ref": "Schema"
-        },
-        "nullable": {
-          "type": "boolean",
-          "description": "Optional. Indicates if the value may be null."
-        },
-        "type": {
-          "enum": [
-            "TYPE_UNSPECIFIED",
-            "STRING",
-            "NUMBER",
-            "INTEGER",
-            "BOOLEAN",
-            "ARRAY",
-            "OBJECT"
+        "delete": {
+          "path": "v1beta/{+name}",
+          "parameters": {
+            "name": {
+              "location": "path",
+              "type": "string",
+              "required": true,
+              "description": "Required. The resource name of the `Corpus`. Example: `corpora/my-corpus-123`",
+              "pattern": "^corpora/[^/]+$"
+            },
+            "force": {
+              "location": "query",
+              "type": "boolean",
+              "description": "Optional. If set to true, any `Document`s and objects related to this `Corpus` will also be deleted. If false (the default), a `FAILED_PRECONDITION` error will be returned if `Corpus` contains any `Document`s."
+            }
+          },
+          "response": {
+            "$ref": "Empty"
+          },
+          "id": "generativelanguage.corpora.delete",
+          "parameterOrder": [
+            "name"
           ],
-          "description": "Required. Data type.",
-          "type": "string",
-          "enumDescriptions": [
-            "Not specified, should not be used.",
-            "String type.",
-            "Number type.",
-            "Integer type.",
-            "Boolean type.",
-            "Array type.",
-            "Object type."
-          ]
-        }
-      },
-      "id": "Schema"
-    },
-    "CreateFileRequest": {
-      "properties": {
-        "file": {
-          "$ref": "File",
-          "description": "Optional. Metadata for the file to create."
-        }
-      },
-      "type": "object",
-      "id": "CreateFileRequest",
-      "description": "Request for `CreateFile`."
-    },
-    "Operation": {
-      "description": "This resource represents a long-running operation that is the result of a network API call.",
-      "properties": {
-        "error": {
-          "$ref": "Status",
-          "description": "The error result of the operation in case of failure or cancellation."
+          "flatPath": "v1beta/corpora/{corporaId}",
+          "description": "Deletes a `Corpus`.",
+          "httpMethod": "DELETE"
         },
-        "metadata": {
-          "description": "Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "any",
-            "description": "Properties of the object. Contains field @type with type URL."
+        "get": {
+          "flatPath": "v1beta/corpora/{corporaId}",
+          "parameters": {
+            "name": {
+              "required": true,
+              "type": "string",
+              "description": "Required. The name of the `Corpus`. Example: `corpora/my-corpus-123`",
+              "location": "path",
+              "pattern": "^corpora/[^/]+$"
+            }
+          },
+          "httpMethod": "GET",
+          "description": "Gets information about a specific `Corpus`.",
+          "parameterOrder": [
+            "name"
+          ],
+          "path": "v1beta/{+name}",
+          "id": "generativelanguage.corpora.get",
+          "response": {
+            "$ref": "Corpus"
+          }
+        }
+      },
+      "resources": {
+        "permissions": {
+          "methods": {
+            "create": {
+              "parameterOrder": [
+                "parent"
+              ],
+              "description": "Create a permission to a specific resource.",
+              "response": {
+                "$ref": "Permission"
+              },
+              "id": "generativelanguage.corpora.permissions.create",
+              "flatPath": "v1beta/corpora/{corporaId}/permissions",
+              "parameters": {
+                "parent": {
+                  "location": "path",
+                  "required": true,
+                  "pattern": "^corpora/[^/]+$",
+                  "type": "string",
+                  "description": "Required. The parent resource of the `Permission`. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`"
+                }
+              },
+              "httpMethod": "POST",
+              "path": "v1beta/{+parent}/permissions",
+              "request": {
+                "$ref": "Permission"
+              }
+            },
+            "patch": {
+              "parameterOrder": [
+                "name"
+              ],
+              "id": "generativelanguage.corpora.permissions.patch",
+              "httpMethod": "PATCH",
+              "description": "Updates the permission.",
+              "parameters": {
+                "updateMask": {
+                  "description": "Required. The list of fields to update. Accepted ones: - role (`Permission.role` field)",
+                  "format": "google-fieldmask",
+                  "location": "query",
+                  "type": "string"
+                },
+                "name": {
+                  "location": "path",
+                  "description": "Output only. Identifier. The permission name. A unique name will be generated on create. Examples: tunedModels/{tuned_model}/permissions/{permission} corpora/{corpus}/permissions/{permission} Output only.",
+                  "required": true,
+                  "pattern": "^corpora/[^/]+/permissions/[^/]+$",
+                  "type": "string"
+                }
+              },
+              "response": {
+                "$ref": "Permission"
+              },
+              "path": "v1beta/{+name}",
+              "request": {
+                "$ref": "Permission"
+              },
+              "flatPath": "v1beta/corpora/{corporaId}/permissions/{permissionsId}"
+            },
+            "list": {
+              "response": {
+                "$ref": "ListPermissionsResponse"
+              },
+              "id": "generativelanguage.corpora.permissions.list",
+              "flatPath": "v1beta/corpora/{corporaId}/permissions",
+              "path": "v1beta/{+parent}/permissions",
+              "parameters": {
+                "parent": {
+                  "required": true,
+                  "description": "Required. The parent resource of the permissions. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`",
+                  "location": "path",
+                  "type": "string",
+                  "pattern": "^corpora/[^/]+$"
+                },
+                "pageToken": {
+                  "description": "Optional. A page token, received from a previous `ListPermissions` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListPermissions` must match the call that provided the page token.",
+                  "location": "query",
+                  "type": "string"
+                },
+                "pageSize": {
+                  "format": "int32",
+                  "description": "Optional. The maximum number of `Permission`s to return (per page). The service may return fewer permissions. If unspecified, at most 10 permissions will be returned. This method returns at most 1000 permissions per page, even if you pass larger page_size.",
+                  "type": "integer",
+                  "location": "query"
+                }
+              },
+              "httpMethod": "GET",
+              "parameterOrder": [
+                "parent"
+              ],
+              "description": "Lists permissions for the specific resource."
+            },
+            "delete": {
+              "parameterOrder": [
+                "name"
+              ],
+              "response": {
+                "$ref": "Empty"
+              },
+              "description": "Deletes the permission.",
+              "flatPath": "v1beta/corpora/{corporaId}/permissions/{permissionsId}",
+              "httpMethod": "DELETE",
+              "parameters": {
+                "name": {
+                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
+                  "required": true,
+                  "location": "path",
+                  "type": "string",
+                  "pattern": "^corpora/[^/]+/permissions/[^/]+$"
+                }
+              },
+              "id": "generativelanguage.corpora.permissions.delete",
+              "path": "v1beta/{+name}"
+            },
+            "get": {
+              "response": {
+                "$ref": "Permission"
+              },
+              "httpMethod": "GET",
+              "parameterOrder": [
+                "name"
+              ],
+              "description": "Gets information about a specific Permission.",
+              "path": "v1beta/{+name}",
+              "parameters": {
+                "name": {
+                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
+                  "required": true,
+                  "location": "path",
+                  "type": "string",
+                  "pattern": "^corpora/[^/]+/permissions/[^/]+$"
+                }
+              },
+              "id": "generativelanguage.corpora.permissions.get",
+              "flatPath": "v1beta/corpora/{corporaId}/permissions/{permissionsId}"
+            }
           }
         },
-        "response": {
-          "description": "The normal, successful response of the operation. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`.",
-          "additionalProperties": {
-            "type": "any",
-            "description": "Properties of the object. Contains field @type with type URL."
+        "documents": {
+          "methods": {
+            "create": {
+              "flatPath": "v1beta/corpora/{corporaId}/documents",
+              "request": {
+                "$ref": "Document"
+              },
+              "parameterOrder": [
+                "parent"
+              ],
+              "httpMethod": "POST",
+              "parameters": {
+                "parent": {
+                  "type": "string",
+                  "pattern": "^corpora/[^/]+$",
+                  "description": "Required. The name of the `Corpus` where this `Document` will be created. Example: `corpora/my-corpus-123`",
+                  "location": "path",
+                  "required": true
+                }
+              },
+              "path": "v1beta/{+parent}/documents",
+              "response": {
+                "$ref": "Document"
+              },
+              "id": "generativelanguage.corpora.documents.create",
+              "description": "Creates an empty `Document`."
+            },
+            "list": {
+              "id": "generativelanguage.corpora.documents.list",
+              "path": "v1beta/{+parent}/documents",
+              "parameterOrder": [
+                "parent"
+              ],
+              "flatPath": "v1beta/corpora/{corporaId}/documents",
+              "response": {
+                "$ref": "ListDocumentsResponse"
+              },
+              "httpMethod": "GET",
+              "parameters": {
+                "pageToken": {
+                  "location": "query",
+                  "type": "string",
+                  "description": "Optional. A page token, received from a previous `ListDocuments` call. Provide the `next_page_token` returned in the response as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListDocuments` must match the call that provided the page token."
+                },
+                "parent": {
+                  "pattern": "^corpora/[^/]+$",
+                  "location": "path",
+                  "required": true,
+                  "type": "string",
+                  "description": "Required. The name of the `Corpus` containing `Document`s. Example: `corpora/my-corpus-123`"
+                },
+                "pageSize": {
+                  "description": "Optional. The maximum number of `Document`s to return (per page). The service may return fewer `Document`s. If unspecified, at most 10 `Document`s will be returned. The maximum size limit is 20 `Document`s per page.",
+                  "format": "int32",
+                  "type": "integer",
+                  "location": "query"
+                }
+              },
+              "description": "Lists all `Document`s in a `Corpus`."
+            },
+            "get": {
+              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}",
+              "description": "Gets information about a specific `Document`.",
+              "response": {
+                "$ref": "Document"
+              },
+              "id": "generativelanguage.corpora.documents.get",
+              "parameters": {
+                "name": {
+                  "description": "Required. The name of the `Document` to retrieve. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
+                  "type": "string",
+                  "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                  "required": true,
+                  "location": "path"
+                }
+              },
+              "path": "v1beta/{+name}",
+              "httpMethod": "GET",
+              "parameterOrder": [
+                "name"
+              ]
+            },
+            "query": {
+              "path": "v1beta/{+name}:query",
+              "id": "generativelanguage.corpora.documents.query",
+              "httpMethod": "POST",
+              "parameterOrder": [
+                "name"
+              ],
+              "parameters": {
+                "name": {
+                  "location": "path",
+                  "description": "Required. The name of the `Document` to query. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
+                  "type": "string",
+                  "required": true,
+                  "pattern": "^corpora/[^/]+/documents/[^/]+$"
+                }
+              },
+              "request": {
+                "$ref": "QueryDocumentRequest"
+              },
+              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}:query",
+              "response": {
+                "$ref": "QueryDocumentResponse"
+              },
+              "description": "Performs semantic search over a `Document`."
+            },
+            "patch": {
+              "httpMethod": "PATCH",
+              "description": "Updates a `Document`.",
+              "parameterOrder": [
+                "name"
+              ],
+              "parameters": {
+                "name": {
+                  "description": "Immutable. Identifier. The `Document` resource name. The ID (name excluding the \"corpora/*/documents/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/{corpus_id}/documents/my-awesome-doc-123a456b789c`",
+                  "type": "string",
+                  "required": true,
+                  "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                  "location": "path"
+                },
+                "updateMask": {
+                  "type": "string",
+                  "description": "Required. The list of fields to update. Currently, this only supports updating `display_name` and `custom_metadata`.",
+                  "location": "query",
+                  "format": "google-fieldmask"
+                }
+              },
+              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}",
+              "response": {
+                "$ref": "Document"
+              },
+              "id": "generativelanguage.corpora.documents.patch",
+              "path": "v1beta/{+name}",
+              "request": {
+                "$ref": "Document"
+              }
+            },
+            "delete": {
+              "id": "generativelanguage.corpora.documents.delete",
+              "parameters": {
+                "name": {
+                  "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                  "type": "string",
+                  "required": true,
+                  "location": "path",
+                  "description": "Required. The resource name of the `Document` to delete. Example: `corpora/my-corpus-123/documents/the-doc-abc`"
+                },
+                "force": {
+                  "description": "Optional. If set to true, any `Chunk`s and objects related to this `Document` will also be deleted. If false (the default), a `FAILED_PRECONDITION` error will be returned if `Document` contains any `Chunk`s.",
+                  "type": "boolean",
+                  "location": "query"
+                }
+              },
+              "description": "Deletes a `Document`.",
+              "response": {
+                "$ref": "Empty"
+              },
+              "httpMethod": "DELETE",
+              "path": "v1beta/{+name}",
+              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}",
+              "parameterOrder": [
+                "name"
+              ]
+            }
           },
-          "type": "object"
-        },
-        "done": {
-          "type": "boolean",
-          "description": "If the value is `false`, it means the operation is still in progress. If `true`, the operation is completed, and either `error` or `response` is available."
-        },
-        "name": {
-          "type": "string",
-          "description": "The server-assigned name, which is only unique within the same service that originally returns it. If you use the default HTTP mapping, the `name` should be a resource name ending with `operations/{unique_id}`."
-        }
-      },
-      "id": "Operation",
-      "type": "object"
-    },
-    "Dataset": {
-      "id": "Dataset",
-      "properties": {
-        "examples": {
-          "$ref": "TuningExamples",
-          "description": "Optional. Inline examples."
-        }
-      },
-      "description": "Dataset for training or validation.",
-      "type": "object"
-    },
-    "ListTunedModelsResponse": {
-      "description": "Response from `ListTunedModels` containing a paginated list of Models.",
-      "type": "object",
-      "properties": {
-        "tunedModels": {
-          "items": {
-            "$ref": "TunedModel"
-          },
-          "description": "The returned Models.",
-          "type": "array"
-        },
-        "nextPageToken": {
-          "type": "string",
-          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
-        }
-      },
-      "id": "ListTunedModelsResponse"
-    },
-    "CitationMetadata": {
-      "id": "CitationMetadata",
-      "description": "A collection of source attributions for a piece of content.",
-      "type": "object",
-      "properties": {
-        "citationSources": {
-          "items": {
-            "$ref": "CitationSource"
-          },
-          "description": "Citations to sources for a specific response.",
-          "type": "array"
+          "resources": {
+            "chunks": {
+              "methods": {
+                "create": {
+                  "request": {
+                    "$ref": "Chunk"
+                  },
+                  "parameters": {
+                    "parent": {
+                      "type": "string",
+                      "location": "path",
+                      "required": true,
+                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                      "description": "Required. The name of the `Document` where this `Chunk` will be created. Example: `corpora/my-corpus-123/documents/the-doc-abc`"
+                    }
+                  },
+                  "description": "Creates a `Chunk`.",
+                  "path": "v1beta/{+parent}/chunks",
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks",
+                  "httpMethod": "POST",
+                  "id": "generativelanguage.corpora.documents.chunks.create",
+                  "response": {
+                    "$ref": "Chunk"
+                  },
+                  "parameterOrder": [
+                    "parent"
+                  ]
+                },
+                "patch": {
+                  "httpMethod": "PATCH",
+                  "path": "v1beta/{+name}",
+                  "parameters": {
+                    "updateMask": {
+                      "location": "query",
+                      "type": "string",
+                      "format": "google-fieldmask",
+                      "description": "Required. The list of fields to update. Currently, this only supports updating `custom_metadata` and `data`."
+                    },
+                    "name": {
+                      "required": true,
+                      "pattern": "^corpora/[^/]+/documents/[^/]+/chunks/[^/]+$",
+                      "location": "path",
+                      "type": "string",
+                      "description": "Immutable. Identifier. The `Chunk` resource name. The ID (name excluding the \"corpora/*/documents/*/chunks/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a random 12-character unique ID will be generated. Example: `corpora/{corpus_id}/documents/{document_id}/chunks/123a456b789c`"
+                    }
+                  },
+                  "request": {
+                    "$ref": "Chunk"
+                  },
+                  "id": "generativelanguage.corpora.documents.chunks.patch",
+                  "description": "Updates a `Chunk`.",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks/{chunksId}",
+                  "response": {
+                    "$ref": "Chunk"
+                  }
+                },
+                "batchDelete": {
+                  "id": "generativelanguage.corpora.documents.chunks.batchDelete",
+                  "request": {
+                    "$ref": "BatchDeleteChunksRequest"
+                  },
+                  "parameters": {
+                    "parent": {
+                      "type": "string",
+                      "location": "path",
+                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                      "required": true,
+                      "description": "Optional. The name of the `Document` containing the `Chunk`s to delete. The parent field in every `DeleteChunkRequest` must match this value. Example: `corpora/my-corpus-123/documents/the-doc-abc`"
+                    }
+                  },
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "path": "v1beta/{+parent}/chunks:batchDelete",
+                  "httpMethod": "POST",
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks:batchDelete",
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "description": "Batch delete `Chunk`s."
+                },
+                "batchUpdate": {
+                  "path": "v1beta/{+parent}/chunks:batchUpdate",
+                  "id": "generativelanguage.corpora.documents.chunks.batchUpdate",
+                  "response": {
+                    "$ref": "BatchUpdateChunksResponse"
+                  },
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "httpMethod": "POST",
+                  "description": "Batch update `Chunk`s.",
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks:batchUpdate",
+                  "request": {
+                    "$ref": "BatchUpdateChunksRequest"
+                  },
+                  "parameters": {
+                    "parent": {
+                      "description": "Optional. The name of the `Document` containing the `Chunk`s to update. The parent field in every `UpdateChunkRequest` must match this value. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
+                      "location": "path",
+                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                      "type": "string",
+                      "required": true
+                    }
+                  }
+                },
+                "batchCreate": {
+                  "request": {
+                    "$ref": "BatchCreateChunksRequest"
+                  },
+                  "path": "v1beta/{+parent}/chunks:batchCreate",
+                  "id": "generativelanguage.corpora.documents.chunks.batchCreate",
+                  "httpMethod": "POST",
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks:batchCreate",
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "description": "Batch create `Chunk`s.",
+                  "response": {
+                    "$ref": "BatchCreateChunksResponse"
+                  },
+                  "parameters": {
+                    "parent": {
+                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
+                      "type": "string",
+                      "description": "Optional. The name of the `Document` where this batch of `Chunk`s will be created. The parent field in every `CreateChunkRequest` must match this value. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
+                      "location": "path",
+                      "required": true
+                    }
+                  }
+                },
+                "get": {
+                  "path": "v1beta/{+name}",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "id": "generativelanguage.corpora.documents.chunks.get",
+                  "description": "Gets information about a specific `Chunk`.",
+                  "parameters": {
+                    "name": {
+                      "location": "path",
+                      "required": true,
+                      "type": "string",
+                      "pattern": "^corpora/[^/]+/documents/[^/]+/chunks/[^/]+$",
+                      "description": "Required. The name of the `Chunk` to retrieve. Example: `corpora/my-corpus-123/documents/the-doc-abc/chunks/some-chunk`"
+                    }
+                  },
+                  "httpMethod": "GET",
+                  "response": {
+                    "$ref": "Chunk"
+                  },
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks/{chunksId}"
+                },
+                "delete": {
+                  "path": "v1beta/{+name}",
+                  "parameterOrder": [
+                    "name"
+                  ],
+                  "httpMethod": "DELETE",
+                  "description": "Deletes a `Chunk`.",
+                  "id": "generativelanguage.corpora.documents.chunks.delete",
+                  "parameters": {
+                    "name": {
+                      "pattern": "^corpora/[^/]+/documents/[^/]+/chunks/[^/]+$",
+                      "type": "string",
+                      "required": true,
+                      "description": "Required. The resource name of the `Chunk` to delete. Example: `corpora/my-corpus-123/documents/the-doc-abc/chunks/some-chunk`",
+                      "location": "path"
+                    }
+                  },
+                  "response": {
+                    "$ref": "Empty"
+                  },
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks/{chunksId}"
+                },
+                "list": {
+                  "description": "Lists all `Chunk`s in a `Document`.",
+                  "parameters": {
+                    "pageSize": {
+                      "location": "query",
+                      "description": "Optional. The maximum number of `Chunk`s to return (per page). The service may return fewer `Chunk`s. If unspecified, at most 10 `Chunk`s will be returned. The maximum size limit is 100 `Chunk`s per page.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "parent": {
+                      "required": true,
+                      "location": "path",
+                      "type": "string",
+                      "description": "Required. The name of the `Document` containing `Chunk`s. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
+                      "pattern": "^corpora/[^/]+/documents/[^/]+$"
+                    },
+                    "pageToken": {
+                      "type": "string",
+                      "location": "query",
+                      "description": "Optional. A page token, received from a previous `ListChunks` call. Provide the `next_page_token` returned in the response as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListChunks` must match the call that provided the page token."
+                    }
+                  },
+                  "response": {
+                    "$ref": "ListChunksResponse"
+                  },
+                  "id": "generativelanguage.corpora.documents.chunks.list",
+                  "httpMethod": "GET",
+                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks",
+                  "parameterOrder": [
+                    "parent"
+                  ],
+                  "path": "v1beta/{+parent}/chunks"
+                }
+              }
+            }
+          }
         }
       }
     },
-    "CachedContentUsageMetadata": {
-      "description": "Metadata on the usage of the cached content.",
-      "id": "CachedContentUsageMetadata",
-      "type": "object",
-      "properties": {
-        "totalTokenCount": {
-          "type": "integer",
-          "description": "Total number of tokens that the cached content consumes.",
-          "format": "int32"
-        }
-      }
-    },
-    "VideoMetadata": {
-      "description": "Metadata for a video `File`.",
-      "id": "VideoMetadata",
-      "properties": {
-        "videoDuration": {
-          "format": "google-duration",
-          "description": "Duration of the video.",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "ListFilesResponse": {
-      "id": "ListFilesResponse",
-      "properties": {
-        "files": {
-          "items": {
+    "files": {
+      "methods": {
+        "get": {
+          "id": "generativelanguage.files.get",
+          "httpMethod": "GET",
+          "response": {
             "$ref": "File"
           },
-          "description": "The list of `File`s.",
-          "type": "array"
+          "description": "Gets the metadata for the given `File`.",
+          "path": "v1beta/{+name}",
+          "parameterOrder": [
+            "name"
+          ],
+          "flatPath": "v1beta/files/{filesId}",
+          "parameters": {
+            "name": {
+              "required": true,
+              "type": "string",
+              "description": "Required. The name of the `File` to get. Example: `files/abc-123`",
+              "pattern": "^files/[^/]+$",
+              "location": "path"
+            }
+          }
         },
-        "nextPageToken": {
-          "type": "string",
-          "description": "A token that can be sent as a `page_token` into a subsequent `ListFiles` call."
-        }
-      },
-      "type": "object",
-      "description": "Response for `ListFiles`."
-    },
-    "QueryCorpusResponse": {
-      "description": "Response from `QueryCorpus` containing a list of relevant chunks.",
-      "id": "QueryCorpusResponse",
-      "properties": {
-        "relevantChunks": {
-          "description": "The relevant chunks.",
-          "items": {
-            "$ref": "RelevantChunk"
+        "list": {
+          "description": "Lists the metadata for `File`s owned by the requesting project.",
+          "parameterOrder": [],
+          "flatPath": "v1beta/files",
+          "httpMethod": "GET",
+          "response": {
+            "$ref": "ListFilesResponse"
           },
-          "type": "array"
-        }
-      },
-      "type": "object"
-    },
-    "Empty": {
-      "type": "object",
-      "description": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); }",
-      "id": "Empty",
-      "properties": {}
-    },
-    "FunctionDeclaration": {
-      "description": "Structured representation of a function declaration as defined by the [OpenAPI 3.03 specification](https://spec.openapis.org/oas/v3.0.3). Included in this declaration are the function name and parameters. This FunctionDeclaration is a representation of a block of code that can be used as a `Tool` by the model and executed by the client.",
-      "type": "object",
-      "id": "FunctionDeclaration",
-      "properties": {
-        "name": {
-          "description": "Required. The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63.",
-          "type": "string"
+          "parameters": {
+            "pageSize": {
+              "description": "Optional. Maximum number of `File`s to return per page. If unspecified, defaults to 10. Maximum `page_size` is 100.",
+              "location": "query",
+              "type": "integer",
+              "format": "int32"
+            },
+            "pageToken": {
+              "description": "Optional. A page token from a previous `ListFiles` call.",
+              "type": "string",
+              "location": "query"
+            }
+          },
+          "path": "v1beta/files",
+          "id": "generativelanguage.files.list"
         },
-        "parameters": {
-          "$ref": "Schema",
-          "description": "Optional. Describes the parameters to this function. Reflects the Open API 3.03 Parameter Object string Key: the name of the parameter. Parameter names are case sensitive. Schema Value: the Schema defining the type used for the parameter."
-        },
-        "description": {
-          "type": "string",
-          "description": "Required. A brief description of the function."
+        "delete": {
+          "parameterOrder": [
+            "name"
+          ],
+          "response": {
+            "$ref": "Empty"
+          },
+          "description": "Deletes the `File`.",
+          "path": "v1beta/{+name}",
+          "httpMethod": "DELETE",
+          "id": "generativelanguage.files.delete",
+          "flatPath": "v1beta/files/{filesId}",
+          "parameters": {
+            "name": {
+              "required": true,
+              "location": "path",
+              "pattern": "^files/[^/]+$",
+              "type": "string",
+              "description": "Required. The name of the `File` to delete. Example: `files/abc-123`"
+            }
+          }
         }
       }
     },
-    "BatchCreateChunksRequest": {
-      "description": "Request to batch create `Chunk`s.",
-      "properties": {
-        "requests": {
-          "description": "Required. The request messages specifying the `Chunk`s to create. A maximum of 100 `Chunk`s can be created in a batch.",
-          "items": {
-            "$ref": "CreateChunkRequest"
+    "cachedContents": {
+      "methods": {
+        "get": {
+          "parameters": {
+            "name": {
+              "type": "string",
+              "pattern": "^cachedContents/[^/]+$",
+              "location": "path",
+              "description": "Required. The resource name referring to the content cache entry. Format: `cachedContents/{id}`",
+              "required": true
+            }
           },
-          "type": "array"
-        }
-      },
-      "type": "object",
-      "id": "BatchCreateChunksRequest"
-    },
-    "StringList": {
-      "type": "object",
-      "properties": {
-        "values": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "The string values of the metadata to store."
-        }
-      },
-      "description": "User provided string values assigned to a single metadata key.",
-      "id": "StringList"
-    },
-    "GroundingPassages": {
-      "type": "object",
-      "properties": {
-        "passages": {
-          "items": {
-            "$ref": "GroundingPassage"
-          },
-          "type": "array",
-          "description": "List of passages."
-        }
-      },
-      "description": "A repeated list of passages.",
-      "id": "GroundingPassages"
-    },
-    "GroundingAttribution": {
-      "type": "object",
-      "id": "GroundingAttribution",
-      "properties": {
-        "content": {
-          "description": "Grounding source content that makes up this attribution.",
-          "$ref": "Content"
+          "flatPath": "v1beta/cachedContents/{cachedContentsId}",
+          "parameterOrder": [
+            "name"
+          ],
+          "id": "generativelanguage.cachedContents.get",
+          "httpMethod": "GET",
+          "path": "v1beta/{+name}",
+          "description": "Reads CachedContent resource.",
+          "response": {
+            "$ref": "CachedContent"
+          }
         },
-        "sourceId": {
-          "$ref": "AttributionSourceId",
-          "description": "Output only. Identifier for the source contributing to this attribution.",
-          "readOnly": true
+        "patch": {
+          "description": "Updates CachedContent resource (only expiration is updatable).",
+          "httpMethod": "PATCH",
+          "id": "generativelanguage.cachedContents.patch",
+          "flatPath": "v1beta/cachedContents/{cachedContentsId}",
+          "response": {
+            "$ref": "CachedContent"
+          },
+          "parameterOrder": [
+            "name"
+          ],
+          "path": "v1beta/{+name}",
+          "parameters": {
+            "name": {
+              "description": "Optional. Identifier. The resource name referring to the cached content. Format: `cachedContents/{id}`",
+              "type": "string",
+              "location": "path",
+              "required": true,
+              "pattern": "^cachedContents/[^/]+$"
+            },
+            "updateMask": {
+              "type": "string",
+              "location": "query",
+              "format": "google-fieldmask",
+              "description": "The list of fields to update."
+            }
+          },
+          "request": {
+            "$ref": "CachedContent"
+          }
+        },
+        "create": {
+          "path": "v1beta/cachedContents",
+          "httpMethod": "POST",
+          "request": {
+            "$ref": "CachedContent"
+          },
+          "flatPath": "v1beta/cachedContents",
+          "description": "Creates CachedContent resource.",
+          "id": "generativelanguage.cachedContents.create",
+          "response": {
+            "$ref": "CachedContent"
+          },
+          "parameterOrder": [],
+          "parameters": {}
+        },
+        "list": {
+          "description": "Lists CachedContents.",
+          "parameterOrder": [],
+          "parameters": {
+            "pageSize": {
+              "type": "integer",
+              "location": "query",
+              "format": "int32",
+              "description": "Optional. The maximum number of cached contents to return. The service may return fewer than this value. If unspecified, some default (under maximum) number of items will be returned. The maximum value is 1000; values above 1000 will be coerced to 1000."
+            },
+            "pageToken": {
+              "location": "query",
+              "description": "Optional. A page token, received from a previous `ListCachedContents` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListCachedContents` must match the call that provided the page token.",
+              "type": "string"
+            }
+          },
+          "httpMethod": "GET",
+          "response": {
+            "$ref": "ListCachedContentsResponse"
+          },
+          "path": "v1beta/cachedContents",
+          "id": "generativelanguage.cachedContents.list",
+          "flatPath": "v1beta/cachedContents"
+        },
+        "delete": {
+          "id": "generativelanguage.cachedContents.delete",
+          "response": {
+            "$ref": "Empty"
+          },
+          "parameterOrder": [
+            "name"
+          ],
+          "flatPath": "v1beta/cachedContents/{cachedContentsId}",
+          "parameters": {
+            "name": {
+              "pattern": "^cachedContents/[^/]+$",
+              "required": true,
+              "type": "string",
+              "location": "path",
+              "description": "Required. The resource name referring to the content cache entry Format: `cachedContents/{id}`"
+            }
+          },
+          "description": "Deletes CachedContent resource.",
+          "httpMethod": "DELETE",
+          "path": "v1beta/{+name}"
         }
-      },
-      "description": "Attribution for a source that contributed to an answer."
+      }
     },
-    "BatchDeleteChunksRequest": {
-      "type": "object",
-      "properties": {
-        "requests": {
-          "type": "array",
-          "description": "Required. The request messages specifying the `Chunk`s to delete.",
-          "items": {
-            "$ref": "DeleteChunkRequest"
+    "media": {
+      "methods": {
+        "upload": {
+          "request": {
+            "$ref": "CreateFileRequest"
+          },
+          "parameters": {},
+          "httpMethod": "POST",
+          "supportsMediaUpload": true,
+          "path": "v1beta/files",
+          "response": {
+            "$ref": "CreateFileResponse"
+          },
+          "id": "generativelanguage.media.upload",
+          "parameterOrder": [],
+          "mediaUpload": {
+            "accept": [
+              "*/*"
+            ],
+            "protocols": {
+              "simple": {
+                "multipart": true,
+                "path": "/upload/v1beta/files"
+              },
+              "resumable": {
+                "path": "/resumable/upload/v1beta/files",
+                "multipart": true
+              }
+            },
+            "maxSize": "2147483648"
+          },
+          "flatPath": "v1beta/files",
+          "description": "Creates a `File`."
+        }
+      }
+    },
+    "tunedModels": {
+      "resources": {
+        "permissions": {
+          "methods": {
+            "patch": {
+              "description": "Updates the permission.",
+              "parameters": {
+                "updateMask": {
+                  "location": "query",
+                  "format": "google-fieldmask",
+                  "type": "string",
+                  "description": "Required. The list of fields to update. Accepted ones: - role (`Permission.role` field)"
+                },
+                "name": {
+                  "pattern": "^tunedModels/[^/]+/permissions/[^/]+$",
+                  "type": "string",
+                  "required": true,
+                  "location": "path",
+                  "description": "Output only. Identifier. The permission name. A unique name will be generated on create. Examples: tunedModels/{tuned_model}/permissions/{permission} corpora/{corpus}/permissions/{permission} Output only."
+                }
+              },
+              "id": "generativelanguage.tunedModels.permissions.patch",
+              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions/{permissionsId}",
+              "path": "v1beta/{+name}",
+              "parameterOrder": [
+                "name"
+              ],
+              "request": {
+                "$ref": "Permission"
+              },
+              "response": {
+                "$ref": "Permission"
+              },
+              "httpMethod": "PATCH"
+            },
+            "list": {
+              "description": "Lists permissions for the specific resource.",
+              "httpMethod": "GET",
+              "response": {
+                "$ref": "ListPermissionsResponse"
+              },
+              "parameters": {
+                "pageSize": {
+                  "description": "Optional. The maximum number of `Permission`s to return (per page). The service may return fewer permissions. If unspecified, at most 10 permissions will be returned. This method returns at most 1000 permissions per page, even if you pass larger page_size.",
+                  "location": "query",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "pageToken": {
+                  "description": "Optional. A page token, received from a previous `ListPermissions` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListPermissions` must match the call that provided the page token.",
+                  "type": "string",
+                  "location": "query"
+                },
+                "parent": {
+                  "pattern": "^tunedModels/[^/]+$",
+                  "description": "Required. The parent resource of the permissions. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`",
+                  "type": "string",
+                  "required": true,
+                  "location": "path"
+                }
+              },
+              "parameterOrder": [
+                "parent"
+              ],
+              "id": "generativelanguage.tunedModels.permissions.list",
+              "path": "v1beta/{+parent}/permissions",
+              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions"
+            },
+            "get": {
+              "path": "v1beta/{+name}",
+              "parameterOrder": [
+                "name"
+              ],
+              "description": "Gets information about a specific Permission.",
+              "response": {
+                "$ref": "Permission"
+              },
+              "id": "generativelanguage.tunedModels.permissions.get",
+              "parameters": {
+                "name": {
+                  "pattern": "^tunedModels/[^/]+/permissions/[^/]+$",
+                  "location": "path",
+                  "required": true,
+                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
+                  "type": "string"
+                }
+              },
+              "httpMethod": "GET",
+              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions/{permissionsId}"
+            },
+            "create": {
+              "parameters": {
+                "parent": {
+                  "required": true,
+                  "type": "string",
+                  "description": "Required. The parent resource of the `Permission`. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`",
+                  "location": "path",
+                  "pattern": "^tunedModels/[^/]+$"
+                }
+              },
+              "path": "v1beta/{+parent}/permissions",
+              "request": {
+                "$ref": "Permission"
+              },
+              "parameterOrder": [
+                "parent"
+              ],
+              "httpMethod": "POST",
+              "response": {
+                "$ref": "Permission"
+              },
+              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions",
+              "id": "generativelanguage.tunedModels.permissions.create",
+              "description": "Create a permission to a specific resource."
+            },
+            "delete": {
+              "parameters": {
+                "name": {
+                  "location": "path",
+                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
+                  "type": "string",
+                  "required": true,
+                  "pattern": "^tunedModels/[^/]+/permissions/[^/]+$"
+                }
+              },
+              "path": "v1beta/{+name}",
+              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions/{permissionsId}",
+              "description": "Deletes the permission.",
+              "httpMethod": "DELETE",
+              "parameterOrder": [
+                "name"
+              ],
+              "id": "generativelanguage.tunedModels.permissions.delete",
+              "response": {
+                "$ref": "Empty"
+              }
+            }
           }
         }
       },
-      "description": "Request to batch delete `Chunk`s.",
-      "id": "BatchDeleteChunksRequest"
-    },
-    "TransferOwnershipResponse": {
-      "id": "TransferOwnershipResponse",
-      "description": "Response from `TransferOwnership`.",
-      "properties": {},
-      "type": "object"
-    },
-    "Document": {
-      "type": "object",
-      "description": "A `Document` is a collection of `Chunk`s. A `Corpus` can have a maximum of 10,000 `Document`s.",
-      "properties": {
-        "updateTime": {
-          "format": "google-datetime",
-          "description": "Output only. The Timestamp of when the `Document` was last updated.",
-          "readOnly": true,
-          "type": "string"
-        },
-        "customMetadata": {
-          "items": {
-            "$ref": "CustomMetadata"
+      "methods": {
+        "generateContent": {
+          "request": {
+            "$ref": "GenerateContentRequest"
           },
-          "type": "array",
-          "description": "Optional. User provided custom metadata stored as key-value pairs used for querying. A `Document` can have a maximum of 20 `CustomMetadata`."
-        },
-        "createTime": {
-          "type": "string",
-          "description": "Output only. The Timestamp of when the `Document` was created.",
-          "format": "google-datetime",
-          "readOnly": true
-        },
-        "displayName": {
-          "description": "Optional. The human-readable display name for the `Document`. The display name must be no more than 512 characters in length, including spaces. Example: \"Semantic Retriever Documentation\"",
-          "type": "string"
-        },
-        "name": {
-          "type": "string",
-          "description": "Immutable. Identifier. The `Document` resource name. The ID (name excluding the \"corpora/*/documents/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/{corpus_id}/documents/my-awesome-doc-123a456b789c`"
-        }
-      },
-      "id": "Document"
-    },
-    "TunedModel": {
-      "description": "A fine-tuned model created using ModelService.CreateTunedModel.",
-      "type": "object",
-      "id": "TunedModel",
-      "properties": {
-        "tunedModelSource": {
-          "$ref": "TunedModelSource",
-          "description": "Optional. TunedModel to use as the starting point for training the new model."
-        },
-        "updateTime": {
-          "format": "google-datetime",
-          "type": "string",
-          "description": "Output only. The timestamp when this model was updated.",
-          "readOnly": true
-        },
-        "state": {
-          "enum": [
-            "STATE_UNSPECIFIED",
-            "CREATING",
-            "ACTIVE",
-            "FAILED"
+          "response": {
+            "$ref": "GenerateContentResponse"
+          },
+          "parameters": {
+            "model": {
+              "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`.",
+              "type": "string",
+              "location": "path",
+              "required": true,
+              "pattern": "^tunedModels/[^/]+$"
+            }
+          },
+          "id": "generativelanguage.tunedModels.generateContent",
+          "parameterOrder": [
+            "model"
           ],
-          "description": "Output only. The state of the tuned model.",
-          "type": "string",
-          "readOnly": true,
-          "enumDescriptions": [
-            "The default value. This value is unused.",
-            "The model is being created.",
-            "The model is ready to be used.",
-            "The model failed to be created."
+          "description": "Generates a response from the model given an input `GenerateContentRequest`. Input capabilities differ between models, including tuned models. See the [model guide](https://ai.google.dev/models/gemini) and [tuning guide](https://ai.google.dev/docs/model_tuning_guidance) for details.",
+          "flatPath": "v1beta/tunedModels/{tunedModelsId}:generateContent",
+          "httpMethod": "POST",
+          "path": "v1beta/{+model}:generateContent"
+        },
+        "generateText": {
+          "parameters": {
+            "model": {
+              "pattern": "^tunedModels/[^/]+$",
+              "type": "string",
+              "required": true,
+              "location": "path",
+              "description": "Required. The name of the `Model` or `TunedModel` to use for generating the completion. Examples: models/text-bison-001 tunedModels/sentence-translator-u3b7m"
+            }
+          },
+          "description": "Generates a response from the model given an input message.",
+          "id": "generativelanguage.tunedModels.generateText",
+          "path": "v1beta/{+model}:generateText",
+          "parameterOrder": [
+            "model"
+          ],
+          "response": {
+            "$ref": "GenerateTextResponse"
+          },
+          "httpMethod": "POST",
+          "flatPath": "v1beta/tunedModels/{tunedModelsId}:generateText",
+          "request": {
+            "$ref": "GenerateTextRequest"
+          }
+        },
+        "patch": {
+          "id": "generativelanguage.tunedModels.patch",
+          "request": {
+            "$ref": "TunedModel"
+          },
+          "description": "Updates a tuned model.",
+          "parameters": {
+            "name": {
+              "required": true,
+              "type": "string",
+              "description": "Output only. The tuned model name. A unique name will be generated on create. Example: `tunedModels/az2mb0bpw6i` If display_name is set on create, the id portion of the name will be set by concatenating the words of the display_name with hyphens and adding a random portion for uniqueness. Example: display_name = \"Sentence Translator\" name = \"tunedModels/sentence-translator-u3b7m\"",
+              "pattern": "^tunedModels/[^/]+$",
+              "location": "path"
+            },
+            "updateMask": {
+              "type": "string",
+              "description": "Required. The list of fields to update.",
+              "format": "google-fieldmask",
+              "location": "query"
+            }
+          },
+          "httpMethod": "PATCH",
+          "flatPath": "v1beta/tunedModels/{tunedModelsId}",
+          "path": "v1beta/{+name}",
+          "parameterOrder": [
+            "name"
+          ],
+          "response": {
+            "$ref": "TunedModel"
+          }
+        },
+        "get": {
+          "parameterOrder": [
+            "name"
+          ],
+          "id": "generativelanguage.tunedModels.get",
+          "description": "Gets information about a specific TunedModel.",
+          "flatPath": "v1beta/tunedModels/{tunedModelsId}",
+          "response": {
+            "$ref": "TunedModel"
+          },
+          "parameters": {
+            "name": {
+              "pattern": "^tunedModels/[^/]+$",
+              "location": "path",
+              "required": true,
+              "type": "string",
+              "description": "Required. The resource name of the model. Format: `tunedModels/my-model-id`"
+            }
+          },
+          "httpMethod": "GET",
+          "path": "v1beta/{+name}"
+        },
+        "delete": {
+          "path": "v1beta/{+name}",
+          "description": "Deletes a tuned model.",
+          "id": "generativelanguage.tunedModels.delete",
+          "response": {
+            "$ref": "Empty"
+          },
+          "flatPath": "v1beta/tunedModels/{tunedModelsId}",
+          "httpMethod": "DELETE",
+          "parameters": {
+            "name": {
+              "type": "string",
+              "description": "Required. The resource name of the model. Format: `tunedModels/my-model-id`",
+              "required": true,
+              "pattern": "^tunedModels/[^/]+$",
+              "location": "path"
+            }
+          },
+          "parameterOrder": [
+            "name"
           ]
         },
-        "name": {
-          "type": "string",
-          "description": "Output only. The tuned model name. A unique name will be generated on create. Example: `tunedModels/az2mb0bpw6i` If display_name is set on create, the id portion of the name will be set by concatenating the words of the display_name with hyphens and adding a random portion for uniqueness. Example: display_name = \"Sentence Translator\" name = \"tunedModels/sentence-translator-u3b7m\"",
-          "readOnly": true
-        },
-        "description": {
-          "type": "string",
-          "description": "Optional. A short description of this model."
-        },
-        "topK": {
-          "format": "int32",
-          "type": "integer",
-          "description": "Optional. For Top-k sampling. Top-k sampling considers the set of `top_k` most probable tokens. This value specifies default to be used by the backend while making the call to the model. This value specifies default to be the one used by the base model while creating the model."
-        },
-        "createTime": {
-          "description": "Output only. The timestamp when this model was created.",
-          "format": "google-datetime",
-          "type": "string",
-          "readOnly": true
-        },
-        "baseModel": {
-          "description": "Immutable. The name of the `Model` to tune. Example: `models/text-bison-001`",
-          "type": "string"
-        },
-        "tuningTask": {
-          "$ref": "TuningTask",
-          "description": "Required. The tuning task that creates the tuned model."
-        },
-        "topP": {
-          "type": "number",
-          "description": "Optional. For Nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`. This value specifies default to be the one used by the base model while creating the model.",
-          "format": "float"
-        },
-        "temperature": {
-          "description": "Optional. Controls the randomness of the output. Values can range over `[0.0,1.0]`, inclusive. A value closer to `1.0` will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model. This value specifies default to be the one used by the base model while creating the model.",
-          "format": "float",
-          "type": "number"
-        },
-        "displayName": {
-          "description": "Optional. The name to display for this model in user interfaces. The display name must be up to 40 characters including spaces.",
-          "type": "string"
-        }
-      }
-    },
-    "TuningTask": {
-      "type": "object",
-      "description": "Tuning tasks that create tuned models.",
-      "id": "TuningTask",
-      "properties": {
-        "startTime": {
-          "type": "string",
-          "readOnly": true,
-          "description": "Output only. The timestamp when tuning this model started.",
-          "format": "google-datetime"
-        },
-        "trainingData": {
-          "description": "Required. Input only. Immutable. The model training data.",
-          "$ref": "Dataset"
-        },
-        "snapshots": {
-          "type": "array",
-          "description": "Output only. Metrics collected during tuning.",
-          "items": {
-            "$ref": "TuningSnapshot"
+        "transferOwnership": {
+          "parameters": {
+            "name": {
+              "description": "Required. The resource name of the tuned model to transfer ownership. Format: `tunedModels/my-model-id`",
+              "pattern": "^tunedModels/[^/]+$",
+              "type": "string",
+              "required": true,
+              "location": "path"
+            }
           },
-          "readOnly": true
-        },
-        "completeTime": {
-          "readOnly": true,
-          "format": "google-datetime",
-          "type": "string",
-          "description": "Output only. The timestamp when tuning this model completed."
-        },
-        "hyperparameters": {
-          "$ref": "Hyperparameters",
-          "description": "Immutable. Hyperparameters controlling the tuning process. If not provided, default values will be used."
-        }
-      }
-    },
-    "UpdateChunkRequest": {
-      "type": "object",
-      "id": "UpdateChunkRequest",
-      "properties": {
-        "updateMask": {
-          "format": "google-fieldmask",
-          "description": "Required. The list of fields to update. Currently, this only supports updating `custom_metadata` and `data`.",
-          "type": "string"
-        },
-        "chunk": {
-          "description": "Required. The `Chunk` to update.",
-          "$ref": "Chunk"
-        }
-      },
-      "description": "Request to update a `Chunk`."
-    },
-    "GenerateContentRequest": {
-      "id": "GenerateContentRequest",
-      "properties": {
-        "model": {
-          "type": "string",
-          "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`."
-        },
-        "tools": {
-          "items": {
-            "$ref": "Tool"
+          "path": "v1beta/{+name}:transferOwnership",
+          "httpMethod": "POST",
+          "flatPath": "v1beta/tunedModels/{tunedModelsId}:transferOwnership",
+          "request": {
+            "$ref": "TransferOwnershipRequest"
           },
-          "type": "array",
-          "description": "Optional. A list of `Tools` the model may use to generate the next response. A `Tool` is a piece of code that enables the system to interact with external systems to perform an action, or set of actions, outside of knowledge and scope of the model. The only supported tool is currently `Function`."
-        },
-        "generationConfig": {
-          "description": "Optional. Configuration options for model generation and outputs.",
-          "$ref": "GenerationConfig"
-        },
-        "contents": {
-          "items": {
-            "$ref": "Content"
+          "description": "Transfers ownership of the tuned model. This is the only way to change ownership of the tuned model. The current owner will be downgraded to writer role.",
+          "response": {
+            "$ref": "TransferOwnershipResponse"
           },
-          "type": "array",
-          "description": "Required. The content of the current conversation with the model. For single-turn queries, this is a single instance. For multi-turn queries, this is a repeated field that contains conversation history + latest request."
-        },
-        "safetySettings": {
-          "items": {
-            "$ref": "SafetySetting"
-          },
-          "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content. This will be enforced on the `GenerateContentRequest.contents` and `GenerateContentResponse.candidates`. There should not be more than one setting for each `SafetyCategory` type. The API will block any contents and responses that fail to meet the thresholds set by these settings. This list overrides the default settings for each `SafetyCategory` specified in the safety_settings. If there is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use the default safety setting for that category. Harm categories HARM_CATEGORY_HATE_SPEECH, HARM_CATEGORY_SEXUALLY_EXPLICIT, HARM_CATEGORY_DANGEROUS_CONTENT, HARM_CATEGORY_HARASSMENT are supported.",
-          "type": "array"
-        },
-        "toolConfig": {
-          "$ref": "ToolConfig",
-          "description": "Optional. Tool configuration for any `Tool` specified in the request."
-        },
-        "systemInstruction": {
-          "$ref": "Content",
-          "description": "Optional. Developer set system instruction. Currently, text only."
-        },
-        "cachedContent": {
-          "type": "string",
-          "description": "Optional. The name of the cached content used as context to serve the prediction. Note: only used in explicit caching, where users can have control over caching (e.g. what content to cache) and enjoy guaranteed cost savings. Format: `cachedContents/{cachedContent}`"
-        }
-      },
-      "type": "object",
-      "description": "Request to generate a completion from the model."
-    },
-    "CountTokensResponse": {
-      "description": "A response from `CountTokens`. It returns the model's `token_count` for the `prompt`.",
-      "type": "object",
-      "id": "CountTokensResponse",
-      "properties": {
-        "totalTokens": {
-          "description": "The number of tokens that the `model` tokenizes the `prompt` into. Always non-negative. When cached_content is set, this is still the total effective prompt size. I.e. this includes the number of tokens in the cached content.",
-          "format": "int32",
-          "type": "integer"
-        }
-      }
-    },
-    "QueryCorpusRequest": {
-      "description": "Request for querying a `Corpus`.",
-      "id": "QueryCorpusRequest",
-      "properties": {
-        "query": {
-          "description": "Required. Query string to perform semantic search.",
-          "type": "string"
-        },
-        "metadataFilters": {
-          "items": {
-            "$ref": "MetadataFilter"
-          },
-          "description": "Optional. Filter for `Chunk` and `Document` metadata. Each `MetadataFilter` object should correspond to a unique key. Multiple `MetadataFilter` objects are joined by logical \"AND\"s. Example query at document level: (year \u003e= 2020 OR year \u003c 2010) AND (genre = drama OR genre = action) `MetadataFilter` object list: metadata_filters = [ {key = \"document.custom_metadata.year\" conditions = [{int_value = 2020, operation = GREATER_EQUAL}, {int_value = 2010, operation = LESS}]}, {key = \"document.custom_metadata.year\" conditions = [{int_value = 2020, operation = GREATER_EQUAL}, {int_value = 2010, operation = LESS}]}, {key = \"document.custom_metadata.genre\" conditions = [{string_value = \"drama\", operation = EQUAL}, {string_value = \"action\", operation = EQUAL}]}] Example query at chunk level for a numeric range of values: (year \u003e 2015 AND year \u003c= 2020) `MetadataFilter` object list: metadata_filters = [ {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2015, operation = GREATER}]}, {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2020, operation = LESS_EQUAL}]}] Note: \"AND\"s for the same key are only supported for numeric values. String values only support \"OR\"s for the same key.",
-          "type": "array"
-        },
-        "resultsCount": {
-          "format": "int32",
-          "description": "Optional. The maximum number of `Chunk`s to return. The service may return fewer `Chunk`s. If unspecified, at most 10 `Chunk`s will be returned. The maximum specified result count is 100.",
-          "type": "integer"
-        }
-      },
-      "type": "object"
-    },
-    "TransferOwnershipRequest": {
-      "type": "object",
-      "properties": {
-        "emailAddress": {
-          "type": "string",
-          "description": "Required. The email address of the user to whom the tuned model is being transferred to."
-        }
-      },
-      "id": "TransferOwnershipRequest",
-      "description": "Request to transfer the ownership of the tuned model."
-    },
-    "Model": {
-      "properties": {
-        "version": {
-          "type": "string",
-          "description": "Required. The version number of the model. This represents the major version"
-        },
-        "displayName": {
-          "description": "The human-readable name of the model. E.g. \"Chat Bison\". The name can be up to 128 characters long and can consist of any UTF-8 characters.",
-          "type": "string"
-        },
-        "baseModelId": {
-          "type": "string",
-          "description": "Required. The name of the base model, pass this to the generation request. Examples: * `chat-bison`"
-        },
-        "maxTemperature": {
-          "type": "number",
-          "format": "float",
-          "description": "The maximum temperature this model can use."
-        },
-        "topP": {
-          "type": "number",
-          "description": "For Nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`. This value specifies default to be used by the backend while making the call to the model.",
-          "format": "float"
-        },
-        "inputTokenLimit": {
-          "type": "integer",
-          "description": "Maximum number of input tokens allowed for this model.",
-          "format": "int32"
-        },
-        "temperature": {
-          "format": "float",
-          "type": "number",
-          "description": "Controls the randomness of the output. Values can range over `[0.0,max_temperature]`, inclusive. A higher value will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model. This value specifies default to be used by the backend while making the call to the model."
-        },
-        "topK": {
-          "type": "integer",
-          "description": "For Top-k sampling. Top-k sampling considers the set of `top_k` most probable tokens. This value specifies default to be used by the backend while making the call to the model. If empty, indicates the model doesn't use top-k sampling, and `top_k` isn't allowed as a generation parameter.",
-          "format": "int32"
-        },
-        "name": {
-          "type": "string",
-          "description": "Required. The resource name of the `Model`. Format: `models/{model}` with a `{model}` naming convention of: * \"{base_model_id}-{version}\" Examples: * `models/chat-bison-001`"
-        },
-        "outputTokenLimit": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Maximum number of output tokens available for this model."
-        },
-        "supportedGenerationMethods": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "The model's supported generation methods. The method names are defined as Pascal case strings, such as `generateMessage` which correspond to API methods."
-        },
-        "description": {
-          "description": "A short description of the model.",
-          "type": "string"
-        }
-      },
-      "type": "object",
-      "id": "Model",
-      "description": "Information about a Generative Language Model."
-    },
-    "Condition": {
-      "properties": {
-        "operation": {
-          "description": "Required. Operator applied to the given key-value pair to trigger the condition.",
-          "type": "string",
-          "enum": [
-            "OPERATOR_UNSPECIFIED",
-            "LESS",
-            "LESS_EQUAL",
-            "EQUAL",
-            "GREATER_EQUAL",
-            "GREATER",
-            "NOT_EQUAL",
-            "INCLUDES",
-            "EXCLUDES"
-          ],
-          "enumDescriptions": [
-            "The default value. This value is unused.",
-            "Supported by numeric.",
-            "Supported by numeric.",
-            "Supported by numeric & string.",
-            "Supported by numeric.",
-            "Supported by numeric.",
-            "Supported by numeric & string.",
-            "Supported by string only when `CustomMetadata` value type for the given key has a `string_list_value`.",
-            "Supported by string only when `CustomMetadata` value type for the given key has a `string_list_value`."
+          "id": "generativelanguage.tunedModels.transferOwnership",
+          "parameterOrder": [
+            "name"
           ]
         },
-        "stringValue": {
-          "description": "The string value to filter the metadata on.",
-          "type": "string"
+        "create": {
+          "path": "v1beta/tunedModels",
+          "parameters": {
+            "tunedModelId": {
+              "type": "string",
+              "description": "Optional. The unique id for the tuned model if specified. This value should be up to 40 characters, the first character must be a letter, the last could be a letter or a number. The id must match the regular expression: [a-z]([a-z0-9-]{0,38}[a-z0-9])?.",
+              "location": "query"
+            }
+          },
+          "id": "generativelanguage.tunedModels.create",
+          "description": "Creates a tuned model. Intermediate tuning progress (if any) is accessed through the [google.longrunning.Operations] service. Status and results can be accessed through the Operations service. Example: GET /v1/tunedModels/az2mb0bpw6i/operations/000-111-222",
+          "httpMethod": "POST",
+          "request": {
+            "$ref": "TunedModel"
+          },
+          "response": {
+            "$ref": "Operation"
+          },
+          "parameterOrder": [],
+          "flatPath": "v1beta/tunedModels"
+        },
+        "list": {
+          "flatPath": "v1beta/tunedModels",
+          "parameters": {
+            "pageToken": {
+              "description": "Optional. A page token, received from a previous `ListTunedModels` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListTunedModels` must match the call that provided the page token.",
+              "type": "string",
+              "location": "query"
+            },
+            "pageSize": {
+              "type": "integer",
+              "location": "query",
+              "format": "int32",
+              "description": "Optional. The maximum number of `TunedModels` to return (per page). The service may return fewer tuned models. If unspecified, at most 10 tuned models will be returned. This method returns at most 1000 models per page, even if you pass a larger page_size."
+            },
+            "filter": {
+              "location": "query",
+              "type": "string",
+              "description": "Optional. A filter is a full text search over the tuned model's description and display name. By default, results will not include tuned models shared with everyone. Additional operators: - owner:me - writers:me - readers:me - readers:everyone Examples: \"owner:me\" returns all tuned models to which caller has owner role \"readers:me\" returns all tuned models to which caller has reader role \"readers:everyone\" returns all tuned models that are shared with everyone"
+            }
+          },
+          "parameterOrder": [],
+          "description": "Lists tuned models owned by the user.",
+          "httpMethod": "GET",
+          "response": {
+            "$ref": "ListTunedModelsResponse"
+          },
+          "id": "generativelanguage.tunedModels.list",
+          "path": "v1beta/tunedModels"
+        }
+      }
+    }
+  },
+  "schemas": {
+    "CustomMetadata": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "Required. The key of the metadata to store."
+        },
+        "stringListValue": {
+          "$ref": "StringList",
+          "description": "The StringList value of the metadata to store."
         },
         "numericValue": {
-          "description": "The numeric value to filter the metadata on.",
-          "type": "number",
-          "format": "float"
-        }
-      },
-      "type": "object",
-      "description": "Filter condition applicable to a single key.",
-      "id": "Condition"
-    },
-    "CountMessageTokensRequest": {
-      "properties": {
-        "prompt": {
-          "description": "Required. The prompt, whose token count is to be returned.",
-          "$ref": "MessagePrompt"
-        }
-      },
-      "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`.",
-      "type": "object",
-      "id": "CountMessageTokensRequest"
-    },
-    "InputFeedback": {
-      "properties": {
-        "safetyRatings": {
-          "items": {
-            "$ref": "SafetyRating"
-          },
-          "description": "Ratings for safety of the input. There is at most one rating per category.",
-          "type": "array"
-        },
-        "blockReason": {
-          "description": "Optional. If set, the input was blocked and no candidates are returned. Rephrase your input.",
-          "type": "string",
-          "enumDescriptions": [
-            "Default value. This value is unused.",
-            "Input was blocked due to safety reasons. You can inspect `safety_ratings` to understand which safety category blocked it.",
-            "Input was blocked due to other reasons."
-          ],
-          "enum": [
-            "BLOCK_REASON_UNSPECIFIED",
-            "SAFETY",
-            "OTHER"
-          ]
-        }
-      },
-      "description": "Feedback related to the input data used to answer the question, as opposed to model-generated response to the question.",
-      "id": "InputFeedback",
-      "type": "object"
-    },
-    "CountTextTokensResponse": {
-      "type": "object",
-      "description": "A response from `CountTextTokens`. It returns the model's `token_count` for the `prompt`.",
-      "properties": {
-        "tokenCount": {
-          "format": "int32",
-          "type": "integer",
-          "description": "The number of tokens that the `model` tokenizes the `prompt` into. Always non-negative."
-        }
-      },
-      "id": "CountTextTokensResponse"
-    },
-    "Chunk": {
-      "type": "object",
-      "description": "A `Chunk` is a subpart of a `Document` that is treated as an independent unit for the purposes of vector representation and storage. A `Corpus` can have a maximum of 1 million `Chunk`s.",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Immutable. Identifier. The `Chunk` resource name. The ID (name excluding the \"corpora/*/documents/*/chunks/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a random 12-character unique ID will be generated. Example: `corpora/{corpus_id}/documents/{document_id}/chunks/123a456b789c`"
-        },
-        "updateTime": {
-          "format": "google-datetime",
-          "type": "string",
-          "readOnly": true,
-          "description": "Output only. The Timestamp of when the `Chunk` was last updated."
-        },
-        "customMetadata": {
-          "description": "Optional. User provided custom metadata stored as key-value pairs. The maximum number of `CustomMetadata` per chunk is 20.",
-          "items": {
-            "$ref": "CustomMetadata"
-          },
-          "type": "array"
-        },
-        "createTime": {
-          "description": "Output only. The Timestamp of when the `Chunk` was created.",
-          "readOnly": true,
-          "type": "string",
-          "format": "google-datetime"
-        },
-        "state": {
-          "type": "string",
-          "readOnly": true,
-          "enum": [
-            "STATE_UNSPECIFIED",
-            "STATE_PENDING_PROCESSING",
-            "STATE_ACTIVE",
-            "STATE_FAILED"
-          ],
-          "enumDescriptions": [
-            "The default value. This value is used if the state is omitted.",
-            "`Chunk` is being processed (embedding and vector storage).",
-            "`Chunk` is processed and available for querying.",
-            "`Chunk` failed processing."
-          ],
-          "description": "Output only. Current state of the `Chunk`."
-        },
-        "data": {
-          "description": "Required. The content for the `Chunk`, such as the text string. The maximum number of tokens per chunk is 2043.",
-          "$ref": "ChunkData"
-        }
-      },
-      "id": "Chunk"
-    },
-    "GenerationConfig": {
-      "properties": {
-        "topP": {
-          "format": "float",
-          "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Tokens are sorted based on their assigned probabilities so that only the most likely tokens are considered. Top-k sampling directly limits the maximum number of tokens to consider, while Nucleus sampling limits number of tokens based on the cumulative probability. Note: The default value varies by model, see the `Model.top_p` attribute of the `Model` returned from the `getModel` function.",
-          "type": "number"
-        },
-        "stopSequences": {
-          "description": "Optional. The set of character sequences (up to 5) that will stop output generation. If specified, the API will stop at the first appearance of a stop sequence. The stop sequence will not be included as part of the response.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "temperature": {
-          "description": "Optional. Controls the randomness of the output. Note: The default value varies by model, see the `Model.temperature` attribute of the `Model` returned from the `getModel` function. Values can range from [0.0, 2.0].",
+          "description": "The numeric value of the metadata to store.",
           "type": "number",
           "format": "float"
         },
-        "candidateCount": {
-          "format": "int32",
-          "type": "integer",
-          "description": "Optional. Number of generated responses to return. Currently, this value can only be set to 1. If unset, this will default to 1."
-        },
-        "maxOutputTokens": {
-          "type": "integer",
-          "description": "Optional. The maximum number of tokens to include in a candidate. Note: The default value varies by model, see the `Model.output_token_limit` attribute of the `Model` returned from the `getModel` function.",
-          "format": "int32"
-        },
-        "responseMimeType": {
-          "type": "string",
-          "description": "Optional. Output response mimetype of the generated candidate text. Supported mimetype: `text/plain`: (default) Text output. `application/json`: JSON response in the candidates."
-        },
-        "responseSchema": {
-          "$ref": "Schema",
-          "description": "Optional. Output response schema of the generated candidate text when response mime type can have schema. Schema can be objects, primitives or arrays and is a subset of [OpenAPI schema](https://spec.openapis.org/oas/v3.0.3#schema). If set, a compatible response_mime_type must also be set. Compatible mimetypes: `application/json`: Schema for JSON response."
-        },
-        "topK": {
-          "description": "Optional. The maximum number of tokens to consider when sampling. Models use nucleus sampling or combined Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens. Models running with nucleus sampling don't allow top_k setting. Note: The default value varies by model, see the `Model.top_k` attribute of the `Model` returned from the `getModel` function. Empty `top_k` field in `Model` indicates the model doesn't apply top-k sampling and doesn't allow setting `top_k` on requests.",
-          "type": "integer",
-          "format": "int32"
-        }
-      },
-      "type": "object",
-      "description": "Configuration options for model generation and outputs. Not all parameters may be configurable for every model.",
-      "id": "GenerationConfig"
-    },
-    "MetadataFilter": {
-      "properties": {
-        "conditions": {
-          "items": {
-            "$ref": "Condition"
-          },
-          "description": "Required. The `Condition`s for the given key that will trigger this filter. Multiple `Condition`s are joined by logical ORs.",
-          "type": "array"
-        },
-        "key": {
-          "description": "Required. The key of the metadata to filter on.",
+        "stringValue": {
+          "description": "The string value of the metadata to store.",
           "type": "string"
         }
       },
-      "id": "MetadataFilter",
-      "description": "User provided filter to limit retrieval based on `Chunk` or `Document` level metadata values. Example (genre = drama OR genre = action): key = \"document.custom_metadata.genre\" conditions = [{string_value = \"drama\", operation = EQUAL}, {string_value = \"action\", operation = EQUAL}]",
-      "type": "object"
-    },
-    "SemanticRetrieverConfig": {
-      "properties": {
-        "source": {
-          "type": "string",
-          "description": "Required. Name of the resource for retrieval, e.g. corpora/123 or corpora/123/documents/abc."
-        },
-        "maxChunksCount": {
-          "format": "int32",
-          "type": "integer",
-          "description": "Optional. Maximum number of relevant `Chunk`s to retrieve."
-        },
-        "metadataFilters": {
-          "type": "array",
-          "description": "Optional. Filters for selecting `Document`s and/or `Chunk`s from the resource.",
-          "items": {
-            "$ref": "MetadataFilter"
-          }
-        },
-        "query": {
-          "$ref": "Content",
-          "description": "Required. Query to use for similarity matching `Chunk`s in the given resource."
-        },
-        "minimumRelevanceScore": {
-          "format": "float",
-          "description": "Optional. Minimum relevance score for retrieved relevant `Chunk`s.",
-          "type": "number"
-        }
-      },
-      "id": "SemanticRetrieverConfig",
-      "description": "Configuration for retrieving grounding content from a `Corpus` or `Document` created using the Semantic Retriever API.",
-      "type": "object"
-    },
-    "Embedding": {
-      "description": "A list of floats representing the embedding.",
-      "properties": {
-        "value": {
-          "items": {
-            "type": "number",
-            "format": "float"
-          },
-          "description": "The embedding values.",
-          "type": "array"
-        }
-      },
-      "id": "Embedding",
-      "type": "object"
+      "description": "User provided metadata stored as key-value pairs.",
+      "id": "CustomMetadata"
     },
     "Content": {
       "properties": {
@@ -1422,78 +1714,397 @@
           "description": "Optional. The producer of the content. Must be either 'user' or 'model'. Useful to set for multi-turn conversations, otherwise can be left blank or unset."
         },
         "parts": {
-          "description": "Ordered `Parts` that constitute a single message. Parts may have different MIME types.",
-          "type": "array",
           "items": {
             "$ref": "Part"
-          }
+          },
+          "type": "array",
+          "description": "Ordered `Parts` that constitute a single message. Parts may have different MIME types."
         }
       },
       "description": "The base structured datatype containing multi-part content of a message. A `Content` includes a `role` field designating the producer of the `Content` and a `parts` field containing multi-part data that contains the content of the message turn.",
-      "type": "object",
-      "id": "Content"
+      "id": "Content",
+      "type": "object"
     },
-    "EmbedContentResponse": {
+    "CreateChunkRequest": {
       "type": "object",
       "properties": {
-        "embedding": {
-          "$ref": "ContentEmbedding",
-          "description": "Output only. The embedding generated from the input content.",
-          "readOnly": true
+        "chunk": {
+          "description": "Required. The `Chunk` to create.",
+          "$ref": "Chunk"
+        },
+        "parent": {
+          "type": "string",
+          "description": "Required. The name of the `Document` where this `Chunk` will be created. Example: `corpora/my-corpus-123/documents/the-doc-abc`"
         }
       },
-      "description": "The response to an `EmbedContentRequest`.",
-      "id": "EmbedContentResponse"
+      "id": "CreateChunkRequest",
+      "description": "Request to create a `Chunk`."
     },
-    "FunctionResponse": {
+    "TunedModel": {
       "type": "object",
       "properties": {
-        "response": {
-          "additionalProperties": {
-            "description": "Properties of the object.",
-            "type": "any"
-          },
-          "description": "Required. The function response in JSON object format.",
-          "type": "object"
+        "temperature": {
+          "type": "number",
+          "description": "Optional. Controls the randomness of the output. Values can range over `[0.0,1.0]`, inclusive. A value closer to `1.0` will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model. This value specifies default to be the one used by the base model while creating the model.",
+          "format": "float"
+        },
+        "updateTime": {
+          "readOnly": true,
+          "description": "Output only. The timestamp when this model was updated.",
+          "format": "google-datetime",
+          "type": "string"
         },
         "name": {
-          "description": "Required. The name of the function to call. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63.",
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. The tuned model name. A unique name will be generated on create. Example: `tunedModels/az2mb0bpw6i` If display_name is set on create, the id portion of the name will be set by concatenating the words of the display_name with hyphens and adding a random portion for uniqueness. Example: display_name = \"Sentence Translator\" name = \"tunedModels/sentence-translator-u3b7m\""
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Optional. The name to display for this model in user interfaces. The display name must be up to 40 characters including spaces."
+        },
+        "baseModel": {
+          "description": "Immutable. The name of the `Model` to tune. Example: `models/text-bison-001`",
+          "type": "string"
+        },
+        "topK": {
+          "format": "int32",
+          "description": "Optional. For Top-k sampling. Top-k sampling considers the set of `top_k` most probable tokens. This value specifies default to be used by the backend while making the call to the model. This value specifies default to be the one used by the base model while creating the model.",
+          "type": "integer"
+        },
+        "tunedModelSource": {
+          "$ref": "TunedModelSource",
+          "description": "Optional. TunedModel to use as the starting point for training the new model."
+        },
+        "description": {
+          "type": "string",
+          "description": "Optional. A short description of this model."
+        },
+        "tuningTask": {
+          "description": "Required. The tuning task that creates the tuned model.",
+          "$ref": "TuningTask"
+        },
+        "createTime": {
+          "format": "google-datetime",
+          "type": "string",
+          "readOnly": true,
+          "description": "Output only. The timestamp when this model was created."
+        },
+        "topP": {
+          "type": "number",
+          "description": "Optional. For Nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`. This value specifies default to be the one used by the base model while creating the model.",
+          "format": "float"
+        },
+        "state": {
+          "enumDescriptions": [
+            "The default value. This value is unused.",
+            "The model is being created.",
+            "The model is ready to be used.",
+            "The model failed to be created."
+          ],
+          "description": "Output only. The state of the tuned model.",
+          "enum": [
+            "STATE_UNSPECIFIED",
+            "CREATING",
+            "ACTIVE",
+            "FAILED"
+          ],
+          "readOnly": true,
           "type": "string"
         }
       },
-      "id": "FunctionResponse",
-      "description": "The result output from a `FunctionCall` that contains a string representing the `FunctionDeclaration.name` and a structured JSON object containing any output from the function is used as context to the model. This should contain the result of a`FunctionCall` made based on model prediction."
+      "id": "TunedModel",
+      "description": "A fine-tuned model created using ModelService.CreateTunedModel."
     },
-    "BatchCreateChunksResponse": {
+    "ListFilesResponse": {
       "type": "object",
+      "id": "ListFilesResponse",
+      "description": "Response for `ListFiles`.",
       "properties": {
-        "chunks": {
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token that can be sent as a `page_token` into a subsequent `ListFiles` call."
+        },
+        "files": {
+          "description": "The list of `File`s.",
           "type": "array",
-          "description": "`Chunk`s created.",
           "items": {
-            "$ref": "Chunk"
+            "$ref": "File"
           }
         }
+      }
+    },
+    "Empty": {
+      "description": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); }",
+      "id": "Empty",
+      "properties": {},
+      "type": "object"
+    },
+    "BatchEmbedTextResponse": {
+      "id": "BatchEmbedTextResponse",
+      "type": "object",
+      "description": "The response to a EmbedTextRequest.",
+      "properties": {
+        "embeddings": {
+          "items": {
+            "$ref": "Embedding"
+          },
+          "readOnly": true,
+          "description": "Output only. The embeddings generated from the input text.",
+          "type": "array"
+        }
+      }
+    },
+    "Model": {
+      "type": "object",
+      "description": "Information about a Generative Language Model.",
+      "id": "Model",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Required. The resource name of the `Model`. Format: `models/{model}` with a `{model}` naming convention of: * \"{base_model_id}-{version}\" Examples: * `models/chat-bison-001`"
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The human-readable name of the model. E.g. \"Chat Bison\". The name can be up to 128 characters long and can consist of any UTF-8 characters."
+        },
+        "description": {
+          "description": "A short description of the model.",
+          "type": "string"
+        },
+        "topP": {
+          "type": "number",
+          "format": "float",
+          "description": "For Nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`. This value specifies default to be used by the backend while making the call to the model."
+        },
+        "version": {
+          "description": "Required. The version number of the model. This represents the major version",
+          "type": "string"
+        },
+        "outputTokenLimit": {
+          "format": "int32",
+          "description": "Maximum number of output tokens available for this model.",
+          "type": "integer"
+        },
+        "maxTemperature": {
+          "format": "float",
+          "type": "number",
+          "description": "The maximum temperature this model can use."
+        },
+        "inputTokenLimit": {
+          "format": "int32",
+          "description": "Maximum number of input tokens allowed for this model.",
+          "type": "integer"
+        },
+        "baseModelId": {
+          "description": "Required. The name of the base model, pass this to the generation request. Examples: * `chat-bison`",
+          "type": "string"
+        },
+        "temperature": {
+          "format": "float",
+          "description": "Controls the randomness of the output. Values can range over `[0.0,max_temperature]`, inclusive. A higher value will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model. This value specifies default to be used by the backend while making the call to the model.",
+          "type": "number"
+        },
+        "supportedGenerationMethods": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The model's supported generation methods. The method names are defined as Pascal case strings, such as `generateMessage` which correspond to API methods."
+        },
+        "topK": {
+          "description": "For Top-k sampling. Top-k sampling considers the set of `top_k` most probable tokens. This value specifies default to be used by the backend while making the call to the model. If empty, indicates the model doesn't use top-k sampling, and `top_k` isn't allowed as a generation parameter.",
+          "format": "int32",
+          "type": "integer"
+        }
+      }
+    },
+    "CreateFileRequest": {
+      "properties": {
+        "file": {
+          "$ref": "File",
+          "description": "Optional. Metadata for the file to create."
+        }
       },
-      "id": "BatchCreateChunksResponse",
-      "description": "Response from `BatchCreateChunks` containing a list of created `Chunk`s."
+      "description": "Request for `CreateFile`.",
+      "id": "CreateFileRequest",
+      "type": "object"
+    },
+    "ContentEmbedding": {
+      "description": "A list of floats representing an embedding.",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "format": "float",
+            "type": "number"
+          },
+          "description": "The embedding values."
+        }
+      },
+      "type": "object",
+      "id": "ContentEmbedding"
+    },
+    "ListCorporaResponse": {
+      "description": "Response from `ListCorpora` containing a paginated list of `Corpora`. The results are sorted by ascending `corpus.create_time`.",
+      "id": "ListCorporaResponse",
+      "properties": {
+        "corpora": {
+          "description": "The returned corpora.",
+          "type": "array",
+          "items": {
+            "$ref": "Corpus"
+          }
+        },
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
+        }
+      },
+      "type": "object"
+    },
+    "RelevantChunk": {
+      "type": "object",
+      "properties": {
+        "chunkRelevanceScore": {
+          "description": "`Chunk` relevance to the query.",
+          "type": "number",
+          "format": "float"
+        },
+        "chunk": {
+          "$ref": "Chunk",
+          "description": "`Chunk` associated with the query."
+        }
+      },
+      "id": "RelevantChunk",
+      "description": "The information for a chunk relevant to a query."
+    },
+    "GroundingPassage": {
+      "type": "object",
+      "id": "GroundingPassage",
+      "properties": {
+        "content": {
+          "description": "Content of the passage.",
+          "$ref": "Content"
+        },
+        "id": {
+          "description": "Identifier for the passage for attributing this passage in grounded answers.",
+          "type": "string"
+        }
+      },
+      "description": "Passage included inline with a grounding configuration."
+    },
+    "EmbedContentResponse": {
+      "properties": {
+        "embedding": {
+          "readOnly": true,
+          "description": "Output only. The embedding generated from the input content.",
+          "$ref": "ContentEmbedding"
+        }
+      },
+      "id": "EmbedContentResponse",
+      "type": "object",
+      "description": "The response to an `EmbedContentRequest`."
+    },
+    "Tool": {
+      "type": "object",
+      "description": "Tool details that the model may use to generate response. A `Tool` is a piece of code that enables the system to interact with external systems to perform an action, or set of actions, outside of knowledge and scope of the model.",
+      "id": "Tool",
+      "properties": {
+        "functionDeclarations": {
+          "type": "array",
+          "description": "Optional. A list of `FunctionDeclarations` available to the model that can be used for function calling. The model or system does not execute the function. Instead the defined function may be returned as a FunctionCall with arguments to the client side for execution. The model may decide to call a subset of these functions by populating FunctionCall in the response. The next conversation turn may contain a FunctionResponse with the [content.role] \"function\" generation context for the next model turn.",
+          "items": {
+            "$ref": "FunctionDeclaration"
+          }
+        }
+      }
+    },
+    "BatchEmbedContentsResponse": {
+      "type": "object",
+      "description": "The response to a `BatchEmbedContentsRequest`.",
+      "id": "BatchEmbedContentsResponse",
+      "properties": {
+        "embeddings": {
+          "description": "Output only. The embeddings for each request, in the same order as provided in the batch request.",
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "ContentEmbedding"
+          }
+        }
+      }
+    },
+    "GenerateMessageRequest": {
+      "type": "object",
+      "properties": {
+        "topP": {
+          "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`.",
+          "format": "float",
+          "type": "number"
+        },
+        "temperature": {
+          "type": "number",
+          "format": "float",
+          "description": "Optional. Controls the randomness of the output. Values can range over `[0.0,1.0]`, inclusive. A value closer to `1.0` will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model."
+        },
+        "topK": {
+          "type": "integer",
+          "description": "Optional. The maximum number of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens.",
+          "format": "int32"
+        },
+        "prompt": {
+          "description": "Required. The structured textual input given to the model as a prompt. Given a prompt, the model will return what it predicts is the next message in the discussion.",
+          "$ref": "MessagePrompt"
+        },
+        "candidateCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. The number of generated response messages to return. This value must be between `[1, 8]`, inclusive. If unset, this will default to `1`."
+        }
+      },
+      "id": "GenerateMessageRequest",
+      "description": "Request to generate a message response from the model."
+    },
+    "BatchEmbedContentsRequest": {
+      "id": "BatchEmbedContentsRequest",
+      "properties": {
+        "requests": {
+          "description": "Required. Embed requests for the batch. The model in each of these requests must match the model specified `BatchEmbedContentsRequest.model`.",
+          "items": {
+            "$ref": "EmbedContentRequest"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "description": "Batch request to get embeddings from the model for a list of prompts."
+    },
+    "GroundingPassages": {
+      "type": "object",
+      "description": "A repeated list of passages.",
+      "id": "GroundingPassages",
+      "properties": {
+        "passages": {
+          "description": "List of passages.",
+          "type": "array",
+          "items": {
+            "$ref": "GroundingPassage"
+          }
+        }
+      }
     },
     "GenerateMessageResponse": {
       "description": "The response from the model. This includes candidate messages and conversation history in the form of chronologically-ordered messages.",
+      "id": "GenerateMessageResponse",
+      "type": "object",
       "properties": {
         "candidates": {
           "type": "array",
-          "description": "Candidate response messages from the model.",
           "items": {
             "$ref": "Message"
-          }
-        },
-        "filters": {
-          "items": {
-            "$ref": "ContentFilter"
           },
-          "type": "array",
-          "description": "A set of content filtering metadata for the prompt and response text. This indicates which `SafetyCategory`(s) blocked a candidate from this response, the lowest `HarmProbability` that triggered a block, and the HarmThreshold setting for that category."
+          "description": "Candidate response messages from the model."
         },
         "messages": {
           "type": "array",
@@ -1501,190 +2112,109 @@
           "items": {
             "$ref": "Message"
           }
-        }
-      },
-      "id": "GenerateMessageResponse",
-      "type": "object"
-    },
-    "TextCompletion": {
-      "description": "Output text returned from a model.",
-      "properties": {
-        "output": {
-          "readOnly": true,
-          "description": "Output only. The generated text returned from the model.",
-          "type": "string"
         },
-        "citationMetadata": {
-          "readOnly": true,
-          "description": "Output only. Citation information for model-generated `output` in this `TextCompletion`. This field may be populated with attribution information for any text included in the `output`.",
-          "$ref": "CitationMetadata"
-        },
-        "safetyRatings": {
-          "description": "Ratings for the safety of a response. There is at most one rating per category.",
+        "filters": {
+          "description": "A set of content filtering metadata for the prompt and response text. This indicates which `SafetyCategory`(s) blocked a candidate from this response, the lowest `HarmProbability` that triggered a block, and the HarmThreshold setting for that category.",
           "type": "array",
           "items": {
-            "$ref": "SafetyRating"
-          }
-        }
-      },
-      "id": "TextCompletion",
-      "type": "object"
-    },
-    "DeleteChunkRequest": {
-      "id": "DeleteChunkRequest",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Required. The resource name of the `Chunk` to delete. Example: `corpora/my-corpus-123/documents/the-doc-abc/chunks/some-chunk`"
-        }
-      },
-      "type": "object",
-      "description": "Request to delete a `Chunk`."
-    },
-    "CustomMetadata": {
-      "description": "User provided metadata stored as key-value pairs.",
-      "id": "CustomMetadata",
-      "properties": {
-        "stringListValue": {
-          "$ref": "StringList",
-          "description": "The StringList value of the metadata to store."
-        },
-        "stringValue": {
-          "description": "The string value of the metadata to store.",
-          "type": "string"
-        },
-        "numericValue": {
-          "type": "number",
-          "description": "The numeric value of the metadata to store.",
-          "format": "float"
-        },
-        "key": {
-          "description": "Required. The key of the metadata to store.",
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "GroundingPassage": {
-      "properties": {
-        "id": {
-          "description": "Identifier for the passage for attributing this passage in grounded answers.",
-          "type": "string"
-        },
-        "content": {
-          "description": "Content of the passage.",
-          "$ref": "Content"
-        }
-      },
-      "description": "Passage included inline with a grounding configuration.",
-      "id": "GroundingPassage",
-      "type": "object"
-    },
-    "GenerateTextResponse": {
-      "id": "GenerateTextResponse",
-      "properties": {
-        "filters": {
-          "description": "A set of content filtering metadata for the prompt and response text. This indicates which `SafetyCategory`(s) blocked a candidate from this response, the lowest `HarmProbability` that triggered a block, and the HarmThreshold setting for that category. This indicates the smallest change to the `SafetySettings` that would be necessary to unblock at least 1 response. The blocking is configured by the `SafetySettings` in the request (or the default `SafetySettings` of the API).",
-          "items": {
             "$ref": "ContentFilter"
-          },
-          "type": "array"
-        },
-        "candidates": {
-          "items": {
-            "$ref": "TextCompletion"
-          },
-          "description": "Candidate responses from the model.",
-          "type": "array"
-        },
-        "safetyFeedback": {
-          "items": {
-            "$ref": "SafetyFeedback"
-          },
-          "description": "Returns any safety feedback related to content filtering.",
-          "type": "array"
-        }
-      },
-      "type": "object",
-      "description": "The response from the model, including candidate completions."
-    },
-    "Blob": {
-      "type": "object",
-      "id": "Blob",
-      "description": "Raw media bytes. Text should not be sent as raw bytes, use the 'text' field.",
-      "properties": {
-        "mimeType": {
-          "description": "The IANA standard MIME type of the source data. Examples: - image/png - image/jpeg If an unsupported MIME type is provided, an error will be returned. For a complete list of supported types, see [Supported file formats](https://ai.google.dev/gemini-api/docs/prompting_with_media#supported_file_formats).",
-          "type": "string"
-        },
-        "data": {
-          "description": "Raw bytes for media formats.",
-          "type": "string",
-          "format": "byte"
+          }
         }
       }
     },
-    "File": {
+    "TransferOwnershipRequest": {
+      "type": "object",
+      "description": "Request to transfer the ownership of the tuned model.",
+      "id": "TransferOwnershipRequest",
+      "properties": {
+        "emailAddress": {
+          "type": "string",
+          "description": "Required. The email address of the user to whom the tuned model is being transferred to."
+        }
+      }
+    },
+    "ListPermissionsResponse": {
+      "properties": {
+        "nextPageToken": {
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages.",
+          "type": "string"
+        },
+        "permissions": {
+          "type": "array",
+          "items": {
+            "$ref": "Permission"
+          },
+          "description": "Returned permissions."
+        }
+      },
+      "description": "Response from `ListPermissions` containing a paginated list of permissions.",
+      "type": "object",
+      "id": "ListPermissionsResponse"
+    },
+    "ToolConfig": {
       "type": "object",
       "properties": {
-        "sizeBytes": {
-          "description": "Output only. Size of the file in bytes.",
-          "readOnly": true,
-          "format": "int64",
-          "type": "string"
-        },
-        "sha256Hash": {
-          "readOnly": true,
-          "format": "byte",
-          "type": "string",
-          "description": "Output only. SHA-256 hash of the uploaded bytes."
-        },
-        "expirationTime": {
-          "description": "Output only. The timestamp of when the `File` will be deleted. Only set if the `File` is scheduled to expire.",
-          "format": "google-datetime",
-          "readOnly": true,
-          "type": "string"
-        },
-        "createTime": {
-          "format": "google-datetime",
-          "type": "string",
-          "readOnly": true,
-          "description": "Output only. The timestamp of when the `File` was created."
-        },
-        "updateTime": {
-          "description": "Output only. The timestamp of when the `File` was last updated.",
-          "type": "string",
-          "format": "google-datetime",
-          "readOnly": true
-        },
-        "displayName": {
-          "description": "Optional. The human-readable display name for the `File`. The display name must be no more than 512 characters in length, including spaces. Example: \"Welcome Image\"",
-          "type": "string"
-        },
-        "error": {
-          "readOnly": true,
-          "$ref": "Status",
-          "description": "Output only. Error status if File processing failed."
-        },
+        "functionCallingConfig": {
+          "description": "Optional. Function calling config.",
+          "$ref": "FunctionCallingConfig"
+        }
+      },
+      "id": "ToolConfig",
+      "description": "The Tool configuration containing parameters for specifying `Tool` use in the request."
+    },
+    "CitationSource": {
+      "type": "object",
+      "id": "CitationSource",
+      "properties": {
         "uri": {
-          "description": "Output only. The uri of the `File`.",
           "type": "string",
-          "readOnly": true
+          "description": "Optional. URI that is attributed as a source for a portion of the text."
         },
-        "mimeType": {
-          "readOnly": true,
-          "description": "Output only. MIME type of the file.",
-          "type": "string"
+        "endIndex": {
+          "description": "Optional. End of the attributed segment, exclusive.",
+          "type": "integer",
+          "format": "int32"
         },
-        "videoMetadata": {
-          "readOnly": true,
-          "description": "Output only. Metadata for a video.",
-          "$ref": "VideoMetadata"
+        "startIndex": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. Start of segment of the response that is attributed to this source. Index indicates the start of the segment, measured in bytes."
         },
-        "name": {
+        "license": {
           "type": "string",
-          "description": "Immutable. Identifier. The `File` resource name. The ID (name excluding the \"files/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be generated. Example: `files/123-456`"
-        },
+          "description": "Optional. License for the GitHub project that is attributed as a source for segment. License info is required for code citations."
+        }
+      },
+      "description": "A citation to a source for a portion of a specific response."
+    },
+    "CountMessageTokensResponse": {
+      "id": "CountMessageTokensResponse",
+      "description": "A response from `CountMessageTokens`. It returns the model's `token_count` for the `prompt`.",
+      "properties": {
+        "tokenCount": {
+          "description": "The number of tokens that the `model` tokenizes the `prompt` into. Always non-negative.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "BatchUpdateChunksRequest": {
+      "description": "Request to batch update `Chunk`s.",
+      "id": "BatchUpdateChunksRequest",
+      "properties": {
+        "requests": {
+          "description": "Required. The request messages specifying the `Chunk`s to update. A maximum of 100 `Chunk`s can be updated in a batch.",
+          "items": {
+            "$ref": "UpdateChunkRequest"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "File": {
+      "properties": {
         "state": {
           "enumDescriptions": [
             "The default value. This value is used if the state is omitted.",
@@ -1698,216 +2228,909 @@
             "ACTIVE",
             "FAILED"
           ],
-          "readOnly": true,
           "description": "Output only. Processing state of the File.",
+          "type": "string",
+          "readOnly": true
+        },
+        "mimeType": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Output only. MIME type of the file."
+        },
+        "videoMetadata": {
+          "description": "Output only. Metadata for a video.",
+          "readOnly": true,
+          "$ref": "VideoMetadata"
+        },
+        "uri": {
+          "readOnly": true,
+          "description": "Output only. The uri of the `File`.",
+          "type": "string"
+        },
+        "sha256Hash": {
+          "readOnly": true,
+          "format": "byte",
+          "type": "string",
+          "description": "Output only. SHA-256 hash of the uploaded bytes."
+        },
+        "updateTime": {
+          "format": "google-datetime",
+          "type": "string",
+          "description": "Output only. The timestamp of when the `File` was last updated.",
+          "readOnly": true
+        },
+        "sizeBytes": {
+          "readOnly": true,
+          "format": "int64",
+          "type": "string",
+          "description": "Output only. Size of the file in bytes."
+        },
+        "createTime": {
+          "format": "google-datetime",
+          "description": "Output only. The timestamp of when the `File` was created.",
+          "type": "string",
+          "readOnly": true
+        },
+        "error": {
+          "$ref": "Status",
+          "readOnly": true,
+          "description": "Output only. Error status if File processing failed."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Optional. The human-readable display name for the `File`. The display name must be no more than 512 characters in length, including spaces. Example: \"Welcome Image\""
+        },
+        "expirationTime": {
+          "description": "Output only. The timestamp of when the `File` will be deleted. Only set if the `File` is scheduled to expire.",
+          "type": "string",
+          "format": "google-datetime",
+          "readOnly": true
+        },
+        "name": {
+          "description": "Immutable. Identifier. The `File` resource name. The ID (name excluding the \"files/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be generated. Example: `files/123-456`",
           "type": "string"
         }
       },
-      "description": "A file uploaded to the API.",
-      "id": "File"
+      "type": "object",
+      "id": "File",
+      "description": "A file uploaded to the API."
     },
-    "GenerateTextRequest": {
+    "BatchCreateChunksRequest": {
       "properties": {
-        "topP": {
-          "format": "float",
-          "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Tokens are sorted based on their assigned probabilities so that only the most likely tokens are considered. Top-k sampling directly limits the maximum number of tokens to consider, while Nucleus sampling limits number of tokens based on the cumulative probability. Note: The default value varies by model, see the `Model.top_p` attribute of the `Model` returned the `getModel` function.",
-          "type": "number"
-        },
-        "prompt": {
-          "description": "Required. The free-form input text given to the model as a prompt. Given a prompt, the model will generate a TextCompletion response it predicts as the completion of the input text.",
-          "$ref": "TextPrompt"
-        },
-        "topK": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Optional. The maximum number of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens. Defaults to 40. Note: The default value varies by model, see the `Model.top_k` attribute of the `Model` returned the `getModel` function."
-        },
-        "maxOutputTokens": {
-          "format": "int32",
-          "description": "Optional. The maximum number of tokens to include in a candidate. If unset, this will default to output_token_limit specified in the `Model` specification.",
-          "type": "integer"
-        },
-        "candidateCount": {
-          "description": "Optional. Number of generated responses to return. This value must be between [1, 8], inclusive. If unset, this will default to 1.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "temperature": {
-          "type": "number",
-          "description": "Optional. Controls the randomness of the output. Note: The default value varies by model, see the `Model.temperature` attribute of the `Model` returned the `getModel` function. Values can range from [0.0,1.0], inclusive. A value closer to 1.0 will produce responses that are more varied and creative, while a value closer to 0.0 will typically result in more straightforward responses from the model.",
-          "format": "float"
-        },
-        "safetySettings": {
-          "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content. that will be enforced on the `GenerateTextRequest.prompt` and `GenerateTextResponse.candidates`. There should not be more than one setting for each `SafetyCategory` type. The API will block any prompts and responses that fail to meet the thresholds set by these settings. This list overrides the default settings for each `SafetyCategory` specified in the safety_settings. If there is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use the default safety setting for that category. Harm categories HARM_CATEGORY_DEROGATORY, HARM_CATEGORY_TOXICITY, HARM_CATEGORY_VIOLENCE, HARM_CATEGORY_SEXUAL, HARM_CATEGORY_MEDICAL, HARM_CATEGORY_DANGEROUS are supported in text service.",
+        "requests": {
           "items": {
-            "$ref": "SafetySetting"
+            "$ref": "CreateChunkRequest"
+          },
+          "description": "Required. The request messages specifying the `Chunk`s to create. A maximum of 100 `Chunk`s can be created in a batch.",
+          "type": "array"
+        }
+      },
+      "description": "Request to batch create `Chunk`s.",
+      "type": "object",
+      "id": "BatchCreateChunksRequest"
+    },
+    "UpdateChunkRequest": {
+      "type": "object",
+      "properties": {
+        "updateMask": {
+          "type": "string",
+          "format": "google-fieldmask",
+          "description": "Required. The list of fields to update. Currently, this only supports updating `custom_metadata` and `data`."
+        },
+        "chunk": {
+          "description": "Required. The `Chunk` to update.",
+          "$ref": "Chunk"
+        }
+      },
+      "description": "Request to update a `Chunk`.",
+      "id": "UpdateChunkRequest"
+    },
+    "QueryDocumentResponse": {
+      "type": "object",
+      "description": "Response from `QueryDocument` containing a list of relevant chunks.",
+      "properties": {
+        "relevantChunks": {
+          "items": {
+            "$ref": "RelevantChunk"
+          },
+          "description": "The returned relevant chunks.",
+          "type": "array"
+        }
+      },
+      "id": "QueryDocumentResponse"
+    },
+    "SafetySetting": {
+      "properties": {
+        "category": {
+          "enumDescriptions": [
+            "Category is unspecified.",
+            "Negative or harmful comments targeting identity and/or protected attribute.",
+            "Content that is rude, disrespectful, or profane.",
+            "Describes scenarios depicting violence against an individual or group, or general descriptions of gore.",
+            "Contains references to sexual acts or other lewd content.",
+            "Promotes unchecked medical advice.",
+            "Dangerous content that promotes, facilitates, or encourages harmful acts.",
+            "Harasment content.",
+            "Hate speech and content.",
+            "Sexually explicit content.",
+            "Dangerous content."
+          ],
+          "description": "Required. The category for this setting.",
+          "type": "string",
+          "enum": [
+            "HARM_CATEGORY_UNSPECIFIED",
+            "HARM_CATEGORY_DEROGATORY",
+            "HARM_CATEGORY_TOXICITY",
+            "HARM_CATEGORY_VIOLENCE",
+            "HARM_CATEGORY_SEXUAL",
+            "HARM_CATEGORY_MEDICAL",
+            "HARM_CATEGORY_DANGEROUS",
+            "HARM_CATEGORY_HARASSMENT",
+            "HARM_CATEGORY_HATE_SPEECH",
+            "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+            "HARM_CATEGORY_DANGEROUS_CONTENT"
+          ]
+        },
+        "threshold": {
+          "description": "Required. Controls the probability threshold at which harm is blocked.",
+          "enum": [
+            "HARM_BLOCK_THRESHOLD_UNSPECIFIED",
+            "BLOCK_LOW_AND_ABOVE",
+            "BLOCK_MEDIUM_AND_ABOVE",
+            "BLOCK_ONLY_HIGH",
+            "BLOCK_NONE"
+          ],
+          "type": "string",
+          "enumDescriptions": [
+            "Threshold is unspecified.",
+            "Content with NEGLIGIBLE will be allowed.",
+            "Content with NEGLIGIBLE and LOW will be allowed.",
+            "Content with NEGLIGIBLE, LOW, and MEDIUM will be allowed.",
+            "All content will be allowed."
+          ]
+        }
+      },
+      "id": "SafetySetting",
+      "type": "object",
+      "description": "Safety setting, affecting the safety-blocking behavior. Passing a safety setting for a category changes the allowed probability that content is blocked."
+    },
+    "SafetyFeedback": {
+      "description": "Safety feedback for an entire request. This field is populated if content in the input and/or response is blocked due to safety settings. SafetyFeedback may not exist for every HarmCategory. Each SafetyFeedback will return the safety settings used by the request as well as the lowest HarmProbability that should be allowed in order to return a result.",
+      "type": "object",
+      "id": "SafetyFeedback",
+      "properties": {
+        "rating": {
+          "description": "Safety rating evaluated from content.",
+          "$ref": "SafetyRating"
+        },
+        "setting": {
+          "$ref": "SafetySetting",
+          "description": "Safety settings applied to the request."
+        }
+      }
+    },
+    "TransferOwnershipResponse": {
+      "id": "TransferOwnershipResponse",
+      "type": "object",
+      "description": "Response from `TransferOwnership`.",
+      "properties": {}
+    },
+    "QueryCorpusRequest": {
+      "type": "object",
+      "properties": {
+        "metadataFilters": {
+          "type": "array",
+          "items": {
+            "$ref": "MetadataFilter"
+          },
+          "description": "Optional. Filter for `Chunk` and `Document` metadata. Each `MetadataFilter` object should correspond to a unique key. Multiple `MetadataFilter` objects are joined by logical \"AND\"s. Example query at document level: (year \u003e= 2020 OR year \u003c 2010) AND (genre = drama OR genre = action) `MetadataFilter` object list: metadata_filters = [ {key = \"document.custom_metadata.year\" conditions = [{int_value = 2020, operation = GREATER_EQUAL}, {int_value = 2010, operation = LESS}]}, {key = \"document.custom_metadata.year\" conditions = [{int_value = 2020, operation = GREATER_EQUAL}, {int_value = 2010, operation = LESS}]}, {key = \"document.custom_metadata.genre\" conditions = [{string_value = \"drama\", operation = EQUAL}, {string_value = \"action\", operation = EQUAL}]}] Example query at chunk level for a numeric range of values: (year \u003e 2015 AND year \u003c= 2020) `MetadataFilter` object list: metadata_filters = [ {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2015, operation = GREATER}]}, {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2020, operation = LESS_EQUAL}]}] Note: \"AND\"s for the same key are only supported for numeric values. String values only support \"OR\"s for the same key."
+        },
+        "query": {
+          "type": "string",
+          "description": "Required. Query string to perform semantic search."
+        },
+        "resultsCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. The maximum number of `Chunk`s to return. The service may return fewer `Chunk`s. If unspecified, at most 10 `Chunk`s will be returned. The maximum specified result count is 100."
+        }
+      },
+      "id": "QueryCorpusRequest",
+      "description": "Request for querying a `Corpus`."
+    },
+    "ListTunedModelsResponse": {
+      "type": "object",
+      "id": "ListTunedModelsResponse",
+      "description": "Response from `ListTunedModels` containing a paginated list of Models.",
+      "properties": {
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
+        },
+        "tunedModels": {
+          "description": "The returned Models.",
+          "type": "array",
+          "items": {
+            "$ref": "TunedModel"
+          }
+        }
+      }
+    },
+    "ListModelsResponse": {
+      "properties": {
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
+        },
+        "models": {
+          "description": "The returned Models.",
+          "items": {
+            "$ref": "Model"
           },
           "type": "array"
-        },
-        "stopSequences": {
+        }
+      },
+      "description": "Response from `ListModel` containing a paginated list of Models.",
+      "id": "ListModelsResponse",
+      "type": "object"
+    },
+    "Embedding": {
+      "description": "A list of floats representing the embedding.",
+      "properties": {
+        "value": {
+          "description": "The embedding values.",
+          "items": {
+            "format": "float",
+            "type": "number"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "id": "Embedding"
+    },
+    "BatchEmbedTextRequest": {
+      "id": "BatchEmbedTextRequest",
+      "type": "object",
+      "description": "Batch request to get a text embedding from the model.",
+      "properties": {
+        "requests": {
+          "description": "Optional. Embed requests for the batch. Only one of `texts` or `requests` can be set.",
           "type": "array",
-          "description": "The set of character sequences (up to 5) that will stop output generation. If specified, the API will stop at the first appearance of a stop sequence. The stop sequence will not be included as part of the response.",
+          "items": {
+            "$ref": "EmbedTextRequest"
+          }
+        },
+        "texts": {
+          "description": "Optional. The free-form input texts that the model will turn into an embedding. The current limit is 100 texts, over which an error will be thrown.",
+          "type": "array",
           "items": {
             "type": "string"
           }
         }
-      },
-      "type": "object",
-      "id": "GenerateTextRequest",
-      "description": "Request to generate a text completion response from the model."
-    },
-    "Hyperparameters": {
-      "id": "Hyperparameters",
-      "properties": {
-        "epochCount": {
-          "description": "Immutable. The number of training epochs. An epoch is one pass through the training data. If not set, a default of 5 will be used.",
-          "format": "int32",
-          "type": "integer"
-        },
-        "learningRate": {
-          "type": "number",
-          "format": "float",
-          "description": "Optional. Immutable. The learning rate hyperparameter for tuning. If not set, a default of 0.001 or 0.0002 will be calculated based on the number of training examples."
-        },
-        "batchSize": {
-          "description": "Immutable. The batch size hyperparameter for tuning. If not set, a default of 4 or 16 will be used based on the number of training examples.",
-          "format": "int32",
-          "type": "integer"
-        },
-        "learningRateMultiplier": {
-          "description": "Optional. Immutable. The learning rate multiplier is used to calculate a final learning_rate based on the default (recommended) value. Actual learning rate := learning_rate_multiplier * default learning rate Default learning rate is dependent on base model and dataset size. If not set, a default of 1.0 will be used.",
-          "format": "float",
-          "type": "number"
-        }
-      },
-      "type": "object",
-      "description": "Hyperparameters controlling the tuning process. Read more at https://ai.google.dev/docs/model_tuning_guidance"
-    },
-    "GenerateAnswerResponse": {
-      "id": "GenerateAnswerResponse",
-      "properties": {
-        "answerableProbability": {
-          "description": "Output only. The model's estimate of the probability that its answer is correct and grounded in the input passages. A low answerable_probability indicates that the answer might not be grounded in the sources. When `answerable_probability` is low, some clients may wish to: * Display a message to the effect of \"We couldn’t answer that question\" to the user. * Fall back to a general-purpose LLM that answers the question from world knowledge. The threshold and nature of such fallbacks will depend on individual clients’ use cases. 0.5 is a good starting threshold.",
-          "type": "number",
-          "readOnly": true,
-          "format": "float"
-        },
-        "inputFeedback": {
-          "description": "Output only. Feedback related to the input data used to answer the question, as opposed to model-generated response to the question. \"Input data\" can be one or more of the following: - Question specified by the last entry in `GenerateAnswerRequest.content` - Conversation history specified by the other entries in `GenerateAnswerRequest.content` - Grounding sources (`GenerateAnswerRequest.semantic_retriever` or `GenerateAnswerRequest.inline_passages`)",
-          "readOnly": true,
-          "$ref": "InputFeedback"
-        },
-        "answer": {
-          "description": "Candidate answer from the model. Note: The model *always* attempts to provide a grounded answer, even when the answer is unlikely to be answerable from the given passages. In that case, a low-quality or ungrounded answer may be provided, along with a low `answerable_probability`.",
-          "$ref": "Candidate"
-        }
-      },
-      "description": "Response from the model for a grounded answer.",
-      "type": "object"
-    },
-    "Message": {
-      "description": "The base unit of structured text. A `Message` includes an `author` and the `content` of the `Message`. The `author` is used to tag messages when they are fed to the model as text.",
-      "id": "Message",
-      "type": "object",
-      "properties": {
-        "citationMetadata": {
-          "readOnly": true,
-          "description": "Output only. Citation information for model-generated `content` in this `Message`. If this `Message` was generated as output from the model, this field may be populated with attribution information for any text included in the `content`. This field is used only on output.",
-          "$ref": "CitationMetadata"
-        },
-        "content": {
-          "type": "string",
-          "description": "Required. The text content of the structured `Message`."
-        },
-        "author": {
-          "description": "Optional. The author of this Message. This serves as a key for tagging the content of this Message when it is fed to the model as text. The author can be any alphanumeric string.",
-          "type": "string"
-        }
       }
     },
-    "AttributionSourceId": {
-      "type": "object",
-      "id": "AttributionSourceId",
-      "description": "Identifier for the source contributing to this attribution.",
+    "ListChunksResponse": {
+      "id": "ListChunksResponse",
       "properties": {
-        "semanticRetrieverChunk": {
-          "description": "Identifier for a `Chunk` fetched via Semantic Retriever.",
-          "$ref": "SemanticRetrieverChunk"
+        "nextPageToken": {
+          "type": "string",
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
         },
-        "groundingPassage": {
-          "description": "Identifier for an inline passage.",
-          "$ref": "GroundingPassageId"
+        "chunks": {
+          "description": "The returned `Chunk`s.",
+          "items": {
+            "$ref": "Chunk"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "description": "Response from `ListChunks` containing a paginated list of `Chunk`s. The `Chunk`s are sorted by ascending `chunk.create_time`."
+    },
+    "QueryCorpusResponse": {
+      "type": "object",
+      "id": "QueryCorpusResponse",
+      "properties": {
+        "relevantChunks": {
+          "items": {
+            "$ref": "RelevantChunk"
+          },
+          "type": "array",
+          "description": "The relevant chunks."
+        }
+      },
+      "description": "Response from `QueryCorpus` containing a list of relevant chunks."
+    },
+    "FunctionCall": {
+      "id": "FunctionCall",
+      "description": "A predicted `FunctionCall` returned from the model that contains a string representing the `FunctionDeclaration.name` with the arguments and their values.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Required. The name of the function to call. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63.",
+          "type": "string"
+        },
+        "args": {
+          "description": "Optional. The function parameters and values in JSON object format.",
+          "additionalProperties": {
+            "type": "any",
+            "description": "Properties of the object."
+          },
+          "type": "object"
         }
       }
     },
     "UsageMetadata": {
-      "id": "UsageMetadata",
-      "type": "object",
       "properties": {
-        "promptTokenCount": {
-          "type": "integer",
+        "candidatesTokenCount": {
           "format": "int32",
-          "description": "Number of tokens in the prompt. When cached_content is set, this is still the total effective prompt size. I.e. this includes the number of tokens in the cached content."
-        },
-        "cachedContentTokenCount": {
-          "format": "int32",
-          "description": "Number of tokens in the cached part of the prompt, i.e. in the cached content.",
+          "description": "Total number of tokens across the generated candidates.",
           "type": "integer"
         },
-        "candidatesTokenCount": {
-          "description": "Total number of tokens across the generated candidates.",
+        "totalTokenCount": {
+          "description": "Total token count for the generation request (prompt + candidates).",
           "type": "integer",
           "format": "int32"
         },
-        "totalTokenCount": {
+        "cachedContentTokenCount": {
+          "description": "Number of tokens in the cached part of the prompt, i.e. in the cached content.",
           "format": "int32",
-          "description": "Total token count for the generation request (prompt + candidates).",
           "type": "integer"
+        },
+        "promptTokenCount": {
+          "format": "int32",
+          "type": "integer",
+          "description": "Number of tokens in the prompt. When cached_content is set, this is still the total effective prompt size. I.e. this includes the number of tokens in the cached content."
         }
       },
+      "id": "UsageMetadata",
+      "type": "object",
       "description": "Metadata on the generation request's token usage."
     },
-    "GenerateMessageRequest": {
+    "FunctionDeclaration": {
+      "description": "Structured representation of a function declaration as defined by the [OpenAPI 3.03 specification](https://spec.openapis.org/oas/v3.0.3). Included in this declaration are the function name and parameters. This FunctionDeclaration is a representation of a block of code that can be used as a `Tool` by the model and executed by the client.",
+      "id": "FunctionDeclaration",
       "properties": {
-        "topK": {
-          "format": "int32",
-          "type": "integer",
-          "description": "Optional. The maximum number of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens."
+        "description": {
+          "description": "Required. A brief description of the function.",
+          "type": "string"
         },
-        "candidateCount": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Optional. The number of generated response messages to return. This value must be between `[1, 8]`, inclusive. If unset, this will default to `1`."
+        "parameters": {
+          "$ref": "Schema",
+          "description": "Optional. Describes the parameters to this function. Reflects the Open API 3.03 Parameter Object string Key: the name of the parameter. Parameter names are case sensitive. Schema Value: the Schema defining the type used for the parameter."
         },
-        "temperature": {
-          "type": "number",
-          "format": "float",
-          "description": "Optional. Controls the randomness of the output. Values can range over `[0.0,1.0]`, inclusive. A value closer to `1.0` will produce responses that are more varied, while a value closer to `0.0` will typically result in less surprising responses from the model."
-        },
-        "topP": {
-          "format": "float",
-          "type": "number",
-          "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Nucleus sampling considers the smallest set of tokens whose probability sum is at least `top_p`."
-        },
-        "prompt": {
-          "description": "Required. The structured textual input given to the model as a prompt. Given a prompt, the model will return what it predicts is the next message in the discussion.",
-          "$ref": "MessagePrompt"
+        "name": {
+          "type": "string",
+          "description": "Required. The name of the function. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
         }
       },
-      "description": "Request to generate a message response from the model.",
+      "type": "object"
+    },
+    "GenerateContentResponse": {
+      "id": "GenerateContentResponse",
+      "properties": {
+        "candidates": {
+          "description": "Candidate responses from the model.",
+          "type": "array",
+          "items": {
+            "$ref": "Candidate"
+          }
+        },
+        "usageMetadata": {
+          "$ref": "UsageMetadata",
+          "readOnly": true,
+          "description": "Output only. Metadata on the generation requests' token usage."
+        },
+        "promptFeedback": {
+          "description": "Returns the prompt's feedback related to the content filters.",
+          "$ref": "PromptFeedback"
+        }
+      },
+      "description": "Response from the model supporting multiple candidates. Note on safety ratings and content filtering. They are reported for both prompt in `GenerateContentResponse.prompt_feedback` and for each candidate in `finish_reason` and in `safety_ratings`. The API contract is that: - either all requested candidates are returned or no candidates at all - no candidates are returned only if there was something wrong with the prompt (see `prompt_feedback`) - feedback on each candidate is reported on `finish_reason` and `safety_ratings`.",
+      "type": "object"
+    },
+    "TunedModelSource": {
+      "id": "TunedModelSource",
+      "description": "Tuned model as a source for training a new model.",
       "type": "object",
-      "id": "GenerateMessageRequest"
+      "properties": {
+        "baseModel": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Output only. The name of the base `Model` this `TunedModel` was tuned from. Example: `models/text-bison-001`"
+        },
+        "tunedModel": {
+          "description": "Immutable. The name of the `TunedModel` to use as the starting point for training the new model. Example: `tunedModels/my-tuned-model`",
+          "type": "string"
+        }
+      }
+    },
+    "BatchUpdateChunksResponse": {
+      "type": "object",
+      "id": "BatchUpdateChunksResponse",
+      "properties": {
+        "chunks": {
+          "type": "array",
+          "description": "`Chunk`s updated.",
+          "items": {
+            "$ref": "Chunk"
+          }
+        }
+      },
+      "description": "Response from `BatchUpdateChunks` containing a list of updated `Chunk`s."
+    },
+    "ListCachedContentsResponse": {
+      "id": "ListCachedContentsResponse",
+      "properties": {
+        "nextPageToken": {
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.",
+          "type": "string"
+        },
+        "cachedContents": {
+          "description": "List of cached contents.",
+          "type": "array",
+          "items": {
+            "$ref": "CachedContent"
+          }
+        }
+      },
+      "description": "Response with CachedContents list.",
+      "type": "object"
+    },
+    "Status": {
+      "description": "The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).",
+      "id": "Status",
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "The status code, which should be an enum value of google.rpc.Code.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "message": {
+          "type": "string",
+          "description": "A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client."
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "description": "Properties of the object. Contains field @type with type URL.",
+              "type": "any"
+            }
+          },
+          "description": "A list of messages that carry the error details. There is a common set of message types for APIs to use."
+        }
+      }
+    },
+    "Hyperparameters": {
+      "description": "Hyperparameters controlling the tuning process. Read more at https://ai.google.dev/docs/model_tuning_guidance",
+      "type": "object",
+      "id": "Hyperparameters",
+      "properties": {
+        "learningRate": {
+          "format": "float",
+          "description": "Optional. Immutable. The learning rate hyperparameter for tuning. If not set, a default of 0.001 or 0.0002 will be calculated based on the number of training examples.",
+          "type": "number"
+        },
+        "epochCount": {
+          "format": "int32",
+          "type": "integer",
+          "description": "Immutable. The number of training epochs. An epoch is one pass through the training data. If not set, a default of 5 will be used."
+        },
+        "learningRateMultiplier": {
+          "format": "float",
+          "description": "Optional. Immutable. The learning rate multiplier is used to calculate a final learning_rate based on the default (recommended) value. Actual learning rate := learning_rate_multiplier * default learning rate Default learning rate is dependent on base model and dataset size. If not set, a default of 1.0 will be used.",
+          "type": "number"
+        },
+        "batchSize": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Immutable. The batch size hyperparameter for tuning. If not set, a default of 4 or 16 will be used based on the number of training examples."
+        }
+      }
+    },
+    "CountMessageTokensRequest": {
+      "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`.",
+      "type": "object",
+      "properties": {
+        "prompt": {
+          "$ref": "MessagePrompt",
+          "description": "Required. The prompt, whose token count is to be returned."
+        }
+      },
+      "id": "CountMessageTokensRequest"
+    },
+    "Operation": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "$ref": "Status",
+          "description": "The error result of the operation in case of failure or cancellation."
+        },
+        "done": {
+          "description": "If the value is `false`, it means the operation is still in progress. If `true`, the operation is completed, and either `error` or `response` is available.",
+          "type": "boolean"
+        },
+        "response": {
+          "description": "The normal, successful response of the operation. If the original method returns no data on success, such as `Delete`, the response is `google.protobuf.Empty`. If the original method is standard `Get`/`Create`/`Update`, the response should be the resource. For other methods, the response should have the type `XxxResponse`, where `Xxx` is the original method name. For example, if the original method name is `TakeSnapshot()`, the inferred response type is `TakeSnapshotResponse`.",
+          "additionalProperties": {
+            "description": "Properties of the object. Contains field @type with type URL.",
+            "type": "any"
+          },
+          "type": "object"
+        },
+        "name": {
+          "description": "The server-assigned name, which is only unique within the same service that originally returns it. If you use the default HTTP mapping, the `name` should be a resource name ending with `operations/{unique_id}`.",
+          "type": "string"
+        },
+        "metadata": {
+          "additionalProperties": {
+            "description": "Properties of the object. Contains field @type with type URL.",
+            "type": "any"
+          },
+          "type": "object",
+          "description": "Service-specific metadata associated with the operation. It typically contains progress information and common metadata such as create time. Some services might not provide such metadata. Any method that returns a long-running operation should document the metadata type, if any."
+        }
+      },
+      "id": "Operation",
+      "description": "This resource represents a long-running operation that is the result of a network API call."
+    },
+    "Permission": {
+      "id": "Permission",
+      "properties": {
+        "emailAddress": {
+          "description": "Optional. Immutable. The email address of the user of group which this permission refers. Field is not set when permission's grantee type is EVERYONE.",
+          "type": "string"
+        },
+        "granteeType": {
+          "type": "string",
+          "description": "Optional. Immutable. The type of the grantee.",
+          "enumDescriptions": [
+            "The default value. This value is unused.",
+            "Represents a user. When set, you must provide email_address for the user.",
+            "Represents a group. When set, you must provide email_address for the group.",
+            "Represents access to everyone. No extra information is required."
+          ],
+          "enum": [
+            "GRANTEE_TYPE_UNSPECIFIED",
+            "USER",
+            "GROUP",
+            "EVERYONE"
+          ]
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. Identifier. The permission name. A unique name will be generated on create. Examples: tunedModels/{tuned_model}/permissions/{permission} corpora/{corpus}/permissions/{permission} Output only."
+        },
+        "role": {
+          "type": "string",
+          "enumDescriptions": [
+            "The default value. This value is unused.",
+            "Owner can use, update, share and delete the resource.",
+            "Writer can use, update and share the resource.",
+            "Reader can use the resource."
+          ],
+          "enum": [
+            "ROLE_UNSPECIFIED",
+            "OWNER",
+            "WRITER",
+            "READER"
+          ],
+          "description": "Required. The role granted by this permission."
+        }
+      },
+      "type": "object",
+      "description": "Permission resource grants user, group or the rest of the world access to the PaLM API resource (e.g. a tuned model, corpus). A role is a collection of permitted operations that allows users to perform specific actions on PaLM API resources. To make them available to users, groups, or service accounts, you assign roles. When you assign a role, you grant permissions that the role contains. There are three concentric roles. Each role is a superset of the previous role's permitted operations: - reader can use the resource (e.g. tuned model, corpus) for inference - writer has reader's permissions and additionally can edit and share - owner has writer's permissions and additionally can delete"
+    },
+    "SemanticRetrieverChunk": {
+      "description": "Identifier for a `Chunk` retrieved via Semantic Retriever specified in the `GenerateAnswerRequest` using `SemanticRetrieverConfig`.",
+      "type": "object",
+      "properties": {
+        "chunk": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. Name of the `Chunk` containing the attributed text. Example: `corpora/123/documents/abc/chunks/xyz`"
+        },
+        "source": {
+          "description": "Output only. Name of the source matching the request's `SemanticRetrieverConfig.source`. Example: `corpora/123` or `corpora/123/documents/abc`",
+          "readOnly": true,
+          "type": "string"
+        }
+      },
+      "id": "SemanticRetrieverChunk"
+    },
+    "GroundingPassageId": {
+      "properties": {
+        "passageId": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. ID of the passage matching the `GenerateAnswerRequest`'s `GroundingPassage.id`."
+        },
+        "partIndex": {
+          "description": "Output only. Index of the part within the `GenerateAnswerRequest`'s `GroundingPassage.content`.",
+          "format": "int32",
+          "type": "integer",
+          "readOnly": true
+        }
+      },
+      "id": "GroundingPassageId",
+      "type": "object",
+      "description": "Identifier for a part within a `GroundingPassage`."
+    },
+    "CountTokensRequest": {
+      "properties": {
+        "contents": {
+          "type": "array",
+          "description": "Optional. The input given to the model as a prompt. This field is ignored when `generate_content_request` is set.",
+          "items": {
+            "$ref": "Content"
+          }
+        },
+        "generateContentRequest": {
+          "description": "Optional. The overall input given to the model. CountTokens will count prompt, function calling, etc.",
+          "$ref": "GenerateContentRequest"
+        }
+      },
+      "type": "object",
+      "id": "CountTokensRequest",
+      "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`."
+    },
+    "Corpus": {
+      "properties": {
+        "updateTime": {
+          "readOnly": true,
+          "format": "google-datetime",
+          "description": "Output only. The Timestamp of when the `Corpus` was last updated.",
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Optional. The human-readable display name for the `Corpus`. The display name must be no more than 512 characters in length, including spaces. Example: \"Docs on Semantic Retriever\""
+        },
+        "createTime": {
+          "type": "string",
+          "format": "google-datetime",
+          "readOnly": true,
+          "description": "Output only. The Timestamp of when the `Corpus` was created."
+        },
+        "name": {
+          "description": "Immutable. Identifier. The `Corpus` resource name. The ID (name excluding the \"corpora/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/my-awesome-corpora-123a456b789c`",
+          "type": "string"
+        }
+      },
+      "id": "Corpus",
+      "description": "A `Corpus` is a collection of `Document`s. A project can create up to 5 corpora.",
+      "type": "object"
+    },
+    "CreateFileResponse": {
+      "description": "Response for `CreateFile`.",
+      "type": "object",
+      "id": "CreateFileResponse",
+      "properties": {
+        "file": {
+          "$ref": "File",
+          "description": "Metadata for the created file."
+        }
+      }
+    },
+    "CountTextTokensRequest": {
+      "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`.",
+      "properties": {
+        "prompt": {
+          "$ref": "TextPrompt",
+          "description": "Required. The free-form input text given to the model as a prompt."
+        }
+      },
+      "id": "CountTextTokensRequest",
+      "type": "object"
+    },
+    "GroundingAttribution": {
+      "properties": {
+        "content": {
+          "description": "Grounding source content that makes up this attribution.",
+          "$ref": "Content"
+        },
+        "sourceId": {
+          "$ref": "AttributionSourceId",
+          "readOnly": true,
+          "description": "Output only. Identifier for the source contributing to this attribution."
+        }
+      },
+      "description": "Attribution for a source that contributed to an answer.",
+      "type": "object",
+      "id": "GroundingAttribution"
+    },
+    "Example": {
+      "description": "An input/output example used to instruct the Model. It demonstrates how the model should respond or format its response.",
+      "type": "object",
+      "properties": {
+        "input": {
+          "$ref": "Message",
+          "description": "Required. An example of an input `Message` from the user."
+        },
+        "output": {
+          "$ref": "Message",
+          "description": "Required. An example of what the model should output given the input."
+        }
+      },
+      "id": "Example"
+    },
+    "VideoMetadata": {
+      "properties": {
+        "videoDuration": {
+          "type": "string",
+          "description": "Duration of the video.",
+          "format": "google-duration"
+        }
+      },
+      "type": "object",
+      "description": "Metadata for a video `File`.",
+      "id": "VideoMetadata"
+    },
+    "InputFeedback": {
+      "properties": {
+        "blockReason": {
+          "description": "Optional. If set, the input was blocked and no candidates are returned. Rephrase your input.",
+          "enum": [
+            "BLOCK_REASON_UNSPECIFIED",
+            "SAFETY",
+            "OTHER"
+          ],
+          "type": "string",
+          "enumDescriptions": [
+            "Default value. This value is unused.",
+            "Input was blocked due to safety reasons. You can inspect `safety_ratings` to understand which safety category blocked it.",
+            "Input was blocked due to other reasons."
+          ]
+        },
+        "safetyRatings": {
+          "type": "array",
+          "items": {
+            "$ref": "SafetyRating"
+          },
+          "description": "Ratings for safety of the input. There is at most one rating per category."
+        }
+      },
+      "type": "object",
+      "description": "Feedback related to the input data used to answer the question, as opposed to model-generated response to the question.",
+      "id": "InputFeedback"
+    },
+    "FunctionCallingConfig": {
+      "description": "Configuration for specifying function calling behavior.",
+      "properties": {
+        "allowedFunctionNames": {
+          "type": "array",
+          "description": "Optional. A set of function names that, when provided, limits the functions the model will call. This should only be set when the Mode is ANY. Function names should match [FunctionDeclaration.name]. With mode set to ANY, model will predict a function call from the set of function names provided.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "mode": {
+          "type": "string",
+          "enumDescriptions": [
+            "Unspecified function calling mode. This value should not be used.",
+            "Default model behavior, model decides to predict either a function call or a natural language response.",
+            "Model is constrained to always predicting a function call only. If \"allowed_function_names\" are set, the predicted function call will be limited to any one of \"allowed_function_names\", else the predicted function call will be any one of the provided \"function_declarations\".",
+            "Model will not predict any function call. Model behavior is same as when not passing any function declarations."
+          ],
+          "enum": [
+            "MODE_UNSPECIFIED",
+            "AUTO",
+            "ANY",
+            "NONE"
+          ],
+          "description": "Optional. Specifies the mode in which function calling should execute. If unspecified, the default value will be set to AUTO."
+        }
+      },
+      "type": "object",
+      "id": "FunctionCallingConfig"
+    },
+    "EmbedTextRequest": {
+      "id": "EmbedTextRequest",
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "Optional. The free-form input text that the model will turn into an embedding."
+        },
+        "model": {
+          "description": "Required. The model name to use with the format model=models/{model}.",
+          "type": "string"
+        }
+      },
+      "description": "Request to get a text embedding from the model.",
+      "type": "object"
+    },
+    "ListDocumentsResponse": {
+      "type": "object",
+      "properties": {
+        "documents": {
+          "type": "array",
+          "items": {
+            "$ref": "Document"
+          },
+          "description": "The returned `Document`s."
+        },
+        "nextPageToken": {
+          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages.",
+          "type": "string"
+        }
+      },
+      "id": "ListDocumentsResponse",
+      "description": "Response from `ListDocuments` containing a paginated list of `Document`s. The `Document`s are sorted by ascending `document.create_time`."
+    },
+    "Part": {
+      "properties": {
+        "functionCall": {
+          "description": "A predicted `FunctionCall` returned from the model that contains a string representing the `FunctionDeclaration.name` with the arguments and their values.",
+          "$ref": "FunctionCall"
+        },
+        "functionResponse": {
+          "description": "The result output of a `FunctionCall` that contains a string representing the `FunctionDeclaration.name` and a structured JSON object containing any output from the function is used as context to the model.",
+          "$ref": "FunctionResponse"
+        },
+        "fileData": {
+          "description": "URI based data.",
+          "$ref": "FileData"
+        },
+        "inlineData": {
+          "$ref": "Blob",
+          "description": "Inline media bytes."
+        },
+        "text": {
+          "type": "string",
+          "description": "Inline text."
+        }
+      },
+      "type": "object",
+      "id": "Part",
+      "description": "A datatype containing media that is part of a multi-part `Content` message. A `Part` consists of data which has an associated datatype. A `Part` can only contain one of the accepted types in `Part.data`. A `Part` must have a fixed IANA MIME type identifying the type and subtype of the media if the `inline_data` field is filled with raw bytes."
+    },
+    "BatchCreateChunksResponse": {
+      "type": "object",
+      "properties": {
+        "chunks": {
+          "description": "`Chunk`s created.",
+          "items": {
+            "$ref": "Chunk"
+          },
+          "type": "array"
+        }
+      },
+      "description": "Response from `BatchCreateChunks` containing a list of created `Chunk`s.",
+      "id": "BatchCreateChunksResponse"
+    },
+    "MetadataFilter": {
+      "id": "MetadataFilter",
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "Required. The key of the metadata to filter on.",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "Required. The `Condition`s for the given key that will trigger this filter. Multiple `Condition`s are joined by logical ORs.",
+          "type": "array",
+          "items": {
+            "$ref": "Condition"
+          }
+        }
+      },
+      "description": "User provided filter to limit retrieval based on `Chunk` or `Document` level metadata values. Example (genre = drama OR genre = action): key = \"document.custom_metadata.genre\" conditions = [{string_value = \"drama\", operation = EQUAL}, {string_value = \"action\", operation = EQUAL}]"
     },
     "TuningExample": {
       "id": "TuningExample",
       "properties": {
-        "output": {
-          "type": "string",
-          "description": "Required. The expected model output."
-        },
         "textInput": {
           "type": "string",
           "description": "Optional. Text model input."
+        },
+        "output": {
+          "description": "Required. The expected model output.",
+          "type": "string"
         }
       },
       "type": "object",
@@ -1916,8 +3139,29 @@
     "SafetyRating": {
       "id": "SafetyRating",
       "description": "Safety rating for a piece of content. The safety rating contains the category of harm and the harm probability level in that category for a piece of content. Content is classified for safety across a number of harm categories and the probability of the harm classification is included here.",
-      "type": "object",
       "properties": {
+        "blocked": {
+          "description": "Was this content blocked because of this rating?",
+          "type": "boolean"
+        },
+        "probability": {
+          "description": "Required. The probability of harm for this content.",
+          "enum": [
+            "HARM_PROBABILITY_UNSPECIFIED",
+            "NEGLIGIBLE",
+            "LOW",
+            "MEDIUM",
+            "HIGH"
+          ],
+          "enumDescriptions": [
+            "Probability is unspecified.",
+            "Content has a negligible chance of being unsafe.",
+            "Content has a low chance of being unsafe.",
+            "Content has a medium chance of being unsafe.",
+            "Content has a high chance of being unsafe."
+          ],
+          "type": "string"
+        },
         "category": {
           "enum": [
             "HARM_CATEGORY_UNSPECIFIED",
@@ -1947,84 +3191,142 @@
             "Sexually explicit content.",
             "Dangerous content."
           ]
-        },
-        "probability": {
-          "enumDescriptions": [
-            "Probability is unspecified.",
-            "Content has a negligible chance of being unsafe.",
-            "Content has a low chance of being unsafe.",
-            "Content has a medium chance of being unsafe.",
-            "Content has a high chance of being unsafe."
-          ],
-          "description": "Required. The probability of harm for this content.",
-          "enum": [
-            "HARM_PROBABILITY_UNSPECIFIED",
-            "NEGLIGIBLE",
-            "LOW",
-            "MEDIUM",
-            "HIGH"
-          ],
-          "type": "string"
-        },
-        "blocked": {
-          "description": "Was this content blocked because of this rating?",
-          "type": "boolean"
         }
-      }
+      },
+      "type": "object"
     },
-    "ListDocumentsResponse": {
-      "type": "object",
-      "id": "ListDocumentsResponse",
+    "GenerateAnswerResponse": {
       "properties": {
-        "nextPageToken": {
-          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages.",
-          "type": "string"
+        "answerableProbability": {
+          "description": "Output only. The model's estimate of the probability that its answer is correct and grounded in the input passages. A low answerable_probability indicates that the answer might not be grounded in the sources. When `answerable_probability` is low, some clients may wish to: * Display a message to the effect of \"We couldn’t answer that question\" to the user. * Fall back to a general-purpose LLM that answers the question from world knowledge. The threshold and nature of such fallbacks will depend on individual clients’ use cases. 0.5 is a good starting threshold.",
+          "readOnly": true,
+          "type": "number",
+          "format": "float"
         },
-        "documents": {
-          "description": "The returned `Document`s.",
+        "inputFeedback": {
+          "readOnly": true,
+          "description": "Output only. Feedback related to the input data used to answer the question, as opposed to model-generated response to the question. \"Input data\" can be one or more of the following: - Question specified by the last entry in `GenerateAnswerRequest.content` - Conversation history specified by the other entries in `GenerateAnswerRequest.content` - Grounding sources (`GenerateAnswerRequest.semantic_retriever` or `GenerateAnswerRequest.inline_passages`)",
+          "$ref": "InputFeedback"
+        },
+        "answer": {
+          "$ref": "Candidate",
+          "description": "Candidate answer from the model. Note: The model *always* attempts to provide a grounded answer, even when the answer is unlikely to be answerable from the given passages. In that case, a low-quality or ungrounded answer may be provided, along with a low `answerable_probability`."
+        }
+      },
+      "id": "GenerateAnswerResponse",
+      "description": "Response from the model for a grounded answer.",
+      "type": "object"
+    },
+    "PromptFeedback": {
+      "type": "object",
+      "id": "PromptFeedback",
+      "properties": {
+        "blockReason": {
+          "type": "string",
+          "enumDescriptions": [
+            "Default value. This value is unused.",
+            "Prompt was blocked due to safety reasons. You can inspect `safety_ratings` to understand which safety category blocked it.",
+            "Prompt was blocked due to unknown reasons."
+          ],
+          "enum": [
+            "BLOCK_REASON_UNSPECIFIED",
+            "SAFETY",
+            "OTHER"
+          ],
+          "description": "Optional. If set, the prompt was blocked and no candidates are returned. Rephrase your prompt."
+        },
+        "safetyRatings": {
           "items": {
-            "$ref": "Document"
+            "$ref": "SafetyRating"
           },
+          "description": "Ratings for safety of the prompt. There is at most one rating per category.",
           "type": "array"
         }
       },
-      "description": "Response from `ListDocuments` containing a paginated list of `Document`s. The `Document`s are sorted by ascending `document.create_time`."
+      "description": "A set of the feedback metadata the prompt specified in `GenerateContentRequest.content`."
     },
-    "Candidate": {
+    "ChunkData": {
+      "id": "ChunkData",
+      "properties": {
+        "stringValue": {
+          "description": "The `Chunk` content as a string. The maximum number of tokens per chunk is 2043.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "description": "Extracted data that represents the `Chunk` content."
+    },
+    "FunctionResponse": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Required. The name of the function to call. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with a maximum length of 63."
+        },
+        "response": {
+          "type": "object",
+          "description": "Required. The function response in JSON object format.",
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          }
+        }
+      },
+      "description": "The result output from a `FunctionCall` that contains a string representing the `FunctionDeclaration.name` and a structured JSON object containing any output from the function is used as context to the model. This should contain the result of a`FunctionCall` made based on model prediction.",
+      "id": "FunctionResponse"
+    },
+    "Message": {
+      "description": "The base unit of structured text. A `Message` includes an `author` and the `content` of the `Message`. The `author` is used to tag messages when they are fed to the model as text.",
       "properties": {
         "citationMetadata": {
-          "description": "Output only. Citation information for model-generated candidate. This field may be populated with recitation information for any text included in the `content`. These are passages that are \"recited\" from copyrighted material in the foundational LLM's training data.",
-          "readOnly": true,
-          "$ref": "CitationMetadata"
+          "$ref": "CitationMetadata",
+          "description": "Output only. Citation information for model-generated `content` in this `Message`. If this `Message` was generated as output from the model, this field may be populated with attribution information for any text included in the `content`. This field is used only on output.",
+          "readOnly": true
         },
         "content": {
-          "readOnly": true,
-          "$ref": "Content",
-          "description": "Output only. Generated content returned from the model."
+          "type": "string",
+          "description": "Required. The text content of the structured `Message`."
         },
-        "groundingAttributions": {
+        "author": {
+          "description": "Optional. The author of this Message. This serves as a key for tagging the content of this Message when it is fed to the model as text. The author can be any alphanumeric string.",
+          "type": "string"
+        }
+      },
+      "id": "Message",
+      "type": "object"
+    },
+    "AttributionSourceId": {
+      "type": "object",
+      "description": "Identifier for the source contributing to this attribution.",
+      "properties": {
+        "semanticRetrieverChunk": {
+          "$ref": "SemanticRetrieverChunk",
+          "description": "Identifier for a `Chunk` fetched via Semantic Retriever."
+        },
+        "groundingPassage": {
+          "description": "Identifier for an inline passage.",
+          "$ref": "GroundingPassageId"
+        }
+      },
+      "id": "AttributionSourceId"
+    },
+    "Candidate": {
+      "description": "A response candidate generated from the model.",
+      "id": "Candidate",
+      "properties": {
+        "citationMetadata": {
+          "$ref": "CitationMetadata",
+          "readOnly": true,
+          "description": "Output only. Citation information for model-generated candidate. This field may be populated with recitation information for any text included in the `content`. These are passages that are \"recited\" from copyrighted material in the foundational LLM's training data."
+        },
+        "safetyRatings": {
           "items": {
-            "$ref": "GroundingAttribution"
+            "$ref": "SafetyRating"
           },
-          "readOnly": true,
-          "type": "array",
-          "description": "Output only. Attribution information for sources that contributed to a grounded answer. This field is populated for `GenerateAnswer` calls."
-        },
-        "index": {
-          "description": "Output only. Index of the candidate in the list of candidates.",
-          "type": "integer",
-          "readOnly": true,
-          "format": "int32"
+          "description": "List of ratings for the safety of a response candidate. There is at most one rating per category.",
+          "type": "array"
         },
         "finishReason": {
-          "enumDescriptions": [
-            "Default value. This value is unused.",
-            "Natural stop point of the model or provided stop sequence.",
-            "The maximum number of tokens as specified in the request was reached.",
-            "The candidate content was flagged for safety reasons.",
-            "The candidate content was flagged for recitation reasons.",
-            "Unknown reason."
-          ],
           "enum": [
             "FINISH_REASON_UNSPECIFIED",
             "STOP",
@@ -2033,276 +3335,496 @@
             "RECITATION",
             "OTHER"
           ],
-          "readOnly": true,
           "description": "Optional. Output only. The reason why the model stopped generating tokens. If empty, the model has not stopped generating the tokens.",
-          "type": "string"
+          "type": "string",
+          "enumDescriptions": [
+            "Default value. This value is unused.",
+            "Natural stop point of the model or provided stop sequence.",
+            "The maximum number of tokens as specified in the request was reached.",
+            "The candidate content was flagged for safety reasons.",
+            "The candidate content was flagged for recitation reasons.",
+            "Unknown reason."
+          ],
+          "readOnly": true
+        },
+        "content": {
+          "$ref": "Content",
+          "description": "Output only. Generated content returned from the model.",
+          "readOnly": true
         },
         "tokenCount": {
+          "type": "integer",
+          "format": "int32",
           "description": "Output only. Token count for this candidate.",
+          "readOnly": true
+        },
+        "groundingAttributions": {
+          "items": {
+            "$ref": "GroundingAttribution"
+          },
+          "type": "array",
+          "readOnly": true,
+          "description": "Output only. Attribution information for sources that contributed to a grounded answer. This field is populated for `GenerateAnswer` calls."
+        },
+        "index": {
+          "description": "Output only. Index of the candidate in the list of candidates.",
+          "type": "integer",
+          "format": "int32",
+          "readOnly": true
+        }
+      },
+      "type": "object"
+    },
+    "TuningSnapshot": {
+      "properties": {
+        "meanLoss": {
+          "readOnly": true,
+          "description": "Output only. The mean loss of the training examples for this step.",
+          "format": "float",
+          "type": "number"
+        },
+        "computeTime": {
+          "type": "string",
+          "description": "Output only. The timestamp when this metric was computed.",
+          "format": "google-datetime",
+          "readOnly": true
+        },
+        "step": {
+          "description": "Output only. The tuning step.",
           "format": "int32",
           "readOnly": true,
           "type": "integer"
         },
-        "safetyRatings": {
-          "type": "array",
-          "items": {
-            "$ref": "SafetyRating"
-          },
-          "description": "List of ratings for the safety of a response candidate. There is at most one rating per category."
-        }
-      },
-      "id": "Candidate",
-      "type": "object",
-      "description": "A response candidate generated from the model."
-    },
-    "Status": {
-      "description": "The `Status` type defines a logical error model that is suitable for different programming environments, including REST APIs and RPC APIs. It is used by [gRPC](https://github.com/grpc). Each `Status` message contains three pieces of data: error code, error message, and error details. You can find out more about this error model and how to work with it in the [API Design Guide](https://cloud.google.com/apis/design/errors).",
-      "type": "object",
-      "properties": {
-        "details": {
-          "items": {
-            "additionalProperties": {
-              "type": "any",
-              "description": "Properties of the object. Contains field @type with type URL."
-            },
-            "type": "object"
-          },
-          "type": "array",
-          "description": "A list of messages that carry the error details. There is a common set of message types for APIs to use."
-        },
-        "code": {
-          "format": "int32",
+        "epoch": {
           "type": "integer",
-          "description": "The status code, which should be an enum value of google.rpc.Code."
-        },
-        "message": {
-          "type": "string",
-          "description": "A developer-facing error message, which should be in English. Any user-facing error message should be localized and sent in the google.rpc.Status.details field, or localized by the client."
+          "format": "int32",
+          "readOnly": true,
+          "description": "Output only. The epoch this step was part of."
         }
       },
-      "id": "Status"
+      "type": "object",
+      "id": "TuningSnapshot",
+      "description": "Record for a single tuning step."
     },
-    "CountTextTokensRequest": {
-      "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`.",
-      "id": "CountTextTokensRequest",
+    "CachedContentUsageMetadata": {
       "properties": {
-        "prompt": {
-          "description": "Required. The free-form input text given to the model as a prompt.",
-          "$ref": "TextPrompt"
+        "totalTokenCount": {
+          "description": "Total number of tokens that the cached content consumes.",
+          "type": "integer",
+          "format": "int32"
         }
       },
+      "id": "CachedContentUsageMetadata",
+      "description": "Metadata on the usage of the cached content.",
       "type": "object"
     },
-    "Corpus": {
-      "type": "object",
-      "description": "A `Corpus` is a collection of `Document`s. A project can create up to 5 corpora.",
+    "DeleteChunkRequest": {
+      "description": "Request to delete a `Chunk`.",
       "properties": {
-        "createTime": {
-          "readOnly": true,
-          "format": "google-datetime",
-          "type": "string",
-          "description": "Output only. The Timestamp of when the `Corpus` was created."
-        },
         "name": {
           "type": "string",
-          "description": "Immutable. Identifier. The `Corpus` resource name. The ID (name excluding the \"corpora/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/my-awesome-corpora-123a456b789c`"
+          "description": "Required. The resource name of the `Chunk` to delete. Example: `corpora/my-corpus-123/documents/the-doc-abc/chunks/some-chunk`"
+        }
+      },
+      "type": "object",
+      "id": "DeleteChunkRequest"
+    },
+    "Condition": {
+      "properties": {
+        "operation": {
+          "enum": [
+            "OPERATOR_UNSPECIFIED",
+            "LESS",
+            "LESS_EQUAL",
+            "EQUAL",
+            "GREATER_EQUAL",
+            "GREATER",
+            "NOT_EQUAL",
+            "INCLUDES",
+            "EXCLUDES"
+          ],
+          "enumDescriptions": [
+            "The default value. This value is unused.",
+            "Supported by numeric.",
+            "Supported by numeric.",
+            "Supported by numeric & string.",
+            "Supported by numeric.",
+            "Supported by numeric.",
+            "Supported by numeric & string.",
+            "Supported by string only when `CustomMetadata` value type for the given key has a `string_list_value`.",
+            "Supported by string only when `CustomMetadata` value type for the given key has a `string_list_value`."
+          ],
+          "description": "Required. Operator applied to the given key-value pair to trigger the condition.",
+          "type": "string"
+        },
+        "stringValue": {
+          "description": "The string value to filter the metadata on.",
+          "type": "string"
+        },
+        "numericValue": {
+          "description": "The numeric value to filter the metadata on.",
+          "type": "number",
+          "format": "float"
+        }
+      },
+      "id": "Condition",
+      "type": "object",
+      "description": "Filter condition applicable to a single key."
+    },
+    "Document": {
+      "description": "A `Document` is a collection of `Chunk`s. A `Corpus` can have a maximum of 10,000 `Document`s.",
+      "properties": {
+        "name": {
+          "description": "Immutable. Identifier. The `Document` resource name. The ID (name excluding the \"corpora/*/documents/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/{corpus_id}/documents/my-awesome-doc-123a456b789c`",
+          "type": "string"
+        },
+        "createTime": {
+          "type": "string",
+          "format": "google-datetime",
+          "readOnly": true,
+          "description": "Output only. The Timestamp of when the `Document` was created."
         },
         "displayName": {
           "type": "string",
-          "description": "Optional. The human-readable display name for the `Corpus`. The display name must be no more than 512 characters in length, including spaces. Example: \"Docs on Semantic Retriever\""
+          "description": "Optional. The human-readable display name for the `Document`. The display name must be no more than 512 characters in length, including spaces. Example: \"Semantic Retriever Documentation\""
         },
         "updateTime": {
+          "readOnly": true,
           "type": "string",
           "format": "google-datetime",
-          "readOnly": true,
-          "description": "Output only. The Timestamp of when the `Corpus` was last updated."
+          "description": "Output only. The Timestamp of when the `Document` was last updated."
+        },
+        "customMetadata": {
+          "items": {
+            "$ref": "CustomMetadata"
+          },
+          "description": "Optional. User provided custom metadata stored as key-value pairs used for querying. A `Document` can have a maximum of 20 `CustomMetadata`.",
+          "type": "array"
         }
       },
-      "id": "Corpus"
+      "id": "Document",
+      "type": "object"
     },
-    "BatchEmbedTextRequest": {
+    "GenerationConfig": {
       "type": "object",
-      "description": "Batch request to get a text embedding from the model.",
-      "id": "BatchEmbedTextRequest",
+      "description": "Configuration options for model generation and outputs. Not all parameters may be configurable for every model.",
+      "id": "GenerationConfig",
       "properties": {
-        "texts": {
-          "description": "Optional. The free-form input texts that the model will turn into an embedding. The current limit is 100 texts, over which an error will be thrown.",
-          "type": "array",
+        "responseMimeType": {
+          "type": "string",
+          "description": "Optional. Output response mimetype of the generated candidate text. Supported mimetype: `text/plain`: (default) Text output. `application/json`: JSON response in the candidates."
+        },
+        "temperature": {
+          "format": "float",
+          "description": "Optional. Controls the randomness of the output. Note: The default value varies by model, see the `Model.temperature` attribute of the `Model` returned from the `getModel` function. Values can range from [0.0, 2.0].",
+          "type": "number"
+        },
+        "candidateCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. Number of generated responses to return. Currently, this value can only be set to 1. If unset, this will default to 1."
+        },
+        "responseSchema": {
+          "description": "Optional. Output response schema of the generated candidate text when response mime type can have schema. Schema can be objects, primitives or arrays and is a subset of [OpenAPI schema](https://spec.openapis.org/oas/v3.0.3#schema). If set, a compatible response_mime_type must also be set. Compatible mimetypes: `application/json`: Schema for JSON response.",
+          "$ref": "Schema"
+        },
+        "topK": {
+          "format": "int32",
+          "description": "Optional. The maximum number of tokens to consider when sampling. Models use nucleus sampling or combined Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens. Models running with nucleus sampling don't allow top_k setting. Note: The default value varies by model, see the `Model.top_k` attribute of the `Model` returned from the `getModel` function. Empty `top_k` field in `Model` indicates the model doesn't apply top-k sampling and doesn't allow setting `top_k` on requests.",
+          "type": "integer"
+        },
+        "topP": {
+          "format": "float",
+          "type": "number",
+          "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Tokens are sorted based on their assigned probabilities so that only the most likely tokens are considered. Top-k sampling directly limits the maximum number of tokens to consider, while Nucleus sampling limits number of tokens based on the cumulative probability. Note: The default value varies by model, see the `Model.top_p` attribute of the `Model` returned from the `getModel` function."
+        },
+        "maxOutputTokens": {
+          "type": "integer",
+          "description": "Optional. The maximum number of tokens to include in a candidate. Note: The default value varies by model, see the `Model.output_token_limit` attribute of the `Model` returned from the `getModel` function.",
+          "format": "int32"
+        },
+        "stopSequences": {
+          "description": "Optional. The set of character sequences (up to 5) that will stop output generation. If specified, the API will stop at the first appearance of a stop sequence. The stop sequence will not be included as part of the response.",
           "items": {
             "type": "string"
-          }
-        },
-        "requests": {
-          "items": {
-            "$ref": "EmbedTextRequest"
           },
-          "description": "Optional. Embed requests for the batch. Only one of `texts` or `requests` can be set.",
           "type": "array"
         }
       }
     },
-    "Part": {
+    "BatchDeleteChunksRequest": {
+      "id": "BatchDeleteChunksRequest",
+      "description": "Request to batch delete `Chunk`s.",
       "properties": {
-        "fileData": {
-          "$ref": "FileData",
-          "description": "URI based data."
+        "requests": {
+          "description": "Required. The request messages specifying the `Chunk`s to delete.",
+          "items": {
+            "$ref": "DeleteChunkRequest"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "GenerateAnswerRequest": {
+      "properties": {
+        "answerStyle": {
+          "type": "string",
+          "description": "Required. Style in which answers should be returned.",
+          "enum": [
+            "ANSWER_STYLE_UNSPECIFIED",
+            "ABSTRACTIVE",
+            "EXTRACTIVE",
+            "VERBOSE"
+          ],
+          "enumDescriptions": [
+            "Unspecified answer style.",
+            "Succint but abstract style.",
+            "Very brief and extractive style.",
+            "Verbose style including extra details. The response may be formatted as a sentence, paragraph, multiple paragraphs, or bullet points, etc."
+          ]
         },
-        "inlineData": {
-          "$ref": "Blob",
-          "description": "Inline media bytes."
+        "inlinePassages": {
+          "description": "Passages provided inline with the request.",
+          "$ref": "GroundingPassages"
         },
-        "functionResponse": {
-          "description": "The result output of a `FunctionCall` that contains a string representing the `FunctionDeclaration.name` and a structured JSON object containing any output from the function is used as context to the model.",
-          "$ref": "FunctionResponse"
+        "semanticRetriever": {
+          "$ref": "SemanticRetrieverConfig",
+          "description": "Content retrieved from resources created via the Semantic Retriever API."
         },
-        "functionCall": {
-          "description": "A predicted `FunctionCall` returned from the model that contains a string representing the `FunctionDeclaration.name` with the arguments and their values.",
-          "$ref": "FunctionCall"
+        "temperature": {
+          "description": "Optional. Controls the randomness of the output. Values can range from [0.0,1.0], inclusive. A value closer to 1.0 will produce responses that are more varied and creative, while a value closer to 0.0 will typically result in more straightforward responses from the model. A low temperature (~0.2) is usually recommended for Attributed-Question-Answering use cases.",
+          "format": "float",
+          "type": "number"
         },
-        "text": {
-          "description": "Inline text.",
+        "contents": {
+          "description": "Required. The content of the current conversation with the model. For single-turn queries, this is a single question to answer. For multi-turn queries, this is a repeated field that contains conversation history and the last `Content` in the list containing the question. Note: GenerateAnswer currently only supports queries in English.",
+          "items": {
+            "$ref": "Content"
+          },
+          "type": "array"
+        },
+        "safetySettings": {
+          "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content. This will be enforced on the `GenerateAnswerRequest.contents` and `GenerateAnswerResponse.candidate`. There should not be more than one setting for each `SafetyCategory` type. The API will block any contents and responses that fail to meet the thresholds set by these settings. This list overrides the default settings for each `SafetyCategory` specified in the safety_settings. If there is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use the default safety setting for that category. Harm categories HARM_CATEGORY_HATE_SPEECH, HARM_CATEGORY_SEXUALLY_EXPLICIT, HARM_CATEGORY_DANGEROUS_CONTENT, HARM_CATEGORY_HARASSMENT are supported.",
+          "items": {
+            "$ref": "SafetySetting"
+          },
+          "type": "array"
+        }
+      },
+      "description": "Request to generate a grounded answer from the model.",
+      "id": "GenerateAnswerRequest",
+      "type": "object"
+    },
+    "Chunk": {
+      "description": "A `Chunk` is a subpart of a `Document` that is treated as an independent unit for the purposes of vector representation and storage. A `Corpus` can have a maximum of 1 million `Chunk`s.",
+      "id": "Chunk",
+      "type": "object",
+      "properties": {
+        "customMetadata": {
+          "items": {
+            "$ref": "CustomMetadata"
+          },
+          "type": "array",
+          "description": "Optional. User provided custom metadata stored as key-value pairs. The maximum number of `CustomMetadata` per chunk is 20."
+        },
+        "data": {
+          "$ref": "ChunkData",
+          "description": "Required. The content for the `Chunk`, such as the text string. The maximum number of tokens per chunk is 2043."
+        },
+        "updateTime": {
+          "readOnly": true,
+          "type": "string",
+          "format": "google-datetime",
+          "description": "Output only. The Timestamp of when the `Chunk` was last updated."
+        },
+        "name": {
+          "type": "string",
+          "description": "Immutable. Identifier. The `Chunk` resource name. The ID (name excluding the \"corpora/*/documents/*/chunks/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a random 12-character unique ID will be generated. Example: `corpora/{corpus_id}/documents/{document_id}/chunks/123a456b789c`"
+        },
+        "state": {
+          "type": "string",
+          "description": "Output only. Current state of the `Chunk`.",
+          "enumDescriptions": [
+            "The default value. This value is used if the state is omitted.",
+            "`Chunk` is being processed (embedding and vector storage).",
+            "`Chunk` is processed and available for querying.",
+            "`Chunk` failed processing."
+          ],
+          "enum": [
+            "STATE_UNSPECIFIED",
+            "STATE_PENDING_PROCESSING",
+            "STATE_ACTIVE",
+            "STATE_FAILED"
+          ],
+          "readOnly": true
+        },
+        "createTime": {
+          "format": "google-datetime",
+          "readOnly": true,
+          "description": "Output only. The Timestamp of when the `Chunk` was created.",
+          "type": "string"
+        }
+      }
+    },
+    "TuningTask": {
+      "type": "object",
+      "description": "Tuning tasks that create tuned models.",
+      "id": "TuningTask",
+      "properties": {
+        "snapshots": {
+          "description": "Output only. Metrics collected during tuning.",
+          "items": {
+            "$ref": "TuningSnapshot"
+          },
+          "readOnly": true,
+          "type": "array"
+        },
+        "trainingData": {
+          "description": "Required. Input only. Immutable. The model training data.",
+          "$ref": "Dataset"
+        },
+        "hyperparameters": {
+          "$ref": "Hyperparameters",
+          "description": "Immutable. Hyperparameters controlling the tuning process. If not provided, default values will be used."
+        },
+        "completeTime": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Output only. The timestamp when tuning this model completed.",
+          "format": "google-datetime"
+        },
+        "startTime": {
+          "description": "Output only. The timestamp when tuning this model started.",
+          "readOnly": true,
+          "format": "google-datetime",
+          "type": "string"
+        }
+      }
+    },
+    "CountTokensResponse": {
+      "type": "object",
+      "id": "CountTokensResponse",
+      "description": "A response from `CountTokens`. It returns the model's `token_count` for the `prompt`.",
+      "properties": {
+        "totalTokens": {
+          "format": "int32",
+          "description": "The number of tokens that the `model` tokenizes the `prompt` into. Always non-negative. When cached_content is set, this is still the total effective prompt size. I.e. this includes the number of tokens in the cached content.",
+          "type": "integer"
+        }
+      }
+    },
+    "CitationMetadata": {
+      "properties": {
+        "citationSources": {
+          "type": "array",
+          "description": "Citations to sources for a specific response.",
+          "items": {
+            "$ref": "CitationSource"
+          }
+        }
+      },
+      "description": "A collection of source attributions for a piece of content.",
+      "type": "object",
+      "id": "CitationMetadata"
+    },
+    "GenerateContentRequest": {
+      "type": "object",
+      "description": "Request to generate a completion from the model.",
+      "id": "GenerateContentRequest",
+      "properties": {
+        "systemInstruction": {
+          "$ref": "Content",
+          "description": "Optional. Developer set system instruction. Currently, text only."
+        },
+        "contents": {
+          "items": {
+            "$ref": "Content"
+          },
+          "description": "Required. The content of the current conversation with the model. For single-turn queries, this is a single instance. For multi-turn queries, this is a repeated field that contains conversation history + latest request.",
+          "type": "array"
+        },
+        "safetySettings": {
+          "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content. This will be enforced on the `GenerateContentRequest.contents` and `GenerateContentResponse.candidates`. There should not be more than one setting for each `SafetyCategory` type. The API will block any contents and responses that fail to meet the thresholds set by these settings. This list overrides the default settings for each `SafetyCategory` specified in the safety_settings. If there is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use the default safety setting for that category. Harm categories HARM_CATEGORY_HATE_SPEECH, HARM_CATEGORY_SEXUALLY_EXPLICIT, HARM_CATEGORY_DANGEROUS_CONTENT, HARM_CATEGORY_HARASSMENT are supported.",
+          "type": "array",
+          "items": {
+            "$ref": "SafetySetting"
+          }
+        },
+        "toolConfig": {
+          "$ref": "ToolConfig",
+          "description": "Optional. Tool configuration for any `Tool` specified in the request."
+        },
+        "model": {
+          "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`.",
+          "type": "string"
+        },
+        "cachedContent": {
+          "description": "Optional. The name of the cached content used as context to serve the prediction. Note: only used in explicit caching, where users can have control over caching (e.g. what content to cache) and enjoy guaranteed cost savings. Format: `cachedContents/{cachedContent}`",
+          "type": "string"
+        },
+        "generationConfig": {
+          "description": "Optional. Configuration options for model generation and outputs.",
+          "$ref": "GenerationConfig"
+        },
+        "tools": {
+          "description": "Optional. A list of `Tools` the model may use to generate the next response. A `Tool` is a piece of code that enables the system to interact with external systems to perform an action, or set of actions, outside of knowledge and scope of the model. The only supported tool is currently `Function`.",
+          "items": {
+            "$ref": "Tool"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "ContentFilter": {
+      "id": "ContentFilter",
+      "description": "Content filtering metadata associated with processing a single request. ContentFilter contains a reason and an optional supporting string. The reason may be unspecified.",
+      "properties": {
+        "message": {
+          "description": "A string that describes the filtering behavior in more detail.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "The reason content was blocked during request processing.",
+          "enumDescriptions": [
+            "A blocked reason was not specified.",
+            "Content was blocked by safety settings.",
+            "Content was blocked, but the reason is uncategorized."
+          ],
+          "enum": [
+            "BLOCKED_REASON_UNSPECIFIED",
+            "SAFETY",
+            "OTHER"
+          ],
           "type": "string"
         }
       },
-      "type": "object",
-      "id": "Part",
-      "description": "A datatype containing media that is part of a multi-part `Content` message. A `Part` consists of data which has an associated datatype. A `Part` can only contain one of the accepted types in `Part.data`. A `Part` must have a fixed IANA MIME type identifying the type and subtype of the media if the `inline_data` field is filled with raw bytes."
-    },
-    "CountTokensRequest": {
-      "properties": {
-        "generateContentRequest": {
-          "$ref": "GenerateContentRequest",
-          "description": "Optional. The overall input given to the model. CountTokens will count prompt, function calling, etc."
-        },
-        "contents": {
-          "description": "Optional. The input given to the model as a prompt. This field is ignored when `generate_content_request` is set.",
-          "type": "array",
-          "items": {
-            "$ref": "Content"
-          }
-        }
-      },
-      "id": "CountTokensRequest",
-      "description": "Counts the number of tokens in the `prompt` sent to a model. Models may tokenize text differently, so each model may return a different `token_count`.",
       "type": "object"
     },
-    "ListChunksResponse": {
-      "type": "object",
-      "id": "ListChunksResponse",
+    "EmbedTextResponse": {
+      "id": "EmbedTextResponse",
       "properties": {
-        "chunks": {
-          "items": {
-            "$ref": "Chunk"
-          },
-          "type": "array",
-          "description": "The returned `Chunk`s."
-        },
-        "nextPageToken": {
-          "type": "string",
-          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages."
-        }
-      },
-      "description": "Response from `ListChunks` containing a paginated list of `Chunk`s. The `Chunk`s are sorted by ascending `chunk.create_time`."
-    },
-    "FunctionCallingConfig": {
-      "description": "Configuration for specifying function calling behavior.",
-      "type": "object",
-      "properties": {
-        "mode": {
-          "enumDescriptions": [
-            "Unspecified function calling mode. This value should not be used.",
-            "Default model behavior, model decides to predict either a function call or a natural language response.",
-            "Model is constrained to always predicting a function call only. If \"allowed_function_names\" are set, the predicted function call will be limited to any one of \"allowed_function_names\", else the predicted function call will be any one of the provided \"function_declarations\".",
-            "Model will not predict any function call. Model behavior is same as when not passing any function declarations."
-          ],
-          "type": "string",
-          "enum": [
-            "MODE_UNSPECIFIED",
-            "AUTO",
-            "ANY",
-            "NONE"
-          ],
-          "description": "Optional. Specifies the mode in which function calling should execute. If unspecified, the default value will be set to AUTO."
-        },
-        "allowedFunctionNames": {
-          "type": "array",
-          "description": "Optional. A set of function names that, when provided, limits the functions the model will call. This should only be set when the Mode is ANY. Function names should match [FunctionDeclaration.name]. With mode set to ANY, model will predict a function call from the set of function names provided.",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "id": "FunctionCallingConfig"
-    },
-    "SafetyFeedback": {
-      "id": "SafetyFeedback",
-      "properties": {
-        "setting": {
-          "description": "Safety settings applied to the request.",
-          "$ref": "SafetySetting"
-        },
-        "rating": {
-          "description": "Safety rating evaluated from content.",
-          "$ref": "SafetyRating"
-        }
-      },
-      "type": "object",
-      "description": "Safety feedback for an entire request. This field is populated if content in the input and/or response is blocked due to safety settings. SafetyFeedback may not exist for every HarmCategory. Each SafetyFeedback will return the safety settings used by the request as well as the lowest HarmProbability that should be allowed in order to return a result."
-    },
-    "Example": {
-      "type": "object",
-      "id": "Example",
-      "properties": {
-        "output": {
-          "description": "Required. An example of what the model should output given the input.",
-          "$ref": "Message"
-        },
-        "input": {
-          "$ref": "Message",
-          "description": "Required. An example of an input `Message` from the user."
-        }
-      },
-      "description": "An input/output example used to instruct the Model. It demonstrates how the model should respond or format its response."
-    },
-    "GroundingPassageId": {
-      "type": "object",
-      "properties": {
-        "partIndex": {
-          "type": "integer",
+        "embedding": {
+          "$ref": "Embedding",
           "readOnly": true,
-          "format": "int32",
-          "description": "Output only. Index of the part within the `GenerateAnswerRequest`'s `GroundingPassage.content`."
-        },
-        "passageId": {
-          "readOnly": true,
-          "type": "string",
-          "description": "Output only. ID of the passage matching the `GenerateAnswerRequest`'s `GroundingPassage.id`."
+          "description": "Output only. The embedding generated from the input text."
         }
       },
-      "description": "Identifier for a part within a `GroundingPassage`.",
-      "id": "GroundingPassageId"
+      "type": "object",
+      "description": "The response to a EmbedTextRequest."
     },
     "EmbedContentRequest": {
       "id": "EmbedContentRequest",
-      "description": "Request containing the `Content` for the model to embed.",
       "type": "object",
       "properties": {
-        "model": {
-          "type": "string",
-          "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`"
+        "content": {
+          "$ref": "Content",
+          "description": "Required. The content to embed. Only the `parts.text` fields will be counted."
         },
         "outputDimensionality": {
           "type": "integer",
           "format": "int32",
           "description": "Optional. Optional reduced dimension for the output embedding. If set, excessive values in the output embedding are truncated from the end. Supported by newer models since 2024, and the earlier model (`models/embedding-001`) cannot specify this value."
-        },
-        "title": {
-          "description": "Optional. An optional title for the text. Only applicable when TaskType is `RETRIEVAL_DOCUMENT`. Note: Specifying a `title` for `RETRIEVAL_DOCUMENT` provides better quality embeddings for retrieval.",
-          "type": "string"
-        },
-        "content": {
-          "$ref": "Content",
-          "description": "Required. The content to embed. Only the `parts.text` fields will be counted."
         },
         "taskType": {
           "enumDescriptions": [
@@ -2315,6 +3837,7 @@
             "Specifies that the given text will be used for question answering.",
             "Specifies that the given text will be used for fact verification."
           ],
+          "description": "Optional. Optional task type for which the embeddings will be used. Can only be set for `models/embedding-001`.",
           "enum": [
             "TASK_TYPE_UNSPECIFIED",
             "RETRIEVAL_QUERY",
@@ -2325,1958 +3848,435 @@
             "QUESTION_ANSWERING",
             "FACT_VERIFICATION"
           ],
-          "type": "string",
-          "description": "Optional. Optional task type for which the embeddings will be used. Can only be set for `models/embedding-001`."
-        }
-      }
-    },
-    "GenerateAnswerRequest": {
-      "type": "object",
-      "description": "Request to generate a grounded answer from the model.",
-      "id": "GenerateAnswerRequest",
-      "properties": {
-        "safetySettings": {
-          "type": "array",
-          "items": {
-            "$ref": "SafetySetting"
-          },
-          "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content. This will be enforced on the `GenerateAnswerRequest.contents` and `GenerateAnswerResponse.candidate`. There should not be more than one setting for each `SafetyCategory` type. The API will block any contents and responses that fail to meet the thresholds set by these settings. This list overrides the default settings for each `SafetyCategory` specified in the safety_settings. If there is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use the default safety setting for that category. Harm categories HARM_CATEGORY_HATE_SPEECH, HARM_CATEGORY_SEXUALLY_EXPLICIT, HARM_CATEGORY_DANGEROUS_CONTENT, HARM_CATEGORY_HARASSMENT are supported."
+          "type": "string"
         },
-        "contents": {
+        "title": {
+          "description": "Optional. An optional title for the text. Only applicable when TaskType is `RETRIEVAL_DOCUMENT`. Note: Specifying a `title` for `RETRIEVAL_DOCUMENT` provides better quality embeddings for retrieval.",
+          "type": "string"
+        },
+        "model": {
+          "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
+          "type": "string"
+        }
+      },
+      "description": "Request containing the `Content` for the model to embed."
+    },
+    "GenerateTextResponse": {
+      "description": "The response from the model, including candidate completions.",
+      "type": "object",
+      "id": "GenerateTextResponse",
+      "properties": {
+        "safetyFeedback": {
+          "description": "Returns any safety feedback related to content filtering.",
           "type": "array",
-          "description": "Required. The content of the current conversation with the model. For single-turn queries, this is a single question to answer. For multi-turn queries, this is a repeated field that contains conversation history and the last `Content` in the list containing the question. Note: GenerateAnswer currently only supports queries in English.",
           "items": {
-            "$ref": "Content"
+            "$ref": "SafetyFeedback"
           }
         },
-        "temperature": {
-          "format": "float",
-          "description": "Optional. Controls the randomness of the output. Values can range from [0.0,1.0], inclusive. A value closer to 1.0 will produce responses that are more varied and creative, while a value closer to 0.0 will typically result in more straightforward responses from the model. A low temperature (~0.2) is usually recommended for Attributed-Question-Answering use cases.",
-          "type": "number"
-        },
-        "semanticRetriever": {
-          "description": "Content retrieved from resources created via the Semantic Retriever API.",
-          "$ref": "SemanticRetrieverConfig"
-        },
-        "answerStyle": {
-          "type": "string",
-          "enumDescriptions": [
-            "Unspecified answer style.",
-            "Succint but abstract style.",
-            "Very brief and extractive style.",
-            "Verbose style including extra details. The response may be formatted as a sentence, paragraph, multiple paragraphs, or bullet points, etc."
-          ],
-          "description": "Required. Style in which answers should be returned.",
-          "enum": [
-            "ANSWER_STYLE_UNSPECIFIED",
-            "ABSTRACTIVE",
-            "EXTRACTIVE",
-            "VERBOSE"
-          ]
-        },
-        "inlinePassages": {
-          "$ref": "GroundingPassages",
-          "description": "Passages provided inline with the request."
-        }
-      }
-    },
-    "ListCachedContentsResponse": {
-      "type": "object",
-      "description": "Response with CachedContents list.",
-      "id": "ListCachedContentsResponse",
-      "properties": {
-        "nextPageToken": {
-          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no subsequent pages.",
-          "type": "string"
-        },
-        "cachedContents": {
+        "filters": {
+          "description": "A set of content filtering metadata for the prompt and response text. This indicates which `SafetyCategory`(s) blocked a candidate from this response, the lowest `HarmProbability` that triggered a block, and the HarmThreshold setting for that category. This indicates the smallest change to the `SafetySettings` that would be necessary to unblock at least 1 response. The blocking is configured by the `SafetySettings` in the request (or the default `SafetySettings` of the API).",
+          "type": "array",
           "items": {
-            "$ref": "CachedContent"
+            "$ref": "ContentFilter"
+          }
+        },
+        "candidates": {
+          "items": {
+            "$ref": "TextCompletion"
           },
           "type": "array",
-          "description": "List of cached contents."
+          "description": "Candidate responses from the model."
         }
       }
     },
-    "SemanticRetrieverChunk": {
-      "id": "SemanticRetrieverChunk",
-      "description": "Identifier for a `Chunk` retrieved via Semantic Retriever specified in the `GenerateAnswerRequest` using `SemanticRetrieverConfig`.",
+    "Schema": {
+      "description": "The `Schema` object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. Represents a select subset of an [OpenAPI 3.0 schema object](https://spec.openapis.org/oas/v3.0.3#schema).",
+      "type": "object",
+      "id": "Schema",
       "properties": {
-        "source": {
-          "type": "string",
-          "readOnly": true,
-          "description": "Output only. Name of the source matching the request's `SemanticRetrieverConfig.source`. Example: `corpora/123` or `corpora/123/documents/abc`"
+        "items": {
+          "description": "Optional. Schema of the elements of Type.ARRAY.",
+          "$ref": "Schema"
         },
-        "chunk": {
+        "enum": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Optional. Possible values of the element of Type.STRING with enum format. For example we can define an Enum Direction as : {type:STRING, format:enum, enum:[\"EAST\", NORTH\", \"SOUTH\", \"WEST\"]}"
+        },
+        "required": {
+          "type": "array",
+          "description": "Optional. Required properties of Type.OBJECT.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "nullable": {
+          "type": "boolean",
+          "description": "Optional. Indicates if the value may be null."
+        },
+        "description": {
+          "description": "Optional. A brief description of the parameter. This could contain examples of use. Parameter description may be formatted as Markdown.",
+          "type": "string"
+        },
+        "properties": {
+          "additionalProperties": {
+            "$ref": "Schema"
+          },
+          "type": "object",
+          "description": "Optional. Properties of Type.OBJECT."
+        },
+        "format": {
+          "description": "Optional. The format of the data. This is used only for primitive datatypes. Supported formats: for NUMBER type: float, double for INTEGER type: int32, int64",
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "TYPE_UNSPECIFIED",
+            "STRING",
+            "NUMBER",
+            "INTEGER",
+            "BOOLEAN",
+            "ARRAY",
+            "OBJECT"
+          ],
           "type": "string",
-          "description": "Output only. Name of the `Chunk` containing the attributed text. Example: `corpora/123/documents/abc/chunks/xyz`",
+          "enumDescriptions": [
+            "Not specified, should not be used.",
+            "String type.",
+            "Number type.",
+            "Integer type.",
+            "Boolean type.",
+            "Array type.",
+            "Object type."
+          ],
+          "description": "Required. Data type."
+        }
+      }
+    },
+    "MessagePrompt": {
+      "id": "MessagePrompt",
+      "description": "All of the structured input text passed to the model as a prompt. A `MessagePrompt` contains a structured set of fields that provide context for the conversation, examples of user input/model output message pairs that prime the model to respond in different ways, and the conversation history or list of messages representing the alternating turns of the conversation between the user and the model.",
+      "properties": {
+        "examples": {
+          "type": "array",
+          "description": "Optional. Examples of what the model should generate. This includes both user input and the response that the model should emulate. These `examples` are treated identically to conversation messages except that they take precedence over the history in `messages`: If the total input size exceeds the model's `input_token_limit` the input will be truncated. Items will be dropped from `messages` before `examples`.",
+          "items": {
+            "$ref": "Example"
+          }
+        },
+        "messages": {
+          "description": "Required. A snapshot of the recent conversation history sorted chronologically. Turns alternate between two authors. If the total input size exceeds the model's `input_token_limit` the input will be truncated: The oldest items will be dropped from `messages`.",
+          "type": "array",
+          "items": {
+            "$ref": "Message"
+          }
+        },
+        "context": {
+          "type": "string",
+          "description": "Optional. Text that should be provided to the model first to ground the response. If not empty, this `context` will be given to the model first before the `examples` and `messages`. When using a `context` be sure to provide it with every request to maintain continuity. This field can be a description of your prompt to the model to help provide context and guide the responses. Examples: \"Translate the phrase from English to French.\" or \"Given a statement, classify the sentiment as happy, sad or neutral.\" Anything included in this field will take precedence over message history if the total input size exceeds the model's `input_token_limit` and the input request is truncated."
+        }
+      },
+      "type": "object"
+    },
+    "Dataset": {
+      "properties": {
+        "examples": {
+          "description": "Optional. Inline examples.",
+          "$ref": "TuningExamples"
+        }
+      },
+      "type": "object",
+      "description": "Dataset for training or validation.",
+      "id": "Dataset"
+    },
+    "CachedContent": {
+      "id": "CachedContent",
+      "type": "object",
+      "properties": {
+        "updateTime": {
+          "format": "google-datetime",
+          "type": "string",
+          "description": "Output only. When the cache entry was last updated in UTC time.",
           "readOnly": true
-        }
-      },
-      "type": "object"
-    },
-    "Tool": {
-      "id": "Tool",
-      "properties": {
-        "functionDeclarations": {
-          "description": "Optional. A list of `FunctionDeclarations` available to the model that can be used for function calling. The model or system does not execute the function. Instead the defined function may be returned as a FunctionCall with arguments to the client side for execution. The model may decide to call a subset of these functions by populating FunctionCall in the response. The next conversation turn may contain a FunctionResponse with the [content.role] \"function\" generation context for the next model turn.",
-          "items": {
-            "$ref": "FunctionDeclaration"
-          },
-          "type": "array"
-        }
-      },
-      "type": "object",
-      "description": "Tool details that the model may use to generate response. A `Tool` is a piece of code that enables the system to interact with external systems to perform an action, or set of actions, outside of knowledge and scope of the model."
-    },
-    "CitationSource": {
-      "type": "object",
-      "id": "CitationSource",
-      "properties": {
-        "license": {
-          "description": "Optional. License for the GitHub project that is attributed as a source for segment. License info is required for code citations.",
+        },
+        "name": {
+          "description": "Optional. Identifier. The resource name referring to the cached content. Format: `cachedContents/{id}`",
           "type": "string"
         },
-        "uri": {
-          "type": "string",
-          "description": "Optional. URI that is attributed as a source for a portion of the text."
-        },
-        "endIndex": {
-          "description": "Optional. End of the attributed segment, exclusive.",
-          "type": "integer",
-          "format": "int32"
-        },
-        "startIndex": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Optional. Start of segment of the response that is attributed to this source. Index indicates the start of the segment, measured in bytes."
-        }
-      },
-      "description": "A citation to a source for a portion of a specific response."
-    },
-    "BatchEmbedContentsRequest": {
-      "description": "Batch request to get embeddings from the model for a list of prompts.",
-      "properties": {
-        "requests": {
-          "type": "array",
-          "items": {
-            "$ref": "EmbedContentRequest"
-          },
-          "description": "Required. Embed requests for the batch. The model in each of these requests must match the model specified `BatchEmbedContentsRequest.model`."
-        }
-      },
-      "type": "object",
-      "id": "BatchEmbedContentsRequest"
-    },
-    "CountMessageTokensResponse": {
-      "properties": {
-        "tokenCount": {
-          "type": "integer",
-          "description": "The number of tokens that the `model` tokenizes the `prompt` into. Always non-negative.",
-          "format": "int32"
-        }
-      },
-      "id": "CountMessageTokensResponse",
-      "description": "A response from `CountMessageTokens`. It returns the model's `token_count` for the `prompt`.",
-      "type": "object"
-    },
-    "CreateChunkRequest": {
-      "type": "object",
-      "description": "Request to create a `Chunk`.",
-      "properties": {
-        "chunk": {
-          "$ref": "Chunk",
-          "description": "Required. The `Chunk` to create."
-        },
-        "parent": {
-          "type": "string",
-          "description": "Required. The name of the `Document` where this `Chunk` will be created. Example: `corpora/my-corpus-123/documents/the-doc-abc`"
-        }
-      },
-      "id": "CreateChunkRequest"
-    },
-    "EmbedTextResponse": {
-      "properties": {
-        "embedding": {
-          "description": "Output only. The embedding generated from the input text.",
-          "readOnly": true,
-          "$ref": "Embedding"
-        }
-      },
-      "type": "object",
-      "description": "The response to a EmbedTextRequest.",
-      "id": "EmbedTextResponse"
-    },
-    "ContentEmbedding": {
-      "description": "A list of floats representing an embedding.",
-      "id": "ContentEmbedding",
-      "properties": {
-        "values": {
-          "items": {
-            "format": "float",
-            "type": "number"
-          },
-          "type": "array",
-          "description": "The embedding values."
-        }
-      },
-      "type": "object"
-    },
-    "ListPermissionsResponse": {
-      "id": "ListPermissionsResponse",
-      "description": "Response from `ListPermissions` containing a paginated list of permissions.",
-      "type": "object",
-      "properties": {
-        "nextPageToken": {
-          "description": "A token, which can be sent as `page_token` to retrieve the next page. If this field is omitted, there are no more pages.",
+        "ttl": {
+          "format": "google-duration",
+          "description": "Input only. New TTL for this resource, input only.",
           "type": "string"
         },
-        "permissions": {
-          "items": {
-            "$ref": "Permission"
-          },
-          "description": "Returned permissions.",
-          "type": "array"
-        }
-      }
-    },
-    "ContentFilter": {
-      "description": "Content filtering metadata associated with processing a single request. ContentFilter contains a reason and an optional supporting string. The reason may be unspecified.",
-      "properties": {
-        "reason": {
-          "description": "The reason content was blocked during request processing.",
-          "enum": [
-            "BLOCKED_REASON_UNSPECIFIED",
-            "SAFETY",
-            "OTHER"
-          ],
-          "enumDescriptions": [
-            "A blocked reason was not specified.",
-            "Content was blocked by safety settings.",
-            "Content was blocked, but the reason is uncategorized."
-          ],
+        "displayName": {
+          "description": "Optional. Immutable. The user-generated meaningful display name of the cached content. Maximum 128 Unicode characters.",
           "type": "string"
         },
-        "message": {
+        "expireTime": {
+          "format": "google-datetime",
           "type": "string",
-          "description": "A string that describes the filtering behavior in more detail."
-        }
-      },
-      "type": "object",
-      "id": "ContentFilter"
-    },
-    "EmbedTextRequest": {
-      "type": "object",
-      "id": "EmbedTextRequest",
-      "description": "Request to get a text embedding from the model.",
-      "properties": {
-        "text": {
-          "type": "string",
-          "description": "Optional. The free-form input text that the model will turn into an embedding."
+          "description": "Timestamp in UTC of when this resource is considered expired. This is *always* provided on output, regardless of what was sent on input."
         },
         "model": {
           "type": "string",
-          "description": "Required. The model name to use with the format model=models/{model}."
+          "description": "Required. Immutable. The name of the `Model` to use for cached content Format: `models/{model}`"
+        },
+        "toolConfig": {
+          "$ref": "ToolConfig",
+          "description": "Optional. Input only. Immutable. Tool config. This config is shared for all tools."
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "$ref": "Tool"
+          },
+          "description": "Optional. Input only. Immutable. A list of `Tools` the model may use to generate the next response"
+        },
+        "createTime": {
+          "description": "Output only. Creation time of the cache entry.",
+          "readOnly": true,
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "systemInstruction": {
+          "$ref": "Content",
+          "description": "Optional. Input only. Immutable. Developer set system instruction. Currently text only."
+        },
+        "usageMetadata": {
+          "$ref": "CachedContentUsageMetadata",
+          "readOnly": true,
+          "description": "Output only. Metadata on the usage of the cached content."
+        },
+        "contents": {
+          "items": {
+            "$ref": "Content"
+          },
+          "description": "Optional. Input only. Immutable. The content to cache.",
+          "type": "array"
+        }
+      },
+      "description": "Content that has been preprocessed and can be used in subsequent request to GenerativeService. Cached content can be only used with model it was created for."
+    },
+    "TextCompletion": {
+      "type": "object",
+      "id": "TextCompletion",
+      "description": "Output text returned from a model.",
+      "properties": {
+        "citationMetadata": {
+          "description": "Output only. Citation information for model-generated `output` in this `TextCompletion`. This field may be populated with attribution information for any text included in the `output`.",
+          "$ref": "CitationMetadata",
+          "readOnly": true
+        },
+        "output": {
+          "description": "Output only. The generated text returned from the model.",
+          "readOnly": true,
+          "type": "string"
+        },
+        "safetyRatings": {
+          "type": "array",
+          "description": "Ratings for the safety of a response. There is at most one rating per category.",
+          "items": {
+            "$ref": "SafetyRating"
+          }
         }
       }
     },
-    "ToolConfig": {
+    "QueryDocumentRequest": {
+      "description": "Request for querying a `Document`.",
+      "id": "QueryDocumentRequest",
       "type": "object",
       "properties": {
-        "functionCallingConfig": {
-          "description": "Optional. Function calling config.",
-          "$ref": "FunctionCallingConfig"
-        }
-      },
-      "id": "ToolConfig",
-      "description": "The Tool configuration containing parameters for specifying `Tool` use in the request."
-    }
-  },
-  "icons": {
-    "x16": "http://www.google.com/images/icons/product/search-16.gif",
-    "x32": "http://www.google.com/images/icons/product/search-32.gif"
-  },
-  "protocol": "rest",
-  "name": "generativelanguage",
-  "parameters": {
-    "oauth_token": {
-      "location": "query",
-      "type": "string",
-      "description": "OAuth 2.0 token for the current user."
-    },
-    "callback": {
-      "description": "JSONP",
-      "type": "string",
-      "location": "query"
-    },
-    "uploadType": {
-      "type": "string",
-      "location": "query",
-      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\")."
-    },
-    "upload_protocol": {
-      "type": "string",
-      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
-      "location": "query"
-    },
-    "alt": {
-      "enum": [
-        "json",
-        "media",
-        "proto"
-      ],
-      "type": "string",
-      "default": "json",
-      "location": "query",
-      "description": "Data format for response.",
-      "enumDescriptions": [
-        "Responses with Content-Type of application/json",
-        "Media download with context-dependent Content-Type",
-        "Responses with Content-Type of application/x-protobuf"
-      ]
-    },
-    "quotaUser": {
-      "location": "query",
-      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
-      "type": "string"
-    },
-    "prettyPrint": {
-      "type": "boolean",
-      "default": "true",
-      "location": "query",
-      "description": "Returns response with indentations and line breaks."
-    },
-    "$.xgafv": {
-      "enumDescriptions": [
-        "v1 error format",
-        "v2 error format"
-      ],
-      "type": "string",
-      "enum": [
-        "1",
-        "2"
-      ],
-      "description": "V1 error format.",
-      "location": "query"
-    },
-    "access_token": {
-      "type": "string",
-      "description": "OAuth access token.",
-      "location": "query"
-    },
-    "key": {
-      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
-      "type": "string",
-      "location": "query"
-    },
-    "fields": {
-      "location": "query",
-      "type": "string",
-      "description": "Selector specifying which fields to include in a partial response."
-    }
-  },
-  "baseUrl": "https://generativelanguage.googleapis.com/",
-  "discoveryVersion": "v1",
-  "basePath": "",
-  "title": "Generative Language API",
-  "resources": {
-    "corpora": {
-      "methods": {
-        "get": {
-          "flatPath": "v1beta/corpora/{corporaId}",
-          "parameters": {
-            "name": {
-              "location": "path",
-              "pattern": "^corpora/[^/]+$",
-              "type": "string",
-              "description": "Required. The name of the `Corpus`. Example: `corpora/my-corpus-123`",
-              "required": true
-            }
-          },
-          "id": "generativelanguage.corpora.get",
-          "response": {
-            "$ref": "Corpus"
-          },
-          "parameterOrder": [
-            "name"
-          ],
-          "description": "Gets information about a specific `Corpus`.",
-          "path": "v1beta/{+name}",
-          "httpMethod": "GET"
-        },
-        "delete": {
-          "flatPath": "v1beta/corpora/{corporaId}",
-          "id": "generativelanguage.corpora.delete",
-          "path": "v1beta/{+name}",
-          "parameters": {
-            "force": {
-              "location": "query",
-              "description": "Optional. If set to true, any `Document`s and objects related to this `Corpus` will also be deleted. If false (the default), a `FAILED_PRECONDITION` error will be returned if `Corpus` contains any `Document`s.",
-              "type": "boolean"
-            },
-            "name": {
-              "type": "string",
-              "location": "path",
-              "description": "Required. The resource name of the `Corpus`. Example: `corpora/my-corpus-123`",
-              "pattern": "^corpora/[^/]+$",
-              "required": true
-            }
-          },
-          "description": "Deletes a `Corpus`.",
-          "httpMethod": "DELETE",
-          "response": {
-            "$ref": "Empty"
-          },
-          "parameterOrder": [
-            "name"
-          ]
-        },
-        "patch": {
-          "request": {
-            "$ref": "Corpus"
-          },
-          "flatPath": "v1beta/corpora/{corporaId}",
-          "id": "generativelanguage.corpora.patch",
-          "parameterOrder": [
-            "name"
-          ],
-          "parameters": {
-            "updateMask": {
-              "description": "Required. The list of fields to update. Currently, this only supports updating `display_name`.",
-              "format": "google-fieldmask",
-              "type": "string",
-              "location": "query"
-            },
-            "name": {
-              "description": "Immutable. Identifier. The `Corpus` resource name. The ID (name excluding the \"corpora/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/my-awesome-corpora-123a456b789c`",
-              "required": true,
-              "location": "path",
-              "type": "string",
-              "pattern": "^corpora/[^/]+$"
-            }
-          },
-          "response": {
-            "$ref": "Corpus"
-          },
-          "httpMethod": "PATCH",
-          "path": "v1beta/{+name}",
-          "description": "Updates a `Corpus`."
-        },
-        "list": {
-          "path": "v1beta/corpora",
-          "parameters": {
-            "pageSize": {
-              "format": "int32",
-              "description": "Optional. The maximum number of `Corpora` to return (per page). The service may return fewer `Corpora`. If unspecified, at most 10 `Corpora` will be returned. The maximum size limit is 20 `Corpora` per page.",
-              "type": "integer",
-              "location": "query"
-            },
-            "pageToken": {
-              "description": "Optional. A page token, received from a previous `ListCorpora` call. Provide the `next_page_token` returned in the response as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListCorpora` must match the call that provided the page token.",
-              "type": "string",
-              "location": "query"
-            }
-          },
-          "httpMethod": "GET",
-          "parameterOrder": [],
-          "description": "Lists all `Corpora` owned by the user.",
-          "response": {
-            "$ref": "ListCorporaResponse"
-          },
-          "id": "generativelanguage.corpora.list",
-          "flatPath": "v1beta/corpora"
-        },
-        "create": {
-          "parameters": {},
-          "description": "Creates an empty `Corpus`.",
-          "httpMethod": "POST",
-          "response": {
-            "$ref": "Corpus"
-          },
-          "id": "generativelanguage.corpora.create",
-          "parameterOrder": [],
-          "request": {
-            "$ref": "Corpus"
-          },
-          "flatPath": "v1beta/corpora",
-          "path": "v1beta/corpora"
-        },
         "query": {
-          "httpMethod": "POST",
-          "description": "Performs semantic search over a `Corpus`.",
-          "response": {
-            "$ref": "QueryCorpusResponse"
+          "type": "string",
+          "description": "Required. Query string to perform semantic search."
+        },
+        "metadataFilters": {
+          "items": {
+            "$ref": "MetadataFilter"
           },
-          "flatPath": "v1beta/corpora/{corporaId}:query",
-          "request": {
-            "$ref": "QueryCorpusRequest"
+          "type": "array",
+          "description": "Optional. Filter for `Chunk` metadata. Each `MetadataFilter` object should correspond to a unique key. Multiple `MetadataFilter` objects are joined by logical \"AND\"s. Note: `Document`-level filtering is not supported for this request because a `Document` name is already specified. Example query: (year \u003e= 2020 OR year \u003c 2010) AND (genre = drama OR genre = action) `MetadataFilter` object list: metadata_filters = [ {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2020, operation = GREATER_EQUAL}, {int_value = 2010, operation = LESS}}, {key = \"chunk.custom_metadata.genre\" conditions = [{string_value = \"drama\", operation = EQUAL}, {string_value = \"action\", operation = EQUAL}}] Example query for a numeric range of values: (year \u003e 2015 AND year \u003c= 2020) `MetadataFilter` object list: metadata_filters = [ {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2015, operation = GREATER}]}, {key = \"chunk.custom_metadata.year\" conditions = [{int_value = 2020, operation = LESS_EQUAL}]}] Note: \"AND\"s for the same key are only supported for numeric values. String values only support \"OR\"s for the same key."
+        },
+        "resultsCount": {
+          "description": "Optional. The maximum number of `Chunk`s to return. The service may return fewer `Chunk`s. If unspecified, at most 10 `Chunk`s will be returned. The maximum specified result count is 100.",
+          "format": "int32",
+          "type": "integer"
+        }
+      }
+    },
+    "TuningExamples": {
+      "id": "TuningExamples",
+      "type": "object",
+      "description": "A set of tuning examples. Can be training or validation data.",
+      "properties": {
+        "examples": {
+          "items": {
+            "$ref": "TuningExample"
           },
-          "parameters": {
-            "name": {
-              "location": "path",
-              "pattern": "^corpora/[^/]+$",
-              "required": true,
-              "type": "string",
-              "description": "Required. The name of the `Corpus` to query. Example: `corpora/my-corpus-123`"
-            }
+          "description": "Required. The examples. Example input can be for text or discuss, but all examples in a set must be of the same type.",
+          "type": "array"
+        }
+      }
+    },
+    "StringList": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "description": "The string values of the metadata to store.",
+          "items": {
+            "type": "string"
           },
-          "path": "v1beta/{+name}:query",
-          "parameterOrder": [
-            "name"
-          ],
-          "id": "generativelanguage.corpora.query"
+          "type": "array"
         }
       },
-      "resources": {
-        "documents": {
-          "methods": {
-            "list": {
-              "response": {
-                "$ref": "ListDocumentsResponse"
-              },
-              "description": "Lists all `Document`s in a `Corpus`.",
-              "path": "v1beta/{+parent}/documents",
-              "parameters": {
-                "pageSize": {
-                  "location": "query",
-                  "description": "Optional. The maximum number of `Document`s to return (per page). The service may return fewer `Document`s. If unspecified, at most 10 `Document`s will be returned. The maximum size limit is 20 `Document`s per page.",
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "pageToken": {
-                  "location": "query",
-                  "type": "string",
-                  "description": "Optional. A page token, received from a previous `ListDocuments` call. Provide the `next_page_token` returned in the response as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListDocuments` must match the call that provided the page token."
-                },
-                "parent": {
-                  "description": "Required. The name of the `Corpus` containing `Document`s. Example: `corpora/my-corpus-123`",
-                  "required": true,
-                  "pattern": "^corpora/[^/]+$",
-                  "location": "path",
-                  "type": "string"
-                }
-              },
-              "id": "generativelanguage.corpora.documents.list",
-              "flatPath": "v1beta/corpora/{corporaId}/documents",
-              "httpMethod": "GET",
-              "parameterOrder": [
-                "parent"
-              ]
-            },
-            "create": {
-              "parameterOrder": [
-                "parent"
-              ],
-              "httpMethod": "POST",
-              "parameters": {
-                "parent": {
-                  "required": true,
-                  "location": "path",
-                  "description": "Required. The name of the `Corpus` where this `Document` will be created. Example: `corpora/my-corpus-123`",
-                  "type": "string",
-                  "pattern": "^corpora/[^/]+$"
-                }
-              },
-              "flatPath": "v1beta/corpora/{corporaId}/documents",
-              "request": {
-                "$ref": "Document"
-              },
-              "id": "generativelanguage.corpora.documents.create",
-              "response": {
-                "$ref": "Document"
-              },
-              "path": "v1beta/{+parent}/documents",
-              "description": "Creates an empty `Document`."
-            },
-            "patch": {
-              "path": "v1beta/{+name}",
-              "httpMethod": "PATCH",
-              "description": "Updates a `Document`.",
-              "request": {
-                "$ref": "Document"
-              },
-              "id": "generativelanguage.corpora.documents.patch",
-              "response": {
-                "$ref": "Document"
-              },
-              "parameters": {
-                "updateMask": {
-                  "location": "query",
-                  "type": "string",
-                  "description": "Required. The list of fields to update. Currently, this only supports updating `display_name` and `custom_metadata`.",
-                  "format": "google-fieldmask"
-                },
-                "name": {
-                  "description": "Immutable. Identifier. The `Document` resource name. The ID (name excluding the \"corpora/*/documents/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a unique name will be derived from `display_name` along with a 12 character random suffix. Example: `corpora/{corpus_id}/documents/my-awesome-doc-123a456b789c`",
-                  "type": "string",
-                  "location": "path",
-                  "required": true,
-                  "pattern": "^corpora/[^/]+/documents/[^/]+$"
-                }
-              },
-              "parameterOrder": [
-                "name"
-              ],
-              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}"
-            },
-            "get": {
-              "description": "Gets information about a specific `Document`.",
-              "path": "v1beta/{+name}",
-              "httpMethod": "GET",
-              "id": "generativelanguage.corpora.documents.get",
-              "parameters": {
-                "name": {
-                  "description": "Required. The name of the `Document` to retrieve. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
-                  "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                  "location": "path",
-                  "required": true,
-                  "type": "string"
-                }
-              },
-              "response": {
-                "$ref": "Document"
-              },
-              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}",
-              "parameterOrder": [
-                "name"
-              ]
-            },
-            "query": {
-              "httpMethod": "POST",
-              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}:query",
-              "description": "Performs semantic search over a `Document`.",
-              "request": {
-                "$ref": "QueryDocumentRequest"
-              },
-              "parameterOrder": [
-                "name"
-              ],
-              "response": {
-                "$ref": "QueryDocumentResponse"
-              },
-              "parameters": {
-                "name": {
-                  "type": "string",
-                  "description": "Required. The name of the `Document` to query. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
-                  "required": true,
-                  "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                  "location": "path"
-                }
-              },
-              "id": "generativelanguage.corpora.documents.query",
-              "path": "v1beta/{+name}:query"
-            },
-            "delete": {
-              "id": "generativelanguage.corpora.documents.delete",
-              "httpMethod": "DELETE",
-              "parameters": {
-                "force": {
-                  "location": "query",
-                  "description": "Optional. If set to true, any `Chunk`s and objects related to this `Document` will also be deleted. If false (the default), a `FAILED_PRECONDITION` error will be returned if `Document` contains any `Chunk`s.",
-                  "type": "boolean"
-                },
-                "name": {
-                  "description": "Required. The resource name of the `Document` to delete. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
-                  "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                  "type": "string",
-                  "location": "path",
-                  "required": true
-                }
-              },
-              "parameterOrder": [
-                "name"
-              ],
-              "description": "Deletes a `Document`.",
-              "path": "v1beta/{+name}",
-              "response": {
-                "$ref": "Empty"
-              },
-              "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}"
-            }
-          },
-          "resources": {
-            "chunks": {
-              "methods": {
-                "batchUpdate": {
-                  "parameters": {
-                    "parent": {
-                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                      "description": "Optional. The name of the `Document` containing the `Chunk`s to update. The parent field in every `UpdateChunkRequest` must match this value. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
-                      "type": "string",
-                      "required": true,
-                      "location": "path"
-                    }
-                  },
-                  "parameterOrder": [
-                    "parent"
-                  ],
-                  "request": {
-                    "$ref": "BatchUpdateChunksRequest"
-                  },
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks:batchUpdate",
-                  "httpMethod": "POST",
-                  "id": "generativelanguage.corpora.documents.chunks.batchUpdate",
-                  "path": "v1beta/{+parent}/chunks:batchUpdate",
-                  "description": "Batch update `Chunk`s.",
-                  "response": {
-                    "$ref": "BatchUpdateChunksResponse"
-                  }
-                },
-                "batchCreate": {
-                  "request": {
-                    "$ref": "BatchCreateChunksRequest"
-                  },
-                  "id": "generativelanguage.corpora.documents.chunks.batchCreate",
-                  "path": "v1beta/{+parent}/chunks:batchCreate",
-                  "description": "Batch create `Chunk`s.",
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks:batchCreate",
-                  "response": {
-                    "$ref": "BatchCreateChunksResponse"
-                  },
-                  "parameters": {
-                    "parent": {
-                      "location": "path",
-                      "required": true,
-                      "description": "Optional. The name of the `Document` where this batch of `Chunk`s will be created. The parent field in every `CreateChunkRequest` must match this value. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
-                      "type": "string",
-                      "pattern": "^corpora/[^/]+/documents/[^/]+$"
-                    }
-                  },
-                  "httpMethod": "POST",
-                  "parameterOrder": [
-                    "parent"
-                  ]
-                },
-                "patch": {
-                  "id": "generativelanguage.corpora.documents.chunks.patch",
-                  "parameterOrder": [
-                    "name"
-                  ],
-                  "httpMethod": "PATCH",
-                  "parameters": {
-                    "updateMask": {
-                      "description": "Required. The list of fields to update. Currently, this only supports updating `custom_metadata` and `data`.",
-                      "format": "google-fieldmask",
-                      "type": "string",
-                      "location": "query"
-                    },
-                    "name": {
-                      "location": "path",
-                      "required": true,
-                      "pattern": "^corpora/[^/]+/documents/[^/]+/chunks/[^/]+$",
-                      "description": "Immutable. Identifier. The `Chunk` resource name. The ID (name excluding the \"corpora/*/documents/*/chunks/\" prefix) can contain up to 40 characters that are lowercase alphanumeric or dashes (-). The ID cannot start or end with a dash. If the name is empty on create, a random 12-character unique ID will be generated. Example: `corpora/{corpus_id}/documents/{document_id}/chunks/123a456b789c`",
-                      "type": "string"
-                    }
-                  },
-                  "response": {
-                    "$ref": "Chunk"
-                  },
-                  "description": "Updates a `Chunk`.",
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks/{chunksId}",
-                  "request": {
-                    "$ref": "Chunk"
-                  },
-                  "path": "v1beta/{+name}"
-                },
-                "batchDelete": {
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks:batchDelete",
-                  "parameters": {
-                    "parent": {
-                      "location": "path",
-                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                      "type": "string",
-                      "description": "Optional. The name of the `Document` containing the `Chunk`s to delete. The parent field in every `DeleteChunkRequest` must match this value. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
-                      "required": true
-                    }
-                  },
-                  "id": "generativelanguage.corpora.documents.chunks.batchDelete",
-                  "path": "v1beta/{+parent}/chunks:batchDelete",
-                  "description": "Batch delete `Chunk`s.",
-                  "parameterOrder": [
-                    "parent"
-                  ],
-                  "request": {
-                    "$ref": "BatchDeleteChunksRequest"
-                  },
-                  "response": {
-                    "$ref": "Empty"
-                  },
-                  "httpMethod": "POST"
-                },
-                "delete": {
-                  "id": "generativelanguage.corpora.documents.chunks.delete",
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks/{chunksId}",
-                  "description": "Deletes a `Chunk`.",
-                  "httpMethod": "DELETE",
-                  "parameters": {
-                    "name": {
-                      "required": true,
-                      "pattern": "^corpora/[^/]+/documents/[^/]+/chunks/[^/]+$",
-                      "location": "path",
-                      "type": "string",
-                      "description": "Required. The resource name of the `Chunk` to delete. Example: `corpora/my-corpus-123/documents/the-doc-abc/chunks/some-chunk`"
-                    }
-                  },
-                  "response": {
-                    "$ref": "Empty"
-                  },
-                  "parameterOrder": [
-                    "name"
-                  ],
-                  "path": "v1beta/{+name}"
-                },
-                "get": {
-                  "httpMethod": "GET",
-                  "path": "v1beta/{+name}",
-                  "parameters": {
-                    "name": {
-                      "location": "path",
-                      "required": true,
-                      "description": "Required. The name of the `Chunk` to retrieve. Example: `corpora/my-corpus-123/documents/the-doc-abc/chunks/some-chunk`",
-                      "pattern": "^corpora/[^/]+/documents/[^/]+/chunks/[^/]+$",
-                      "type": "string"
-                    }
-                  },
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks/{chunksId}",
-                  "description": "Gets information about a specific `Chunk`.",
-                  "response": {
-                    "$ref": "Chunk"
-                  },
-                  "parameterOrder": [
-                    "name"
-                  ],
-                  "id": "generativelanguage.corpora.documents.chunks.get"
-                },
-                "list": {
-                  "response": {
-                    "$ref": "ListChunksResponse"
-                  },
-                  "parameterOrder": [
-                    "parent"
-                  ],
-                  "path": "v1beta/{+parent}/chunks",
-                  "id": "generativelanguage.corpora.documents.chunks.list",
-                  "description": "Lists all `Chunk`s in a `Document`.",
-                  "httpMethod": "GET",
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks",
-                  "parameters": {
-                    "parent": {
-                      "required": true,
-                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                      "location": "path",
-                      "type": "string",
-                      "description": "Required. The name of the `Document` containing `Chunk`s. Example: `corpora/my-corpus-123/documents/the-doc-abc`"
-                    },
-                    "pageToken": {
-                      "location": "query",
-                      "type": "string",
-                      "description": "Optional. A page token, received from a previous `ListChunks` call. Provide the `next_page_token` returned in the response as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListChunks` must match the call that provided the page token."
-                    },
-                    "pageSize": {
-                      "description": "Optional. The maximum number of `Chunk`s to return (per page). The service may return fewer `Chunk`s. If unspecified, at most 10 `Chunk`s will be returned. The maximum size limit is 100 `Chunk`s per page.",
-                      "location": "query",
-                      "type": "integer",
-                      "format": "int32"
-                    }
-                  }
-                },
-                "create": {
-                  "description": "Creates a `Chunk`.",
-                  "httpMethod": "POST",
-                  "request": {
-                    "$ref": "Chunk"
-                  },
-                  "path": "v1beta/{+parent}/chunks",
-                  "response": {
-                    "$ref": "Chunk"
-                  },
-                  "parameters": {
-                    "parent": {
-                      "type": "string",
-                      "description": "Required. The name of the `Document` where this `Chunk` will be created. Example: `corpora/my-corpus-123/documents/the-doc-abc`",
-                      "pattern": "^corpora/[^/]+/documents/[^/]+$",
-                      "location": "path",
-                      "required": true
-                    }
-                  },
-                  "id": "generativelanguage.corpora.documents.chunks.create",
-                  "parameterOrder": [
-                    "parent"
-                  ],
-                  "flatPath": "v1beta/corpora/{corporaId}/documents/{documentsId}/chunks"
-                }
-              }
-            }
-          }
-        },
-        "permissions": {
-          "methods": {
-            "list": {
-              "path": "v1beta/{+parent}/permissions",
-              "flatPath": "v1beta/corpora/{corporaId}/permissions",
-              "parameters": {
-                "pageToken": {
-                  "type": "string",
-                  "description": "Optional. A page token, received from a previous `ListPermissions` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListPermissions` must match the call that provided the page token.",
-                  "location": "query"
-                },
-                "pageSize": {
-                  "description": "Optional. The maximum number of `Permission`s to return (per page). The service may return fewer permissions. If unspecified, at most 10 permissions will be returned. This method returns at most 1000 permissions per page, even if you pass larger page_size.",
-                  "format": "int32",
-                  "location": "query",
-                  "type": "integer"
-                },
-                "parent": {
-                  "pattern": "^corpora/[^/]+$",
-                  "location": "path",
-                  "required": true,
-                  "description": "Required. The parent resource of the permissions. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`",
-                  "type": "string"
-                }
-              },
-              "description": "Lists permissions for the specific resource.",
-              "httpMethod": "GET",
-              "id": "generativelanguage.corpora.permissions.list",
-              "response": {
-                "$ref": "ListPermissionsResponse"
-              },
-              "parameterOrder": [
-                "parent"
-              ]
-            },
-            "delete": {
-              "parameterOrder": [
-                "name"
-              ],
-              "description": "Deletes the permission.",
-              "parameters": {
-                "name": {
-                  "type": "string",
-                  "pattern": "^corpora/[^/]+/permissions/[^/]+$",
-                  "required": true,
-                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
-                  "location": "path"
-                }
-              },
-              "flatPath": "v1beta/corpora/{corporaId}/permissions/{permissionsId}",
-              "httpMethod": "DELETE",
-              "path": "v1beta/{+name}",
-              "response": {
-                "$ref": "Empty"
-              },
-              "id": "generativelanguage.corpora.permissions.delete"
-            },
-            "get": {
-              "id": "generativelanguage.corpora.permissions.get",
-              "response": {
-                "$ref": "Permission"
-              },
-              "description": "Gets information about a specific Permission.",
-              "parameters": {
-                "name": {
-                  "required": true,
-                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
-                  "location": "path",
-                  "pattern": "^corpora/[^/]+/permissions/[^/]+$",
-                  "type": "string"
-                }
-              },
-              "httpMethod": "GET",
-              "path": "v1beta/{+name}",
-              "flatPath": "v1beta/corpora/{corporaId}/permissions/{permissionsId}",
-              "parameterOrder": [
-                "name"
-              ]
-            },
-            "create": {
-              "response": {
-                "$ref": "Permission"
-              },
-              "request": {
-                "$ref": "Permission"
-              },
-              "id": "generativelanguage.corpora.permissions.create",
-              "parameters": {
-                "parent": {
-                  "description": "Required. The parent resource of the `Permission`. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`",
-                  "location": "path",
-                  "pattern": "^corpora/[^/]+$",
-                  "required": true,
-                  "type": "string"
-                }
-              },
-              "parameterOrder": [
-                "parent"
-              ],
-              "description": "Create a permission to a specific resource.",
-              "flatPath": "v1beta/corpora/{corporaId}/permissions",
-              "httpMethod": "POST",
-              "path": "v1beta/{+parent}/permissions"
-            },
-            "patch": {
-              "parameters": {
-                "updateMask": {
-                  "type": "string",
-                  "location": "query",
-                  "format": "google-fieldmask",
-                  "description": "Required. The list of fields to update. Accepted ones: - role (`Permission.role` field)"
-                },
-                "name": {
-                  "description": "Output only. Identifier. The permission name. A unique name will be generated on create. Examples: tunedModels/{tuned_model}/permissions/{permission} corpora/{corpus}/permissions/{permission} Output only.",
-                  "location": "path",
-                  "pattern": "^corpora/[^/]+/permissions/[^/]+$",
-                  "type": "string",
-                  "required": true
-                }
-              },
-              "id": "generativelanguage.corpora.permissions.patch",
-              "parameterOrder": [
-                "name"
-              ],
-              "request": {
-                "$ref": "Permission"
-              },
-              "flatPath": "v1beta/corpora/{corporaId}/permissions/{permissionsId}",
-              "response": {
-                "$ref": "Permission"
-              },
-              "httpMethod": "PATCH",
-              "description": "Updates the permission.",
-              "path": "v1beta/{+name}"
-            }
-          }
+      "id": "StringList",
+      "description": "User provided string values assigned to a single metadata key."
+    },
+    "CountTextTokensResponse": {
+      "description": "A response from `CountTextTokens`. It returns the model's `token_count` for the `prompt`.",
+      "type": "object",
+      "id": "CountTextTokensResponse",
+      "properties": {
+        "tokenCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of tokens that the `model` tokenizes the `prompt` into. Always non-negative."
         }
       }
     },
-    "media": {
-      "methods": {
-        "upload": {
-          "supportsMediaUpload": true,
-          "response": {
-            "$ref": "CreateFileResponse"
-          },
-          "mediaUpload": {
-            "maxSize": "2147483648",
-            "protocols": {
-              "simple": {
-                "multipart": true,
-                "path": "/upload/v1beta/files"
-              },
-              "resumable": {
-                "path": "/resumable/upload/v1beta/files",
-                "multipart": true
-              }
-            },
-            "accept": [
-              "*/*"
-            ]
-          },
-          "parameters": {},
-          "path": "v1beta/files",
-          "request": {
-            "$ref": "CreateFileRequest"
-          },
-          "parameterOrder": [],
-          "flatPath": "v1beta/files",
-          "description": "Creates a `File`.",
-          "id": "generativelanguage.media.upload",
-          "httpMethod": "POST"
-        }
-      }
-    },
-    "models": {
-      "methods": {
-        "countTextTokens": {
-          "httpMethod": "POST",
-          "path": "v1beta/{+model}:countTextTokens",
-          "parameters": {
-            "model": {
-              "type": "string",
-              "location": "path",
-              "required": true,
-              "pattern": "^models/[^/]+$",
-              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`"
-            }
-          },
-          "request": {
-            "$ref": "CountTextTokensRequest"
-          },
-          "parameterOrder": [
-            "model"
-          ],
-          "description": "Runs a model's tokenizer on a text and returns the token count.",
-          "id": "generativelanguage.models.countTextTokens",
-          "response": {
-            "$ref": "CountTextTokensResponse"
-          },
-          "flatPath": "v1beta/models/{modelsId}:countTextTokens"
+    "SemanticRetrieverConfig": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "$ref": "Content",
+          "description": "Required. Query to use for similarity matching `Chunk`s in the given resource."
         },
-        "get": {
-          "flatPath": "v1beta/models/{modelsId}",
-          "path": "v1beta/{+name}",
-          "description": "Gets information about a specific Model.",
-          "id": "generativelanguage.models.get",
-          "parameters": {
-            "name": {
-              "description": "Required. The resource name of the model. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
-              "required": true,
-              "pattern": "^models/[^/]+$",
-              "type": "string",
-              "location": "path"
-            }
+        "metadataFilters": {
+          "items": {
+            "$ref": "MetadataFilter"
           },
-          "response": {
-            "$ref": "Model"
-          },
-          "parameterOrder": [
-            "name"
-          ],
-          "httpMethod": "GET"
+          "description": "Optional. Filters for selecting `Document`s and/or `Chunk`s from the resource.",
+          "type": "array"
         },
-        "countTokens": {
-          "response": {
-            "$ref": "CountTokensResponse"
-          },
-          "id": "generativelanguage.models.countTokens",
-          "description": "Runs a model's tokenizer on input content and returns the token count.",
-          "parameters": {
-            "model": {
-              "type": "string",
-              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
-              "location": "path",
-              "required": true,
-              "pattern": "^models/[^/]+$"
-            }
-          },
-          "path": "v1beta/{+model}:countTokens",
-          "flatPath": "v1beta/models/{modelsId}:countTokens",
-          "request": {
-            "$ref": "CountTokensRequest"
-          },
-          "parameterOrder": [
-            "model"
-          ],
-          "httpMethod": "POST"
+        "minimumRelevanceScore": {
+          "type": "number",
+          "format": "float",
+          "description": "Optional. Minimum relevance score for retrieved relevant `Chunk`s."
         },
-        "embedText": {
-          "request": {
-            "$ref": "EmbedTextRequest"
-          },
-          "httpMethod": "POST",
-          "description": "Generates an embedding from the model given an input message.",
-          "id": "generativelanguage.models.embedText",
-          "flatPath": "v1beta/models/{modelsId}:embedText",
-          "parameters": {
-            "model": {
-              "description": "Required. The model name to use with the format model=models/{model}.",
-              "required": true,
-              "pattern": "^models/[^/]+$",
-              "type": "string",
-              "location": "path"
-            }
-          },
-          "parameterOrder": [
-            "model"
-          ],
-          "response": {
-            "$ref": "EmbedTextResponse"
-          },
-          "path": "v1beta/{+model}:embedText"
+        "source": {
+          "type": "string",
+          "description": "Required. Name of the resource for retrieval, e.g. corpora/123 or corpora/123/documents/abc."
         },
-        "batchEmbedText": {
-          "request": {
-            "$ref": "BatchEmbedTextRequest"
-          },
-          "path": "v1beta/{+model}:batchEmbedText",
-          "parameters": {
-            "model": {
-              "location": "path",
-              "type": "string",
-              "description": "Required. The name of the `Model` to use for generating the embedding. Examples: models/embedding-gecko-001",
-              "pattern": "^models/[^/]+$",
-              "required": true
-            }
-          },
-          "flatPath": "v1beta/models/{modelsId}:batchEmbedText",
-          "id": "generativelanguage.models.batchEmbedText",
-          "response": {
-            "$ref": "BatchEmbedTextResponse"
-          },
-          "description": "Generates multiple embeddings from the model given input text in a synchronous call.",
-          "parameterOrder": [
-            "model"
-          ],
-          "httpMethod": "POST"
-        },
-        "list": {
-          "httpMethod": "GET",
-          "flatPath": "v1beta/models",
-          "description": "Lists models available through the API.",
-          "path": "v1beta/models",
-          "parameters": {
-            "pageToken": {
-              "type": "string",
-              "description": "A page token, received from a previous `ListModels` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListModels` must match the call that provided the page token.",
-              "location": "query"
-            },
-            "pageSize": {
-              "location": "query",
-              "description": "The maximum number of `Models` to return (per page). The service may return fewer models. If unspecified, at most 50 models will be returned per page. This method returns at most 1000 models per page, even if you pass a larger page_size.",
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          "parameterOrder": [],
-          "response": {
-            "$ref": "ListModelsResponse"
-          },
-          "id": "generativelanguage.models.list"
-        },
-        "batchEmbedContents": {
-          "description": "Generates multiple embeddings from the model given input text in a synchronous call.",
-          "httpMethod": "POST",
-          "parameterOrder": [
-            "model"
-          ],
-          "parameters": {
-            "model": {
-              "required": true,
-              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`",
-              "location": "path",
-              "pattern": "^models/[^/]+$",
-              "type": "string"
-            }
-          },
-          "path": "v1beta/{+model}:batchEmbedContents",
-          "flatPath": "v1beta/models/{modelsId}:batchEmbedContents",
-          "request": {
-            "$ref": "BatchEmbedContentsRequest"
-          },
-          "id": "generativelanguage.models.batchEmbedContents",
-          "response": {
-            "$ref": "BatchEmbedContentsResponse"
-          }
-        },
-        "streamGenerateContent": {
-          "path": "v1beta/{+model}:streamGenerateContent",
-          "httpMethod": "POST",
-          "parameterOrder": [
-            "model"
-          ],
-          "request": {
-            "$ref": "GenerateContentRequest"
-          },
-          "parameters": {
-            "model": {
-              "location": "path",
-              "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`.",
-              "type": "string",
-              "pattern": "^models/[^/]+$",
-              "required": true
-            }
-          },
-          "flatPath": "v1beta/models/{modelsId}:streamGenerateContent",
-          "response": {
-            "$ref": "GenerateContentResponse"
-          },
-          "id": "generativelanguage.models.streamGenerateContent",
-          "description": "Generates a streamed response from the model given an input `GenerateContentRequest`."
-        },
-        "generateText": {
-          "parameterOrder": [
-            "model"
-          ],
-          "flatPath": "v1beta/models/{modelsId}:generateText",
-          "response": {
-            "$ref": "GenerateTextResponse"
-          },
-          "httpMethod": "POST",
-          "description": "Generates a response from the model given an input message.",
-          "path": "v1beta/{+model}:generateText",
-          "request": {
-            "$ref": "GenerateTextRequest"
-          },
-          "id": "generativelanguage.models.generateText",
-          "parameters": {
-            "model": {
-              "location": "path",
-              "description": "Required. The name of the `Model` or `TunedModel` to use for generating the completion. Examples: models/text-bison-001 tunedModels/sentence-translator-u3b7m",
-              "pattern": "^models/[^/]+$",
-              "required": true,
-              "type": "string"
-            }
-          }
-        },
-        "generateContent": {
-          "path": "v1beta/{+model}:generateContent",
-          "httpMethod": "POST",
-          "flatPath": "v1beta/models/{modelsId}:generateContent",
-          "id": "generativelanguage.models.generateContent",
-          "description": "Generates a response from the model given an input `GenerateContentRequest`. Input capabilities differ between models, including tuned models. See the [model guide](https://ai.google.dev/models/gemini) and [tuning guide](https://ai.google.dev/docs/model_tuning_guidance) for details.",
-          "request": {
-            "$ref": "GenerateContentRequest"
-          },
-          "parameters": {
-            "model": {
-              "required": true,
-              "pattern": "^models/[^/]+$",
-              "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`.",
-              "type": "string",
-              "location": "path"
-            }
-          },
-          "parameterOrder": [
-            "model"
-          ],
-          "response": {
-            "$ref": "GenerateContentResponse"
-          }
-        },
-        "countMessageTokens": {
-          "path": "v1beta/{+model}:countMessageTokens",
-          "id": "generativelanguage.models.countMessageTokens",
-          "parameters": {
-            "model": {
-              "location": "path",
-              "type": "string",
-              "required": true,
-              "pattern": "^models/[^/]+$",
-              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`"
-            }
-          },
-          "description": "Runs a model's tokenizer on a string and returns the token count.",
-          "response": {
-            "$ref": "CountMessageTokensResponse"
-          },
-          "httpMethod": "POST",
-          "request": {
-            "$ref": "CountMessageTokensRequest"
-          },
-          "parameterOrder": [
-            "model"
-          ],
-          "flatPath": "v1beta/models/{modelsId}:countMessageTokens"
-        },
-        "embedContent": {
-          "parameterOrder": [
-            "model"
-          ],
-          "parameters": {
-            "model": {
-              "pattern": "^models/[^/]+$",
-              "location": "path",
-              "type": "string",
-              "required": true,
-              "description": "Required. The model's resource name. This serves as an ID for the Model to use. This name should match a model name returned by the `ListModels` method. Format: `models/{model}`"
-            }
-          },
-          "description": "Generates an embedding from the model given an input `Content`.",
-          "request": {
-            "$ref": "EmbedContentRequest"
-          },
-          "flatPath": "v1beta/models/{modelsId}:embedContent",
-          "path": "v1beta/{+model}:embedContent",
-          "httpMethod": "POST",
-          "response": {
-            "$ref": "EmbedContentResponse"
-          },
-          "id": "generativelanguage.models.embedContent"
-        },
-        "generateAnswer": {
-          "request": {
-            "$ref": "GenerateAnswerRequest"
-          },
-          "httpMethod": "POST",
-          "parameterOrder": [
-            "model"
-          ],
-          "description": "Generates a grounded answer from the model given an input `GenerateAnswerRequest`.",
-          "path": "v1beta/{+model}:generateAnswer",
-          "id": "generativelanguage.models.generateAnswer",
-          "flatPath": "v1beta/models/{modelsId}:generateAnswer",
-          "response": {
-            "$ref": "GenerateAnswerResponse"
-          },
-          "parameters": {
-            "model": {
-              "type": "string",
-              "description": "Required. The name of the `Model` to use for generating the grounded response. Format: `model=models/{model}`.",
-              "location": "path",
-              "pattern": "^models/[^/]+$",
-              "required": true
-            }
-          }
-        },
-        "generateMessage": {
-          "request": {
-            "$ref": "GenerateMessageRequest"
-          },
-          "response": {
-            "$ref": "GenerateMessageResponse"
-          },
-          "id": "generativelanguage.models.generateMessage",
-          "httpMethod": "POST",
-          "parameters": {
-            "model": {
-              "type": "string",
-              "description": "Required. The name of the model to use. Format: `name=models/{model}`.",
-              "required": true,
-              "pattern": "^models/[^/]+$",
-              "location": "path"
-            }
-          },
-          "parameterOrder": [
-            "model"
-          ],
-          "path": "v1beta/{+model}:generateMessage",
-          "flatPath": "v1beta/models/{modelsId}:generateMessage",
-          "description": "Generates a response from the model given an input `MessagePrompt`."
-        }
-      }
-    },
-    "cachedContents": {
-      "methods": {
-        "delete": {
-          "description": "Deletes CachedContent resource.",
-          "parameterOrder": [
-            "name"
-          ],
-          "flatPath": "v1beta/cachedContents/{cachedContentsId}",
-          "parameters": {
-            "name": {
-              "required": true,
-              "description": "Required. The resource name referring to the content cache entry Format: `cachedContents/{id}`",
-              "pattern": "^cachedContents/[^/]+$",
-              "type": "string",
-              "location": "path"
-            }
-          },
-          "id": "generativelanguage.cachedContents.delete",
-          "httpMethod": "DELETE",
-          "path": "v1beta/{+name}",
-          "response": {
-            "$ref": "Empty"
-          }
-        },
-        "list": {
-          "id": "generativelanguage.cachedContents.list",
-          "parameterOrder": [],
-          "response": {
-            "$ref": "ListCachedContentsResponse"
-          },
-          "description": "Lists CachedContents.",
-          "path": "v1beta/cachedContents",
-          "flatPath": "v1beta/cachedContents",
-          "parameters": {
-            "pageSize": {
-              "location": "query",
-              "description": "Optional. The maximum number of cached contents to return. The service may return fewer than this value. If unspecified, some default (under maximum) number of items will be returned. The maximum value is 1000; values above 1000 will be coerced to 1000.",
-              "type": "integer",
-              "format": "int32"
-            },
-            "pageToken": {
-              "location": "query",
-              "type": "string",
-              "description": "Optional. A page token, received from a previous `ListCachedContents` call. Provide this to retrieve the subsequent page. When paginating, all other parameters provided to `ListCachedContents` must match the call that provided the page token."
-            }
-          },
-          "httpMethod": "GET"
-        },
-        "patch": {
-          "flatPath": "v1beta/cachedContents/{cachedContentsId}",
-          "parameters": {
-            "updateMask": {
-              "location": "query",
-              "type": "string",
-              "description": "The list of fields to update.",
-              "format": "google-fieldmask"
-            },
-            "name": {
-              "location": "path",
-              "required": true,
-              "description": "Optional. Identifier. The resource name referring to the cached content. Format: `cachedContents/{id}`",
-              "pattern": "^cachedContents/[^/]+$",
-              "type": "string"
-            }
-          },
-          "response": {
-            "$ref": "CachedContent"
-          },
-          "path": "v1beta/{+name}",
-          "httpMethod": "PATCH",
-          "request": {
-            "$ref": "CachedContent"
-          },
-          "parameterOrder": [
-            "name"
-          ],
-          "id": "generativelanguage.cachedContents.patch",
-          "description": "Updates CachedContent resource (only expiration is updatable)."
-        },
-        "create": {
-          "path": "v1beta/cachedContents",
-          "parameterOrder": [],
-          "id": "generativelanguage.cachedContents.create",
-          "parameters": {},
-          "description": "Creates CachedContent resource.",
-          "request": {
-            "$ref": "CachedContent"
-          },
-          "httpMethod": "POST",
-          "response": {
-            "$ref": "CachedContent"
-          },
-          "flatPath": "v1beta/cachedContents"
-        },
-        "get": {
-          "parameterOrder": [
-            "name"
-          ],
-          "httpMethod": "GET",
-          "flatPath": "v1beta/cachedContents/{cachedContentsId}",
-          "parameters": {
-            "name": {
-              "location": "path",
-              "required": true,
-              "type": "string",
-              "description": "Required. The resource name referring to the content cache entry. Format: `cachedContents/{id}`",
-              "pattern": "^cachedContents/[^/]+$"
-            }
-          },
-          "description": "Reads CachedContent resource.",
-          "id": "generativelanguage.cachedContents.get",
-          "response": {
-            "$ref": "CachedContent"
-          },
-          "path": "v1beta/{+name}"
-        }
-      }
-    },
-    "tunedModels": {
-      "resources": {
-        "permissions": {
-          "methods": {
-            "list": {
-              "description": "Lists permissions for the specific resource.",
-              "httpMethod": "GET",
-              "parameters": {
-                "pageSize": {
-                  "format": "int32",
-                  "description": "Optional. The maximum number of `Permission`s to return (per page). The service may return fewer permissions. If unspecified, at most 10 permissions will be returned. This method returns at most 1000 permissions per page, even if you pass larger page_size.",
-                  "type": "integer",
-                  "location": "query"
-                },
-                "pageToken": {
-                  "location": "query",
-                  "description": "Optional. A page token, received from a previous `ListPermissions` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListPermissions` must match the call that provided the page token.",
-                  "type": "string"
-                },
-                "parent": {
-                  "pattern": "^tunedModels/[^/]+$",
-                  "required": true,
-                  "description": "Required. The parent resource of the permissions. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`",
-                  "type": "string",
-                  "location": "path"
-                }
-              },
-              "response": {
-                "$ref": "ListPermissionsResponse"
-              },
-              "parameterOrder": [
-                "parent"
-              ],
-              "path": "v1beta/{+parent}/permissions",
-              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions",
-              "id": "generativelanguage.tunedModels.permissions.list"
-            },
-            "delete": {
-              "id": "generativelanguage.tunedModels.permissions.delete",
-              "parameters": {
-                "name": {
-                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
-                  "pattern": "^tunedModels/[^/]+/permissions/[^/]+$",
-                  "type": "string",
-                  "required": true,
-                  "location": "path"
-                }
-              },
-              "path": "v1beta/{+name}",
-              "description": "Deletes the permission.",
-              "response": {
-                "$ref": "Empty"
-              },
-              "parameterOrder": [
-                "name"
-              ],
-              "httpMethod": "DELETE",
-              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions/{permissionsId}"
-            },
-            "patch": {
-              "request": {
-                "$ref": "Permission"
-              },
-              "parameters": {
-                "name": {
-                  "type": "string",
-                  "pattern": "^tunedModels/[^/]+/permissions/[^/]+$",
-                  "required": true,
-                  "location": "path",
-                  "description": "Output only. Identifier. The permission name. A unique name will be generated on create. Examples: tunedModels/{tuned_model}/permissions/{permission} corpora/{corpus}/permissions/{permission} Output only."
-                },
-                "updateMask": {
-                  "description": "Required. The list of fields to update. Accepted ones: - role (`Permission.role` field)",
-                  "type": "string",
-                  "location": "query",
-                  "format": "google-fieldmask"
-                }
-              },
-              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions/{permissionsId}",
-              "parameterOrder": [
-                "name"
-              ],
-              "response": {
-                "$ref": "Permission"
-              },
-              "id": "generativelanguage.tunedModels.permissions.patch",
-              "httpMethod": "PATCH",
-              "path": "v1beta/{+name}",
-              "description": "Updates the permission."
-            },
-            "get": {
-              "httpMethod": "GET",
-              "id": "generativelanguage.tunedModels.permissions.get",
-              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions/{permissionsId}",
-              "parameterOrder": [
-                "name"
-              ],
-              "path": "v1beta/{+name}",
-              "parameters": {
-                "name": {
-                  "location": "path",
-                  "type": "string",
-                  "description": "Required. The resource name of the permission. Formats: `tunedModels/{tuned_model}/permissions/{permission}` `corpora/{corpus}/permissions/{permission}`",
-                  "required": true,
-                  "pattern": "^tunedModels/[^/]+/permissions/[^/]+$"
-                }
-              },
-              "description": "Gets information about a specific Permission.",
-              "response": {
-                "$ref": "Permission"
-              }
-            },
-            "create": {
-              "parameters": {
-                "parent": {
-                  "pattern": "^tunedModels/[^/]+$",
-                  "description": "Required. The parent resource of the `Permission`. Formats: `tunedModels/{tuned_model}` `corpora/{corpus}`",
-                  "location": "path",
-                  "type": "string",
-                  "required": true
-                }
-              },
-              "description": "Create a permission to a specific resource.",
-              "httpMethod": "POST",
-              "flatPath": "v1beta/tunedModels/{tunedModelsId}/permissions",
-              "request": {
-                "$ref": "Permission"
-              },
-              "parameterOrder": [
-                "parent"
-              ],
-              "id": "generativelanguage.tunedModels.permissions.create",
-              "response": {
-                "$ref": "Permission"
-              },
-              "path": "v1beta/{+parent}/permissions"
-            }
-          }
+        "maxChunksCount": {
+          "format": "int32",
+          "description": "Optional. Maximum number of relevant `Chunk`s to retrieve.",
+          "type": "integer"
         }
       },
-      "methods": {
-        "delete": {
-          "parameterOrder": [
-            "name"
-          ],
-          "description": "Deletes a tuned model.",
-          "path": "v1beta/{+name}",
-          "parameters": {
-            "name": {
-              "type": "string",
-              "pattern": "^tunedModels/[^/]+$",
-              "required": true,
-              "description": "Required. The resource name of the model. Format: `tunedModels/my-model-id`",
-              "location": "path"
-            }
-          },
-          "flatPath": "v1beta/tunedModels/{tunedModelsId}",
-          "id": "generativelanguage.tunedModels.delete",
-          "httpMethod": "DELETE",
-          "response": {
-            "$ref": "Empty"
-          }
+      "id": "SemanticRetrieverConfig",
+      "description": "Configuration for retrieving grounding content from a `Corpus` or `Document` created using the Semantic Retriever API."
+    },
+    "Blob": {
+      "properties": {
+        "mimeType": {
+          "type": "string",
+          "description": "The IANA standard MIME type of the source data. Examples: - image/png - image/jpeg If an unsupported MIME type is provided, an error will be returned. For a complete list of supported types, see [Supported file formats](https://ai.google.dev/gemini-api/docs/prompting_with_media#supported_file_formats)."
         },
-        "transferOwnership": {
-          "parameters": {
-            "name": {
-              "required": true,
-              "pattern": "^tunedModels/[^/]+$",
-              "type": "string",
-              "description": "Required. The resource name of the tuned model to transfer ownership. Format: `tunedModels/my-model-id`",
-              "location": "path"
-            }
-          },
-          "description": "Transfers ownership of the tuned model. This is the only way to change ownership of the tuned model. The current owner will be downgraded to writer role.",
-          "parameterOrder": [
-            "name"
-          ],
-          "httpMethod": "POST",
-          "flatPath": "v1beta/tunedModels/{tunedModelsId}:transferOwnership",
-          "id": "generativelanguage.tunedModels.transferOwnership",
-          "request": {
-            "$ref": "TransferOwnershipRequest"
-          },
-          "response": {
-            "$ref": "TransferOwnershipResponse"
-          },
-          "path": "v1beta/{+name}:transferOwnership"
-        },
-        "generateContent": {
-          "description": "Generates a response from the model given an input `GenerateContentRequest`. Input capabilities differ between models, including tuned models. See the [model guide](https://ai.google.dev/models/gemini) and [tuning guide](https://ai.google.dev/docs/model_tuning_guidance) for details.",
-          "flatPath": "v1beta/tunedModels/{tunedModelsId}:generateContent",
-          "httpMethod": "POST",
-          "parameters": {
-            "model": {
-              "location": "path",
-              "required": true,
-              "type": "string",
-              "pattern": "^tunedModels/[^/]+$",
-              "description": "Required. The name of the `Model` to use for generating the completion. Format: `name=models/{model}`."
-            }
-          },
-          "parameterOrder": [
-            "model"
-          ],
-          "request": {
-            "$ref": "GenerateContentRequest"
-          },
-          "path": "v1beta/{+model}:generateContent",
-          "id": "generativelanguage.tunedModels.generateContent",
-          "response": {
-            "$ref": "GenerateContentResponse"
-          }
-        },
-        "patch": {
-          "description": "Updates a tuned model.",
-          "id": "generativelanguage.tunedModels.patch",
-          "flatPath": "v1beta/tunedModels/{tunedModelsId}",
-          "path": "v1beta/{+name}",
-          "httpMethod": "PATCH",
-          "request": {
-            "$ref": "TunedModel"
-          },
-          "response": {
-            "$ref": "TunedModel"
-          },
-          "parameterOrder": [
-            "name"
-          ],
-          "parameters": {
-            "updateMask": {
-              "type": "string",
-              "location": "query",
-              "format": "google-fieldmask",
-              "description": "Required. The list of fields to update."
-            },
-            "name": {
-              "location": "path",
-              "pattern": "^tunedModels/[^/]+$",
-              "required": true,
-              "type": "string",
-              "description": "Output only. The tuned model name. A unique name will be generated on create. Example: `tunedModels/az2mb0bpw6i` If display_name is set on create, the id portion of the name will be set by concatenating the words of the display_name with hyphens and adding a random portion for uniqueness. Example: display_name = \"Sentence Translator\" name = \"tunedModels/sentence-translator-u3b7m\""
-            }
-          }
-        },
-        "list": {
-          "parameters": {
-            "filter": {
-              "description": "Optional. A filter is a full text search over the tuned model's description and display name. By default, results will not include tuned models shared with everyone. Additional operators: - owner:me - writers:me - readers:me - readers:everyone Examples: \"owner:me\" returns all tuned models to which caller has owner role \"readers:me\" returns all tuned models to which caller has reader role \"readers:everyone\" returns all tuned models that are shared with everyone",
-              "type": "string",
-              "location": "query"
-            },
-            "pageSize": {
-              "format": "int32",
-              "description": "Optional. The maximum number of `TunedModels` to return (per page). The service may return fewer tuned models. If unspecified, at most 10 tuned models will be returned. This method returns at most 1000 models per page, even if you pass a larger page_size.",
-              "location": "query",
-              "type": "integer"
-            },
-            "pageToken": {
-              "location": "query",
-              "type": "string",
-              "description": "Optional. A page token, received from a previous `ListTunedModels` call. Provide the `page_token` returned by one request as an argument to the next request to retrieve the next page. When paginating, all other parameters provided to `ListTunedModels` must match the call that provided the page token."
-            }
-          },
-          "description": "Lists tuned models owned by the user.",
-          "response": {
-            "$ref": "ListTunedModelsResponse"
-          },
-          "id": "generativelanguage.tunedModels.list",
-          "parameterOrder": [],
-          "flatPath": "v1beta/tunedModels",
-          "path": "v1beta/tunedModels",
-          "httpMethod": "GET"
-        },
-        "generateText": {
-          "response": {
-            "$ref": "GenerateTextResponse"
-          },
-          "flatPath": "v1beta/tunedModels/{tunedModelsId}:generateText",
-          "httpMethod": "POST",
-          "request": {
-            "$ref": "GenerateTextRequest"
-          },
-          "description": "Generates a response from the model given an input message.",
-          "id": "generativelanguage.tunedModels.generateText",
-          "path": "v1beta/{+model}:generateText",
-          "parameterOrder": [
-            "model"
-          ],
-          "parameters": {
-            "model": {
-              "pattern": "^tunedModels/[^/]+$",
-              "description": "Required. The name of the `Model` or `TunedModel` to use for generating the completion. Examples: models/text-bison-001 tunedModels/sentence-translator-u3b7m",
-              "type": "string",
-              "location": "path",
-              "required": true
-            }
-          }
-        },
-        "get": {
-          "path": "v1beta/{+name}",
-          "parameterOrder": [
-            "name"
-          ],
-          "description": "Gets information about a specific TunedModel.",
-          "response": {
-            "$ref": "TunedModel"
-          },
-          "httpMethod": "GET",
-          "flatPath": "v1beta/tunedModels/{tunedModelsId}",
-          "parameters": {
-            "name": {
-              "required": true,
-              "location": "path",
-              "type": "string",
-              "description": "Required. The resource name of the model. Format: `tunedModels/my-model-id`",
-              "pattern": "^tunedModels/[^/]+$"
-            }
-          },
-          "id": "generativelanguage.tunedModels.get"
-        },
-        "create": {
-          "description": "Creates a tuned model. Intermediate tuning progress (if any) is accessed through the [google.longrunning.Operations] service. Status and results can be accessed through the Operations service. Example: GET /v1/tunedModels/az2mb0bpw6i/operations/000-111-222",
-          "parameterOrder": [],
-          "id": "generativelanguage.tunedModels.create",
-          "path": "v1beta/tunedModels",
-          "request": {
-            "$ref": "TunedModel"
-          },
-          "flatPath": "v1beta/tunedModels",
-          "httpMethod": "POST",
-          "response": {
-            "$ref": "Operation"
-          },
-          "parameters": {
-            "tunedModelId": {
-              "type": "string",
-              "description": "Optional. The unique id for the tuned model if specified. This value should be up to 40 characters, the first character must be a letter, the last could be a letter or a number. The id must match the regular expression: [a-z]([a-z0-9-]{0,38}[a-z0-9])?.",
-              "location": "query"
-            }
-          }
+        "data": {
+          "description": "Raw bytes for media formats.",
+          "type": "string",
+          "format": "byte"
+        }
+      },
+      "description": "Raw media bytes. Text should not be sent as raw bytes, use the 'text' field.",
+      "id": "Blob",
+      "type": "object"
+    },
+    "TextPrompt": {
+      "type": "object",
+      "description": "Text given to the model as a prompt. The Model will use this TextPrompt to Generate a text completion.",
+      "id": "TextPrompt",
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "Required. The prompt text."
         }
       }
     },
-    "files": {
-      "methods": {
-        "list": {
-          "httpMethod": "GET",
-          "description": "Lists the metadata for `File`s owned by the requesting project.",
-          "flatPath": "v1beta/files",
-          "parameters": {
-            "pageSize": {
-              "location": "query",
-              "format": "int32",
-              "type": "integer",
-              "description": "Optional. Maximum number of `File`s to return per page. If unspecified, defaults to 10. Maximum `page_size` is 100."
-            },
-            "pageToken": {
-              "description": "Optional. A page token from a previous `ListFiles` call.",
-              "type": "string",
-              "location": "query"
-            }
-          },
-          "response": {
-            "$ref": "ListFilesResponse"
-          },
-          "parameterOrder": [],
-          "path": "v1beta/files",
-          "id": "generativelanguage.files.list"
+    "GenerateTextRequest": {
+      "description": "Request to generate a text completion response from the model.",
+      "properties": {
+        "topK": {
+          "format": "int32",
+          "description": "Optional. The maximum number of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Top-k sampling considers the set of `top_k` most probable tokens. Defaults to 40. Note: The default value varies by model, see the `Model.top_k` attribute of the `Model` returned the `getModel` function.",
+          "type": "integer"
         },
-        "delete": {
-          "id": "generativelanguage.files.delete",
-          "response": {
-            "$ref": "Empty"
-          },
-          "httpMethod": "DELETE",
-          "parameters": {
-            "name": {
-              "required": true,
-              "pattern": "^files/[^/]+$",
-              "description": "Required. The name of the `File` to delete. Example: `files/abc-123`",
-              "type": "string",
-              "location": "path"
-            }
-          },
-          "path": "v1beta/{+name}",
-          "description": "Deletes the `File`.",
-          "flatPath": "v1beta/files/{filesId}",
-          "parameterOrder": [
-            "name"
-          ]
+        "prompt": {
+          "$ref": "TextPrompt",
+          "description": "Required. The free-form input text given to the model as a prompt. Given a prompt, the model will generate a TextCompletion response it predicts as the completion of the input text."
         },
-        "get": {
-          "id": "generativelanguage.files.get",
-          "description": "Gets the metadata for the given `File`.",
-          "response": {
-            "$ref": "File"
+        "maxOutputTokens": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. The maximum number of tokens to include in a candidate. If unset, this will default to output_token_limit specified in the `Model` specification."
+        },
+        "safetySettings": {
+          "items": {
+            "$ref": "SafetySetting"
           },
-          "parameterOrder": [
-            "name"
-          ],
-          "parameters": {
-            "name": {
-              "type": "string",
-              "description": "Required. The name of the `File` to get. Example: `files/abc-123`",
-              "location": "path",
-              "pattern": "^files/[^/]+$",
-              "required": true
-            }
-          },
-          "path": "v1beta/{+name}",
-          "flatPath": "v1beta/files/{filesId}",
-          "httpMethod": "GET"
+          "type": "array",
+          "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content. that will be enforced on the `GenerateTextRequest.prompt` and `GenerateTextResponse.candidates`. There should not be more than one setting for each `SafetyCategory` type. The API will block any prompts and responses that fail to meet the thresholds set by these settings. This list overrides the default settings for each `SafetyCategory` specified in the safety_settings. If there is no `SafetySetting` for a given `SafetyCategory` provided in the list, the API will use the default safety setting for that category. Harm categories HARM_CATEGORY_DEROGATORY, HARM_CATEGORY_TOXICITY, HARM_CATEGORY_VIOLENCE, HARM_CATEGORY_SEXUAL, HARM_CATEGORY_MEDICAL, HARM_CATEGORY_DANGEROUS are supported in text service."
+        },
+        "candidateCount": {
+          "format": "int32",
+          "type": "integer",
+          "description": "Optional. Number of generated responses to return. This value must be between [1, 8], inclusive. If unset, this will default to 1."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional. Controls the randomness of the output. Note: The default value varies by model, see the `Model.temperature` attribute of the `Model` returned the `getModel` function. Values can range from [0.0,1.0], inclusive. A value closer to 1.0 will produce responses that are more varied and creative, while a value closer to 0.0 will typically result in more straightforward responses from the model.",
+          "format": "float"
+        },
+        "stopSequences": {
+          "description": "The set of character sequences (up to 5) that will stop output generation. If specified, the API will stop at the first appearance of a stop sequence. The stop sequence will not be included as part of the response.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "topP": {
+          "description": "Optional. The maximum cumulative probability of tokens to consider when sampling. The model uses combined Top-k and nucleus sampling. Tokens are sorted based on their assigned probabilities so that only the most likely tokens are considered. Top-k sampling directly limits the maximum number of tokens to consider, while Nucleus sampling limits number of tokens based on the cumulative probability. Note: The default value varies by model, see the `Model.top_p` attribute of the `Model` returned the `getModel` function.",
+          "format": "float",
+          "type": "number"
         }
-      }
+      },
+      "id": "GenerateTextRequest",
+      "type": "object"
+    },
+    "FileData": {
+      "properties": {
+        "fileUri": {
+          "type": "string",
+          "description": "Required. URI."
+        },
+        "mimeType": {
+          "description": "Optional. The IANA standard MIME type of the source data.",
+          "type": "string"
+        }
+      },
+      "description": "URI based data.",
+      "type": "object",
+      "id": "FileData"
     }
   },
-  "rootUrl": "https://generativelanguage.googleapis.com/",
-  "revision": "20240619",
-  "fullyEncodeReservedExpansion": true,
-  "ownerName": "Google",
-  "description": "The Gemini API allows developers to build generative AI applications using Gemini models. Gemini is our most capable model, built from the ground up to be multimodal. It can generalize and seamlessly understand, operate across, and combine different types of information including language, images, audio, video, and code. You can use the Gemini API for use cases like reasoning across text and images, content generation, dialogue agents, summarization and classification systems, and more.",
-  "canonicalName": "Generative Language",
   "ownerDomain": "google.com",
-  "documentationLink": "https://developers.generativeai.google/api",
-  "servicePath": "",
-  "version_module": true,
-  "id": "generativelanguage:v1beta"
+  "title": "Generative Language API",
+  "revision": "20240619",
+  "basePath": "",
+  "version": "v1beta",
+  "canonicalName": "Generative Language",
+  "id": "generativelanguage:v1beta",
+  "ownerName": "Google"
 }


### PR DESCRIPTION
Return an error if a conversion fails, instead of panicking.

Currently the only possible such failure is when a FunctionResponse
contains a value that can't be converted to a Struct proto.
