### PR TITLE
Update prompt in json_no_schema snippet

### DIFF
--- a/genai/example_test.go
+++ b/genai/example_test.go
@@ -912,7 +912,10 @@ func ExampleGenerativeModel_jSONNoSchema() {
 	model := client.GenerativeModel("gemini-1.5-pro-latest")
 	// Ask the model to respond with JSON.
 	model.ResponseMIMEType = "application/json"
-	resp, err := model.GenerateContent(ctx, genai.Text("List a few popular cookie recipes."))
+	prompt := `List a few popular cookie recipes using this JSON schema:
+                   Recipe = {'recipeName': string}
+	           Return: Array<Recipe>`
+	resp, err := model.GenerateContent(ctx, genai.Text(prompt))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/genai/internal/samples/docs-snippets_test.go
+++ b/genai/internal/samples/docs-snippets_test.go
@@ -942,7 +942,10 @@ func ExampleGenerativeModel_jSONNoSchema() {
 	model := client.GenerativeModel("gemini-1.5-pro-latest")
 	// Ask the model to respond with JSON.
 	model.ResponseMIMEType = "application/json"
-	resp, err := model.GenerateContent(ctx, genai.Text("List a few popular cookie recipes."))
+	prompt := `List a few popular cookie recipes using this JSON schema:
+                   Recipe = {'recipeName': string}
+	           Return: Array<Recipe>`
+	resp, err := model.GenerateContent(ctx, genai.Text(prompt))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Make this match the other language snippets. Tested the change on my machine, and the output is as expected: 

`[{"recipeName": "Chocolate Chip Cookies"}, {"recipeName": "Peanut Butter Cookies"}, {"recipeName": "Oatmeal Raisin Cookies"}, {"recipeName": "Sugar Cookies"}, {"recipeName": "Snickerdoodles"}]`