### PR TITLE
Return error early in SendMessageStream

### DIFF
--- a/genai/chat.go
+++ b/genai/chat.go
@@ -47,11 +47,11 @@ func (cs *ChatSession) SendMessage(ctx context.Context, parts ...Part) (*Generat
 }
 
 // SendMessageStream is like SendMessage, but with a streaming request.
-func (cs *ChatSession) SendMessageStream(ctx context.Context, parts ...Part) *GenerateContentResponseIterator {
+func (cs *ChatSession) SendMessageStream(ctx context.Context, parts ...Part) (*GenerateContentResponseIterator, error) {
 	cs.History = append(cs.History, NewUserContent(parts...))
 	req, err := cs.m.newGenerateContentRequest(cs.History...)
 	if err != nil {
-		return &GenerateContentResponseIterator{err: err}
+		return &GenerateContentResponseIterator{err: err}, err
 	}
 	req.GenerationConfig.CandidateCount = Ptr[int32](1)
 	streamClient, err := cs.m.c.gc.StreamGenerateContent(ctx, req)
@@ -59,7 +59,7 @@ func (cs *ChatSession) SendMessageStream(ctx context.Context, parts ...Part) *Ge
 		sc:  streamClient,
 		err: err,
 		cs:  cs,
-	}
+	}, err
 }
 
 // By default, use the first candidate for history. The user can modify that if they want.

--- a/genai/client_test.go
+++ b/genai/client_test.go
@@ -101,7 +101,10 @@ func TestLive(t *testing.T) {
 			t.Logf("sending %q", msg)
 			nh := len(session.History)
 			if streaming {
-				iter := session.SendMessageStream(ctx, Text(msg))
+				iter, err := session.SendMessageStream(ctx, Text(msg))
+				if err != nil {
+					t.Fatal(err)
+				}
 				for {
 					_, err := iter.Next()
 					if err == iterator.Done {

--- a/genai/example_test.go
+++ b/genai/example_test.go
@@ -985,7 +985,10 @@ func ExampleChatSession_streaming() {
 		},
 	}
 
-	iter := cs.SendMessageStream(ctx, genai.Text("How many paws are in my house?"))
+	iter, err := cs.SendMessageStream(ctx, genai.Text("How many paws are in my house?"))
+	if err != nil {
+		log.Fatal(err)
+	}
 	for {
 		resp, err := iter.Next()
 		if err == iterator.Done {
@@ -1017,9 +1020,12 @@ func ExampleChatSession_streamingWithImage() {
 		log.Fatal(err)
 	}
 
-	iter := cs.SendMessageStream(ctx,
+	iter, err := cs.SendMessageStream(ctx,
 		genai.Text("What family of instruments does this instrument belong to?"),
 		genai.ImageData("jpeg", imgData))
+	if err != nil {
+		log.Fatal(err)
+	}
 	for {
 		resp, err := iter.Next()
 		if err == iterator.Done {

--- a/genai/internal/samples/docs-snippets_test.go
+++ b/genai/internal/samples/docs-snippets_test.go
@@ -1017,7 +1017,10 @@ func ExampleChatSession_streaming() {
 		},
 	}
 
-	iter := cs.SendMessageStream(ctx, genai.Text("How many paws are in my house?"))
+	iter, err := cs.SendMessageStream(ctx, genai.Text("How many paws are in my house?"))
+	if err != nil {
+		log.Fatal(err)
+	}
 	for {
 		resp, err := iter.Next()
 		if err == iterator.Done {
@@ -1050,9 +1053,12 @@ func ExampleChatSession_streamingWithImage() {
 		log.Fatal(err)
 	}
 
-	iter := cs.SendMessageStream(ctx,
+	iter, err := cs.SendMessageStream(ctx,
 		genai.Text("What family of instruments does this instrument belong to?"),
 		genai.ImageData("jpeg", imgData))
+	if err != nil {
+		log.Fatal(err)
+	}
 	for {
 		resp, err := iter.Next()
 		if err == iterator.Done {


### PR DESCRIPTION
This PR modifies SendMessageStream to return errors early for pre-flight checks like API errors and parameter format errors (400 status codes). This change allows developers to handle these errors more efficiently and write more responsive error-handling code. This enhancement is not to replace error checking during the iteration but to provide the ability to address certain errors upfront.

Previous:
```go
iter := cs.SendMessageStream(ctx, genai.Text("something"))
for {
	resp, err := iter.Next()
	if err == iterator.Done {
		break
	}
	if err != nil {
		log.Fatal(err) // API Key not found
	}
	printResponse(resp)
}
```

Now:
```go
iter, err := cs.SendMessageStream(ctx, genai.Text("something"))
if err != nil {
	log.Fatal(err) // API Key not found. Now I can handle these errors before iterating
}
```