### PR TITLE
genai: add explicit MIME type CreateCachedContent example

### DIFF
--- a/genai/example_test.go
+++ b/genai/example_test.go
@@ -1221,7 +1221,7 @@ func ExampleCachedContent_create() {
 	}
 	defer client.Close()
 
-	file, err := uploadFile(ctx, client, filepath.Join(testDataDir, "a11.txt"), "")
+	file, err := uploadFile(ctx, client, filepath.Join(testDataDir, "a11.txt"), "text/plain")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/genai/internal/samples/docs-snippets_test.go
+++ b/genai/internal/samples/docs-snippets_test.go
@@ -1260,7 +1260,7 @@ func ExampleCachedContent_create() {
 
 	// [START cache_create]
 	// [START cache_delete]
-	file, err := uploadFile(ctx, client, filepath.Join(testDataDir, "a11.txt"), "")
+	file, err := uploadFile(ctx, client, filepath.Join(testDataDir, "a11.txt"), "text/plain")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
The model seems to require it (even though it correctly infers
that the MIME type is text/plain).

Fixes #198.
