### PR TITLE
genai: add convenience client.UploadFileFromPath method

### DIFF
--- a/genai/example_test.go
+++ b/genai/example_test.go
@@ -566,7 +566,7 @@ func ExampleGenerativeModel_CountTokens_imageUploadFile() {
 
 	model := client.GenerativeModel("gemini-1.5-flash")
 	prompt := "Tell me about this image"
-	file, err := uploadFile(ctx, client, filepath.Join(testDataDir, "personWorkingOnComputer.jpg"), "")
+	file, err := client.UploadFileFromPath(ctx, filepath.Join(testDataDir, "personWorkingOnComputer.jpg"), nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/genai/files.go
+++ b/genai/files.go
@@ -19,6 +19,7 @@ package genai
 import (
 	"context"
 	"io"
+	"os"
 	"strings"
 
 	gl "cloud.google.com/go/ai/generativelanguage/apiv1beta"
@@ -81,6 +82,19 @@ func (c *Client) UploadFile(ctx context.Context, name string, r io.Reader, opts 
 	// File type.
 	// Instead, make a GetFile call to get the proto file, which our generated code can convert.
 	return c.GetFile(ctx, res.File.Name)
+}
+
+// UploadFileFromPath is a convenience method wrapping [UploadFile]. It takes
+// a path to read the file from, and uses a default auto-generated ID for the
+// uploaded file.
+func (c *Client) UploadFileFromPath(ctx context.Context, path string, opts *UploadFileOptions) (*File, error) {
+	osf, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer osf.Close()
+
+	return c.UploadFile(ctx, "", osf, opts)
 }
 
 // GetFile returns the named file.

--- a/genai/internal/samples/docs-snippets_test.go
+++ b/genai/internal/samples/docs-snippets_test.go
@@ -584,7 +584,7 @@ func ExampleGenerativeModel_CountTokens_imageUploadFile() {
 	// [START tokens_multimodal_image_file_api]
 	model := client.GenerativeModel("gemini-1.5-flash")
 	prompt := "Tell me about this image"
-	file, err := uploadFile(ctx, client, filepath.Join(testDataDir, "personWorkingOnComputer.jpg"), "")
+	file, err := client.UploadFileFromPath(ctx, filepath.Join(testDataDir, "personWorkingOnComputer.jpg"), nil)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Sketch for a new convenience method to upload a file from a path. This would let us remove the `uploadFile` helpers from tests and examples. Examples & snippets would all be "inline" without calling out to a function.